### PR TITLE
fix(commands): add vbw prefix to command names for reliable command discovery

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-name: doctor
+name: vbw:doctor
 disable-model-invocation: true
 description: Run health checks on VBW installation and project setup.
 allowed-tools: Read, Bash, Glob, Grep

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,5 +1,5 @@
 ---
-name: init
+name: vbw:init
 disable-model-invocation: true
 description: Set up environment, scaffold .vbw-planning, detect project context, and bootstrap project-defining files.
 argument-hint:

--- a/commands/map.md
+++ b/commands/map.md
@@ -1,5 +1,5 @@
 ---
-name: map
+name: vbw:map
 disable-model-invocation: true
 description: Analyze existing codebase with adaptive Scout teammates to produce structured mapping documents.
 argument-hint: [--incremental] [--package=name] [--tier=solo|duo|quad]

--- a/commands/todo.md
+++ b/commands/todo.md
@@ -1,5 +1,5 @@
 ---
-name: todo
+name: vbw:todo
 disable-model-invocation: true
 description: Add an item to the persistent backlog in STATE.md.
 argument-hint: <todo-description> [--priority=high|normal|low]

--- a/commands/update.md
+++ b/commands/update.md
@@ -1,5 +1,5 @@
 ---
-name: update
+name: vbw:update
 disable-model-invocation: true
 description: Update VBW to the latest version with automatic cache refresh.
 argument-hint: "[--check]"

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1,5 +1,5 @@
 ---
-name: vibe
+name: vbw:vibe
 description: "The one command. Detects state, parses intent, routes to any lifecycle mode -- bootstrap, scope, plan, execute, discuss, archive, and more."
 argument-hint: "[intent or flags] [--plan] [--execute] [--discuss] [--assumptions] [--scope] [--add] [--insert] [--remove] [--archive] [--yolo] [--effort=level] [--skip-qa] [--skip-audit] [--plan=NN] [N]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch


### PR DESCRIPTION
## What
Add missing `vbw:` prefixes to command frontmatter `name` fields so commands are consistently discovered as `/vbw:*`.

## Why
After PR #10 removed the command-copy step that placed files into `~/.claude/commands/vbw/`, commands load purely from the plugin. Previously the `vbw/` directory path supplied the prefix automatically, so the frontmatter `name` didn't need it. Now the frontmatter `name` field is the sole source for the slash command name, and commands without the `vbw:` prefix stopped appearing under `/vbw:*`.

Closes #28.
Related: #10.

## How
Updated frontmatter `name` values in 6 commands:
- `commands/doctor.md` (`doctor` → `vbw:doctor`)
- `commands/init.md` (`init` → `vbw:init`)
- `commands/map.md` (`map` → `vbw:map`)
- `commands/todo.md` (`todo` → `vbw:todo`)
- `commands/update.md` (`update` → `vbw:update`)
- `commands/vibe.md` (`vibe` → `vbw:vibe`)

## Testing
- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] Tested affected commands against a real project
- [x] No errors on plugin load
- [x] Existing commands still work

## Notes
Straightforward frontmatter-only fix. No logic changes.