### PR TITLE
fix(compile-context): handle unpadded phase numbers in directory lookup

### DIFF
--- a/scripts/compile-context.sh
+++ b/scripts/compile-context.sh
@@ -20,8 +20,12 @@ PLAN_PATH="${4:-}"
 PHASE_NUM=$(echo "$PHASE" | sed 's/^0*//')
 if [ -z "$PHASE_NUM" ]; then PHASE_NUM="0"; fi
 
-# --- Find phase directory ---
+# --- Find phase directory (tolerate both padded and unpadded input) ---
 PHASE_DIR=$(find "$PHASES_DIR" -maxdepth 1 -type d -name "${PHASE}-*" 2>/dev/null | head -1)
+if [ -z "$PHASE_DIR" ]; then
+  PADDED=$(printf "%02d" "$PHASE_NUM")
+  PHASE_DIR=$(find "$PHASES_DIR" -maxdepth 1 -type d -name "${PADDED}-*" 2>/dev/null | head -1)
+fi
 if [ -z "$PHASE_DIR" ]; then
   echo "Phase ${PHASE} directory not found" >&2
   exit 1


### PR DESCRIPTION
## What

Fixes phase directory lookup in `scripts/compile-context.sh` so unpadded phase inputs (for example `1`) can still resolve zero-padded directories (for example `01-...`).

## Why

This addresses #6, where context compilation fails if the phase argument is unpadded and the on-disk phase directory uses the repo’s standard zero-padded naming.

Fixes #6.

## How

- Updated `scripts/compile-context.sh` phase lookup logic.
- Kept the existing exact lookup (`${PHASE}-*`) as first attempt.
- Added fallback lookup using zero-padded phase (`%02d`) when no exact match is found.
- Reused existing `PHASE_NUM` parsing path to avoid introducing new parsing branches.

## Testing

- [x] Loaded plugin locally with `claude --model haiku --plugin-dir . -p "Reply exactly OK"`
- [x] Tested affected commands against a real project
- [x] No errors on plugin load
- [x] Existing commands still work

Additional validation:
- Temp fixture with `.vbw-planning/phases/01-test` + unpadded call `compile-context.sh 1 lead ...` produced `.context-lead.md` successfully.
- Confirmed fallback behavior for unpadded inputs while preserving padded-path behavior.
- Plugin smoke output: `OK`.

## Notes

The change is intentionally small and backward-compatible: existing padded inputs continue to work, and unpadded inputs now resolve correctly as well.