### PR TITLE
fix(todo): align STATE todo headings with /vbw:todo expectations

### DIFF
--- a/commands/todo.md
+++ b/commands/todo.md
@@ -21,7 +21,7 @@ Working directory: `!`pwd``
 
 1. **Resolve context:** ACTIVE → milestone-scoped STATE_PATH. Otherwise → .vbw-planning/STATE.md.
 2. **Parse args:** Description (non-flag text), --priority (default: normal). Format: high=`[HIGH]`, normal=plain, low=`[low]`. Append `(added {YYYY-MM-DD})`.
-3. **Add to STATE.md:** Find `### Pending Todos`. Replace "None." or append after last item.
+3. **Add to STATE.md:** Find `## Todos`. If `### Pending Todos` exists, append there; otherwise create it under `## Todos`. Replace "None." or append after last item.
 4. **Confirm:** Display ✓ + formatted item + Next Up (/vbw:status).
 
 ## Output Format

--- a/templates/STATE.md
+++ b/templates/STATE.md
@@ -12,6 +12,8 @@ Status: {ready|active|complete}
 - {decision}
 
 ## Todos
+
+### Pending Todos
 {todos-or-none}
 
 ## Blockers


### PR DESCRIPTION
## What

Align `STATE.md` scaffolding and `/vbw:todo` insertion instructions so newly initialized projects have the expected todo subsection.

## Why

Fixes a first-run papercut where `/vbw:todo` looked for `### Pending Todos` but `templates/STATE.md` scaffolded only `## Todos`, causing unreliable insertion right after `/vbw:init`.

Closes #7.

## How

- Updated `templates/STATE.md` to scaffold:
  - `## Todos`
  - `### Pending Todos`
  - `{todos-or-none}`
- Updated `commands/todo.md` Step 3 to be resilient:
  - target `## Todos`
  - append to `### Pending Todos` if present
  - otherwise create `### Pending Todos` under `## Todos`

## Testing

- [x] Loaded plugin locally with `claude --model haiku --plugin-dir . -p "Reply exactly OK"`
- [ ] Tested affected commands against a real project
- [x] No errors on plugin load
- [ ] Existing commands still work
- [x] Verified updated headings exist in both modified files
- [x] Confirmed branch includes only intended changes (`commands/todo.md`, `templates/STATE.md`)

Additional validation:
- `templates/STATE.md` contains `### Pending Todos`.
- `commands/todo.md` Step 3 anchors on `## Todos` and fallback subsection creation.
- Plugin smoke output: `OK`.

## Notes

This is a minimal docs/template alignment fix with backward-compatible command guidance for existing state files that only have `## Todos`.