### PR TITLE
fix(stack): detect nested manifests and add iOS mappings

### DIFF
--- a/config/stack-mappings.json
+++ b/config/stack-mappings.json
@@ -48,7 +48,7 @@
       "description": "Tailwind CSS"
     },
     "typescript": {
-      "detect": ["tsconfig.json"],
+      "detect": ["tsconfig.json", "**/tsconfig.json"],
       "skills": ["typescript-skill"],
       "description": "TypeScript"
     },
@@ -92,7 +92,16 @@
       "skills": ["supabase-skill"]
     },
     "firebase": {
-      "detect": ["firebase.json", "package.json:firebase"],
+      "detect": [
+        "firebase.json",
+        "**/firebase.json",
+        "package.json:firebase",
+        "package.json:firebase-functions",
+        "package.json:firebase-admin",
+        "**/package.json:firebase",
+        "**/package.json:firebase-functions",
+        "**/package.json:firebase-admin"
+      ],
       "skills": ["firebase-skill"]
     },
     "clerk": {
@@ -138,6 +147,25 @@
       "detect": [".github/workflows"],
       "skills": ["github-actions-skill"],
       "description": "GitHub Actions CI/CD"
+    }
+  },
+  "mobile": {
+    "ios-swift": {
+      "detect": [
+        "*.xcodeproj",
+        "*.xcworkspace",
+        "**/*.xcodeproj",
+        "**/*.xcworkspace",
+        "Package.swift",
+        "**/Package.swift"
+      ],
+      "skills": ["swift-skill"],
+      "description": "iOS/macOS Swift project"
+    },
+    "swiftui": {
+      "detect": ["**/ContentView.swift", "**/*App.swift"],
+      "skills": ["swiftui-expert-skill"],
+      "description": "SwiftUI interface"
     }
   }
 }


### PR DESCRIPTION
## What

Improves stack detection for multi-component repos by adding nested manifest discovery and new iOS/Swift mappings.

## Why

This resolves #9, where `scripts/detect-stack.sh` only checked repo-root manifests and missed subdirectory manifests (for example nested backend/app layouts), producing incomplete stack detection.

Closes #9.

## How

- Updated `scripts/detect-stack.sh`:
  - moved to strict bash mode (`set -euo pipefail`)
  - added recursive pattern support (`**/...`) and glob-aware checks
  - added nested dependency checks (including nested `package.json` cases)
  - excluded generated/vendor directories from recursive scans
- Updated `config/stack-mappings.json`:
  - added recursive detection entries for TypeScript and Firebase
  - added `ios-swift` and `swiftui` mapping entries

## Testing

- [x] Loaded plugin locally with `claude --model haiku --plugin-dir . -p "Reply exactly OK"`
- [ ] Tested affected commands against a real project
- [x] No errors on plugin load
- [ ] Existing commands still work

Additional validation:
- Synthetic nested fixture confirmed detection of `typescript`, `firebase`, and `ios-swift` from subdirectories.
- `bash -n scripts/detect-stack.sh` and `jq` parse checks passed in prior validation.
- Plugin smoke output: `OK`.

## Notes

This expands detection coverage for brownfield and monorepo-style layouts without changing command surface area.