### PR TITLE
fix(statusline): isolate cache per repository to prevent cross-repo leakage

### DIFF
--- a/tests/statusline-cache-isolation.bats
+++ b/tests/statusline-cache-isolation.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# Tests for statusline cache isolation across repositories
+# Verifies cache keys include repo identity and no-remote repos display correctly.
+
+load test_helper
+
+STATUSLINE="$SCRIPTS_DIR/vbw-statusline.sh"
+
+setup() {
+  setup_temp_dir
+  export ORIG_UID=$(id -u)
+  # Clean any existing caches
+  rm -f /tmp/vbw-*-"${ORIG_UID}"-* /tmp/vbw-*-"${ORIG_UID}" 2>/dev/null || true
+}
+
+teardown() {
+  rm -f /tmp/vbw-*-"${ORIG_UID}"-* /tmp/vbw-*-"${ORIG_UID}" 2>/dev/null || true
+  teardown_temp_dir
+}
+
+# --- Cache key includes repo hash ---
+
+@test "cache key includes repo-specific hash" {
+  local uid=$(id -u)
+  # Run statusline in the project repo
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+  # Cache files should contain an 8-char hash segment after the UID
+  local cache_files
+  cache_files=$(ls /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null || true)
+  [ -n "$cache_files" ]
+  # Verify the hash segment is present (pattern: vbw-{ver}-{uid}-{hash}-fast)
+  echo "$cache_files" | grep -qE "vbw-[0-9.]+-${uid}-[a-f0-9]+-fast"
+}
+
+@test "different repos produce different cache keys" {
+  local uid=$(id -u)
+
+  # Run in project repo
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+  local cache1
+  cache1=$(ls /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null | head -1)
+
+  # Create a second repo and run there
+  local repo2="$TEST_TEMP_DIR/repo2"
+  mkdir -p "$repo2"
+  git -C "$repo2" init -q
+  git -C "$repo2" commit --allow-empty -m "test(init): seed" -q
+  rm -f /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null
+  cd "$repo2"
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+  cd "$PROJECT_ROOT"
+  local cache2
+  cache2=$(ls /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null | head -1)
+
+  # Cache filenames should differ (different hash)
+  [ "$cache1" != "$cache2" ]
+}
+
+@test "cache is not shared between repos within TTL window" {
+  local uid=$(id -u)
+
+  # Create two isolated repos
+  local repo_a="$TEST_TEMP_DIR/repo-a"
+  local repo_b="$TEST_TEMP_DIR/repo-b"
+  mkdir -p "$repo_a" "$repo_b"
+  git -C "$repo_a" init -q
+  git -C "$repo_a" commit --allow-empty -m "test(init): seed" -q
+  git -C "$repo_b" init -q
+  git -C "$repo_b" commit --allow-empty -m "test(init): seed" -q
+
+  # Run statusline in repo A
+  cd "$repo_a"
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+  local cache_a
+  cache_a=$(cat /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null | head -1)
+
+  # Run statusline in repo B (within 5s TTL)
+  cd "$repo_b"
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+
+  # Repo A's cache should be unchanged
+  cd "$repo_a"
+  local cache_a_after
+  cache_a_after=$(cat /tmp/vbw-*-"${uid}"-*-fast 2>/dev/null | head -1)
+  cd "$PROJECT_ROOT"
+
+  [ "$cache_a" = "$cache_a_after" ]
+}
+
+# --- No-remote repo handling ---
+
+@test "no-remote repo shows directory name in status line" {
+  local repo="$TEST_TEMP_DIR/my-local-project"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" commit --allow-empty -m "test(init): seed" -q
+
+  cd "$repo"
+  local output
+  output=$(echo '{}' | bash "$STATUSLINE" 2>&1 | head -1)
+  cd "$PROJECT_ROOT"
+
+  # Should contain directory name and branch
+  echo "$output" | grep -q "my-local-project:main"
+}
+
+@test "no-remote repo does not show another repo's name" {
+  local uid=$(id -u)
+  local repo="$TEST_TEMP_DIR/isolated-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" commit --allow-empty -m "test(init): seed" -q
+
+  # First run in main project (has origin remote)
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+
+  # Then run in local-only repo
+  cd "$repo"
+  local output
+  output=$(echo '{}' | bash "$STATUSLINE" 2>&1 | head -1)
+  cd "$PROJECT_ROOT"
+
+  # Should NOT contain the main project's GitHub repo name
+  ! echo "$output" | grep -q "vibe-better-with-claude-code-vbw"
+  # Should contain the local directory name
+  echo "$output" | grep -q "isolated-repo"
+}
+
+@test "repo with remote shows GitHub link, not bare directory name" {
+  local output
+  output=$(echo '{}' | bash "$STATUSLINE" 2>&1 | head -1)
+  # Should contain the OSC 8 link escape sequence (clickable link)
+  echo "$output" | grep -q ']8;;https://'
+}
+
+# --- Cache cleanup ---
+
+@test "stale cache cleanup removes old-format caches" {
+  local uid=$(id -u)
+  # Create fake old-format cache (no repo hash)
+  touch "/tmp/vbw-0.0.0-${uid}-fast"
+  touch "/tmp/vbw-0.0.0-${uid}-slow"
+  touch "/tmp/vbw-0.0.0-${uid}-ok"
+
+  # Run statusline — should clean up old format
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+
+  # Old caches should be gone (cleaned by the -ok check or glob cleanup)
+  [ ! -f "/tmp/vbw-0.0.0-${uid}-fast" ]
+  [ ! -f "/tmp/vbw-0.0.0-${uid}-slow" ]
+}
+
+@test "cache-nuke.sh cleans repo-scoped caches" {
+  local uid=$(id -u)
+  # Create cache files in new format
+  echo '{}' | bash "$STATUSLINE" >/dev/null 2>&1
+  local before
+  before=$(ls /tmp/vbw-*-"${uid}"-* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$before" -gt 0 ]
+
+  # Nuke caches
+  bash "$SCRIPTS_DIR/cache-nuke.sh" >/dev/null 2>&1
+
+  # All caches for this user should be gone
+  local after
+  after=$(ls /tmp/vbw-*-"${uid}"-* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$after" -eq 0 ]
+}
+
+# --- Non-git directory handling ---
+
+@test "statusline works in non-git directory" {
+  local noGitDir="$TEST_TEMP_DIR/not-a-repo"
+  mkdir -p "$noGitDir"
+  cd "$noGitDir"
+  local output
+  output=$(echo '{}' | bash "$STATUSLINE" 2>&1)
+  cd "$PROJECT_ROOT"
+  # Should produce 4 lines without errors
+  local lines
+  lines=$(echo "$output" | wc -l | tr -d ' ')
+  [ "$lines" -eq 4 ]
+}


### PR DESCRIPTION
## Summary

Fixes #40 — The statusline cache key only included VBW version and UID, so all repos on the same machine shared one cache. When multiple Claude sessions ran in different repos, whichever refreshed last would overwrite the other's repo name and branch. Local-only git repos (no remote) were especially affected, displaying another repo's GitHub name.

- Add 8-char hash of git toplevel path to cache key, isolating each repo's cache
- For repos without a remote, display directory name instead of nothing
- Add 9 bats tests covering isolation, no-remote display, cleanup, and non-git directories

## Changes

| File | What |
|------|------|
| `scripts/vbw-statusline.sh` | Add `_REPO_HASH` to cache key; add `REPO_LABEL` fallback for no-remote repos |
| `tests/statusline-cache-isolation.bats` | 9 tests for cache isolation and no-remote display |

## Test plan

- [x] `bats tests/statusline-cache-isolation.bats` — 9/9 passing
- [x] `bash testing/run-all.sh` — 357/357 passing
- [ ] Manual: open two Claude sessions in different repos, verify each shows its own repo name and branch
- [ ] Manual: open Claude in a local-only git repo (no remote), verify it shows directory name

🤖 Generated with [Claude Code](https://claude.com/claude-code)