### PR TITLE
fix(hooks): prevent SessionStart:compact errors and restore security-filter blocking

### DIFF
--- a/scripts/hook-wrapper.sh
+++ b/scripts/hook-wrapper.sh
@@ -33,6 +33,9 @@ RC=$?
 [ "$VBW_DEBUG" = "1" ] && [ "$RC" -ne 0 ] && echo "[VBW DEBUG] hook-wrapper: $SCRIPT exit=$RC" >&2
 [ "$RC" -eq 0 ] && exit 0
 
+# Exit 2 = intentional block (PreToolUse/UserPromptSubmit) — pass through, not a failure
+[ "$RC" -eq 2 ] && exit 2
+
 # --- Failure: log and exit 0 ---
 if [ -d ".vbw-planning" ]; then
   LOG=".vbw-planning/.hook-errors.log"

--- a/scripts/map-staleness.sh
+++ b/scripts/map-staleness.sh
@@ -3,17 +3,34 @@
 # Output: key-value pairs on stdout. Exit 0 always.
 set -euo pipefail
 
+# Skip during compaction — post-compact.sh handles the compact SessionStart.
+if [[ -f ".vbw-planning/.compaction-marker" ]]; then
+  _cm_ts=$(cat ".vbw-planning/.compaction-marker" 2>/dev/null || echo 0)
+  _cm_now=$(date +%s 2>/dev/null || echo 0)
+  if (( _cm_now - _cm_ts < 60 )); then
+    exit 0
+  fi
+fi
+
 META=".vbw-planning/codebase/META.md"
+
+# Detect hook context: when stdout is not a terminal, we're called as a hook.
+# In hook mode, only JSON goes to stdout; diagnostics go to stderr.
+IS_HOOK=false
+[ -t 1 ] || IS_HOOK=true
+
+# Helper: emit diagnostic lines to the right destination
+_diag() { if [[ "$IS_HOOK" == true ]]; then echo "$@" >&2; else echo "$@"; fi; }
 
 # No map
 if [[ ! -f "$META" ]]; then
-  echo "status: no_map"
+  _diag "status: no_map"
   exit 0
 fi
 
 # No git
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-  echo "status: no_git"
+  _diag "status: no_git"
   exit 0
 fi
 
@@ -24,18 +41,18 @@ mapped_at=$(grep '^mapped_at:' "$META" | awk '{print $2}')
 
 # Validate parsed values
 if [[ -z "$git_hash" || -z "$file_count" || "$file_count" -eq 0 ]]; then
-  echo "status: no_map"
+  _diag "status: no_map"
   exit 0
 fi
 
 # Verify the stored hash exists in this repo
 if ! git cat-file -e "$git_hash" 2>/dev/null; then
-  echo "status: stale"
-  echo "staleness: 100%"
-  echo "changed: unknown"
-  echo "total: $file_count"
-  echo "since: $mapped_at"
-  if ! [ -t 1 ]; then
+  _diag "status: stale"
+  _diag "staleness: 100%"
+  _diag "changed: unknown"
+  _diag "total: $file_count"
+  _diag "since: $mapped_at"
+  if [[ "$IS_HOOK" == true ]]; then
     echo "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Codebase map is stale (100% files changed). Run /vbw:map --incremental to refresh.\"}}"
   fi
   exit 0
@@ -53,13 +70,13 @@ else
   status="fresh"
 fi
 
-echo "status: $status"
-echo "staleness: ${staleness}%"
-echo "changed: $changed"
-echo "total: $file_count"
-echo "since: $mapped_at"
+_diag "status: $status"
+_diag "staleness: ${staleness}%"
+_diag "changed: $changed"
+_diag "total: $file_count"
+_diag "since: $mapped_at"
 
-# When called as a SessionStart hook (stdout is not a terminal), output hookSpecificOutput
-if [[ "$status" == "stale" ]] && ! [ -t 1 ]; then
+# When called as a SessionStart hook, output hookSpecificOutput JSON only
+if [[ "$status" == "stale" ]] && [[ "$IS_HOOK" == true ]]; then
   echo "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Codebase map is stale (${staleness}% files changed). Run /vbw:map --incremental to refresh.\"}}"
 fi

--- a/scripts/post-compact.sh
+++ b/scripts/post-compact.sh
@@ -5,8 +5,8 @@ set -u
 
 INPUT=$(cat)
 
-# Clean up cost tracking files (stale after compaction)
-rm -f .vbw-planning/.cost-ledger.json .vbw-planning/.active-agent 2>/dev/null
+# Clean up cost tracking files and compaction marker (stale after compaction)
+rm -f .vbw-planning/.cost-ledger.json .vbw-planning/.active-agent .vbw-planning/.compaction-marker 2>/dev/null
 
 # Try to identify agent role from input context
 ROLE=""

--- a/tests/sessionstart-compact-hooks.bats
+++ b/tests/sessionstart-compact-hooks.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  create_test_config
+  cd "$TEST_TEMP_DIR"
+
+  # Init git so map-staleness.sh and session-start.sh work
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  echo "init" > init.txt && git add init.txt && git commit -q -m "init"
+
+  # Create minimal STATE.md for session-start.sh
+  cat > "$TEST_TEMP_DIR/.vbw-planning/STATE.md" <<'STATE'
+Phase: 1 of 2 (Setup)
+Status: in-progress
+Progress: 50%
+STATE
+
+  # Create phases dir
+  mkdir -p "$TEST_TEMP_DIR/.vbw-planning/phases/01-setup"
+
+  # Create PROJECT.md so session-start doesn't suggest /vbw:init
+  echo "# Test Project" > "$TEST_TEMP_DIR/.vbw-planning/PROJECT.md"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+# --- session-start.sh compact skip ---
+
+@test "session-start: skips heavy init when fresh compaction marker present" {
+  cd "$TEST_TEMP_DIR"
+  date +%s > .vbw-planning/.compaction-marker
+  run bash "$SCRIPTS_DIR/session-start.sh"
+  [ "$status" -eq 0 ]
+  # Should produce NO output (skipped entirely)
+  [ -z "$output" ]
+}
+
+@test "session-start: runs normally when no compaction marker" {
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/session-start.sh"
+  [ "$status" -eq 0 ]
+  # Should produce hookSpecificOutput JSON
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
+}
+
+@test "session-start: runs normally when compaction marker is stale (>60s)" {
+  cd "$TEST_TEMP_DIR"
+  # Write a timestamp 120 seconds in the past
+  echo $(( $(date +%s) - 120 )) > .vbw-planning/.compaction-marker
+  run bash "$SCRIPTS_DIR/session-start.sh"
+  [ "$status" -eq 0 ]
+  # Should produce hookSpecificOutput JSON (did not skip)
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
+  # Stale marker should be cleaned up
+  [ ! -f ".vbw-planning/.compaction-marker" ]
+}
+
+# --- map-staleness.sh compact skip ---
+
+@test "map-staleness: skips when fresh compaction marker present" {
+  cd "$TEST_TEMP_DIR"
+  date +%s > .vbw-planning/.compaction-marker
+  run bash "$SCRIPTS_DIR/map-staleness.sh"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "map-staleness: runs normally when no compaction marker" {
+  cd "$TEST_TEMP_DIR"
+  # bats `run` captures both stdout+stderr; use explicit redirect to test stdout only
+  stdout=$(bash "$SCRIPTS_DIR/map-staleness.sh" 2>/dev/null)
+  [ -z "$stdout" ]
+  # stderr should have the diagnostic
+  stderr=$(bash "$SCRIPTS_DIR/map-staleness.sh" 2>&1 >/dev/null)
+  [[ "$stderr" == *"status: no_map"* ]]
+}
+
+@test "map-staleness: no plain text on stdout when running as hook (no map)" {
+  cd "$TEST_TEMP_DIR"
+  # Pipe forces non-tty (hook mode). Only JSON should go to stdout.
+  result=$(bash "$SCRIPTS_DIR/map-staleness.sh" 2>/dev/null)
+  [ -z "$result" ]
+}
+
+# --- post-compact.sh marker cleanup ---
+
+@test "post-compact: cleans compaction marker" {
+  cd "$TEST_TEMP_DIR"
+  date +%s > .vbw-planning/.compaction-marker
+  [ -f ".vbw-planning/.compaction-marker" ]
+  echo '{}' | bash "$SCRIPTS_DIR/post-compact.sh"
+  [ ! -f ".vbw-planning/.compaction-marker" ]
+}
+
+@test "post-compact: produces valid hookSpecificOutput JSON" {
+  cd "$TEST_TEMP_DIR"
+  run bash -c 'echo "{}" | bash "$1"' _ "$SCRIPTS_DIR/post-compact.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
+}
+
+# --- hook-wrapper.sh exit code passthrough ---
+
+@test "hook-wrapper: passes through exit 2 for PreToolUse block" {
+  cd "$TEST_TEMP_DIR"
+  # Create a mock script that exits 2
+  mkdir -p "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts"
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" <<'WRAPPER'
+#!/bin/bash
+SCRIPT="$1"; shift
+[ -z "$SCRIPT" ] && exit 0
+CACHE="$(dirname "$0")/.."
+TARGET="$CACHE/scripts/$SCRIPT"
+[ -z "$TARGET" ] || [ ! -f "$TARGET" ] && exit 0
+bash "$TARGET" "$@"
+RC=$?
+[ "$RC" -eq 0 ] && exit 0
+[ "$RC" -eq 2 ] && exit 2
+exit 0
+WRAPPER
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-block.sh" <<'MOCK'
+#!/bin/bash
+echo "Blocked: test" >&2
+exit 2
+MOCK
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh"
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-block.sh"
+  run bash "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" mock-block.sh
+  [ "$status" -eq 2 ]
+}
+
+@test "hook-wrapper: exit 0 for successful scripts" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts"
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" <<'WRAPPER'
+#!/bin/bash
+SCRIPT="$1"; shift
+[ -z "$SCRIPT" ] && exit 0
+CACHE="$(dirname "$0")/.."
+TARGET="$CACHE/scripts/$SCRIPT"
+[ -z "$TARGET" ] || [ ! -f "$TARGET" ] && exit 0
+bash "$TARGET" "$@"
+RC=$?
+[ "$RC" -eq 0 ] && exit 0
+[ "$RC" -eq 2 ] && exit 2
+exit 0
+WRAPPER
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-allow.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh"
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-allow.sh"
+  run bash "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" mock-allow.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "hook-wrapper: exit 0 for failing scripts (graceful degradation)" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts"
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" <<'WRAPPER'
+#!/bin/bash
+SCRIPT="$1"; shift
+[ -z "$SCRIPT" ] && exit 0
+CACHE="$(dirname "$0")/.."
+TARGET="$CACHE/scripts/$SCRIPT"
+[ -z "$TARGET" ] || [ ! -f "$TARGET" ] && exit 0
+bash "$TARGET" "$@"
+RC=$?
+[ "$RC" -eq 0 ] && exit 0
+[ "$RC" -eq 2 ] && exit 2
+exit 0
+WRAPPER
+  cat > "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-fail.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh"
+  chmod +x "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/mock-fail.sh"
+  run bash "$TEST_TEMP_DIR/mock-cache/1.0.0/scripts/hook-wrapper.sh" mock-fail.sh
+  [ "$status" -eq 0 ]
+}
+
+# --- security-filter.sh integration (exit 2 should block) ---
+
+@test "security-filter: blocks .env file with exit 2" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter: allows normal file with exit 0" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"src/app.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "security-filter: exit 2 preserved through hook-wrapper logic" {
+  # Verify that the hook-wrapper exit-code logic preserves exit 2
+  # (This tests the actual hook-wrapper.sh, not the mock)
+  cd "$TEST_TEMP_DIR"
+
+  # Create a fake plugin cache with the real hook-wrapper and security-filter
+  mkdir -p "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts"
+  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/security-filter.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
+  run bash -c "export HOME='$TEST_TEMP_DIR'; echo '$INPUT' | bash '$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' security-filter.sh"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## What

Fix "SessionStart:compact hook error" appearing twice after compaction, and restore `security-filter.sh` blocking semantics that were silently broken by `hook-wrapper.sh`.

## Why

Fixes #34. Two issues:

1. `session-start.sh` and `map-staleness.sh` fire unnecessarily during `SessionStart:compact` events (no `matcher` filter), timing out on heavy operations and surfacing hook errors to the user.
2. `hook-wrapper.sh` swallows exit code 2 (the Claude Code "block tool call" signal), making `security-filter.sh` non-functional — sensitive file blocks (`.env`, `.pem`, `.key`, credentials) are silently converted to allows.

## How

**`scripts/session-start.sh`** — Detect fresh compaction marker (< 60s, set by `compaction-instructions.sh` during PreCompact) and exit 0 immediately, letting `post-compact.sh` handle the compact event. Stale markers from crashed compactions are cleaned up and normal init proceeds.

**`scripts/map-staleness.sh`** — Same compaction marker check to skip during compact. Also fixed mixed stdout output: diagnostic key-value lines now route to stderr when running as a hook, keeping stdout clean for JSON `hookSpecificOutput` only.

**`scripts/post-compact.sh`** — Added `.compaction-marker` to the cleanup list so the marker is removed after compact handling.

**`scripts/hook-wrapper.sh`** — Pass through exit code 2 instead of swallowing it. Exit 2 = intentional block (PreToolUse/UserPromptSubmit), not a failure. No longer logged as a hook error.

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] Tested affected commands against a real project
- [x] No errors on plugin load
- [x] Existing commands still work

**Automated:**
- 14 new bats tests in `tests/sessionstart-compact-hooks.bats` covering:
  - session-start compact skip / normal run / stale marker cleanup
  - map-staleness compact skip / clean stdout in hook mode
  - post-compact marker cleanup / valid JSON output
  - hook-wrapper exit 2 passthrough / exit 0 on success / exit 0 on general failure
  - security-filter blocks `.env` / allows normal files / exit 2 preserved through wrapper
- Full test suite (`bash testing/run-all.sh`): all checks pass, 0 failures

## Notes

- The security filter being non-functional is a significant finding — existing users on prior versions have `.env`/sensitive file protections effectively disabled through `hook-wrapper.sh`. The fix takes effect on next plugin cache refresh.
- The compaction marker mechanism uses a 60-second freshness window to avoid stale markers from crashed compactions blocking normal session starts.