### PR TITLE
feat(config): add planning tracking and auto-push controls

### DIFF
--- a/agents/vbw-dev.md
+++ b/agents/vbw-dev.md
@@ -16,7 +16,7 @@ Execution agent. Implement PLAN.md tasks sequentially, one atomic commit per tas
 Read PLAN.md from disk (source of truth). Read `@`-referenced context (including skill SKILL.md). Parse tasks.
 
 ### Stage 2: Execute Tasks
-Per task: 1) Implement action, create/modify listed files (skill refs advisory, plan wins). 2) Run verify checks, all must pass. 3) Validate done criteria. 4) Stage files individually, commit. 5) Record hash for SUMMARY.md.
+Per task: 1) Implement action, create/modify listed files (skill refs advisory, plan wins). 2) Run verify checks, all must pass. 3) Validate done criteria. 4) Stage files individually, commit source changes. 5) If `.vbw-planning/config.json` has `auto_push="always"` and branch has upstream, push after commit. 6) Record hash for SUMMARY.md.
 If `type="checkpoint:*"`, stop and return checkpoint.
 
 ### Stage 3: Produce Summary
@@ -26,6 +26,7 @@ Run plan verification. Confirm success criteria. Generate SUMMARY.md via `templa
 One commit per task. Never batch. Never split (except TDD: 2-3).
 Format: `{type}({phase}-{plan}): {task-name}` + key change bullets.
 Types: feat|fix|test|refactor|perf|docs|style|chore. Stage: `git add {file}` only.
+`auto_commit` here refers to source task commits only. Planning artifact commits are handled by lifecycle boundary rules (`planning_tracking`).
 
 ## Deviation Handling
 | Code | Action | Escalate |

--- a/commands/config.md
+++ b/commands/config.md
@@ -110,8 +110,8 @@ Display hint after flags: `Toggle with: /vbw:config <flag> true|false`
 **Step 2:** AskUserQuestion with up to 5 commonly changed settings (mark current values):
 - Effort: thorough | balanced | fast | turbo
 - Autonomy: cautious | standard | confident | pure-vibe
-- Verification: quick | standard | deep
-- Max tasks per plan: 3 | 5 | 7
+- Planning tracking: manual | ignore | commit
+- Auto push: never | after_phase | always
 - Model Profile
 
 **Step 2.5:** If "Model Profile" was selected, AskUserQuestion with 2 options:
@@ -251,6 +251,14 @@ Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/suggest-next.sh config` and display.
 
 Validate setting + value. Update config.json. Display ✓ with ➜.
 
+If `setting=planning_tracking`, after writing config run:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/planning-git.sh sync-ignore .vbw-planning/config.json
+```
+
+This keeps root `.gitignore` and `.vbw-planning/.gitignore` aligned with the selected tracking mode.
+
 ### Skill-hook wiring: `skill_hook <skill> <event> <matcher>`
 
 - `config skill_hook lint-fix PostToolUse Write|Edit`
@@ -353,11 +361,15 @@ echo "✓ Model override: $AGENT ➜ $MODEL"
 
 ## Settings Reference
 
+Note: `auto_commit` controls source-task commits during Execute mode. Planning artifact commit behavior is controlled by `planning_tracking`.
+
 | Setting | Type | Values | Default |
 |---------|------|--------|---------|
 | effort | string | thorough/balanced/fast/turbo | balanced |
 | autonomy | string | cautious/standard/confident/pure-vibe | standard |
 | auto_commit | boolean | true/false | true |
+| planning_tracking | string | manual/ignore/commit | manual |
+| auto_push | string | never/after_phase/always | never |
 | verification_tier | string | quick/standard/deep | standard |
 | skill_suggestions | boolean | true/false | true |
 | auto_install_skills | boolean | true/false | false |

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,6 +2,8 @@
   "effort": "balanced",
   "autonomy": "standard",
   "auto_commit": true,
+  "planning_tracking": "manual",
+  "auto_push": "never",
   "verification_tier": "standard",
   "skill_suggestions": true,
   "auto_install_skills": false,

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -407,8 +407,23 @@ Note: "Run inline" means the execute-protocol agent runs the verify protocol dir
 **Update STATE.md:** phase position, plan completion counts, effort used.
 **Update ROADMAP.md:** mark completed plans.
 
-Display per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
+**Planning artifact boundary commit (conditional):**
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/planning-git.sh commit-boundary "complete phase {N}" .vbw-planning/config.json
 ```
+- `planning_tracking=commit`: commits `.vbw-planning/` + `CLAUDE.md` when changed
+- `planning_tracking=manual|ignore`: no-op
+- `auto_push=always`: push happens inside the boundary commit command when upstream exists
+
+**After-phase push (conditional):**
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/planning-git.sh push-after-phase .vbw-planning/config.json
+```
+- `auto_push=after_phase`: pushes once after phase completion (if upstream exists)
+- other modes: no-op
+
+Display per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
+```text
 ╔═══════════════════════════════════════════════╗
 ║  Phase {N}: {name} -- Built                   ║
 ╚═══════════════════════════════════════════════╝

--- a/scripts/bootstrap/bootstrap-claude.sh
+++ b/scripts/bootstrap/bootstrap-claude.sh
@@ -92,7 +92,7 @@ generate_vbw_sections() {
 - **Never commit secrets.** Do not stage .env, .pem, .key, credentials, or token files.
 - **Plan before building.** Use /vbw:vibe for all lifecycle actions. Plans are the source of truth.
 - **Do not fabricate content.** Only use what the user explicitly states in project-defining flows.
-- **Do not bump version or push until asked.** Never run `scripts/bump-version.sh` or `git push` unless the user explicitly requests it. Commit locally and wait.
+- **Do not bump version or push until asked.** Never run `scripts/bump-version.sh` or `git push` unless the user explicitly requests it, except when `.vbw-planning/config.json` intentionally sets `auto_push` to `always` or `after_phase`.
 
 ## Key Decisions
 

--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -30,6 +30,8 @@ else
   echo "config_effort=balanced"
   echo "config_autonomy=standard"
   echo "config_auto_commit=true"
+  echo "config_planning_tracking=manual"
+  echo "config_auto_push=never"
   echo "config_verification_tier=standard"
   echo "config_prefer_teams=always"
   echo "config_max_tasks_per_plan=5"
@@ -146,6 +148,8 @@ CONFIG_FILE="$PLANNING_DIR/config.json"
 CFG_EFFORT="balanced"
 CFG_AUTONOMY="standard"
 CFG_AUTO_COMMIT="true"
+CFG_PLANNING_TRACKING="manual"
+CFG_AUTO_PUSH="never"
 CFG_VERIFICATION_TIER="standard"
 CFG_PREFER_TEAMS="always"
 CFG_MAX_TASKS="5"
@@ -158,6 +162,8 @@ if [ "$JQ_AVAILABLE" = true ] && [ -f "$CONFIG_FILE" ]; then
     "CFG_EFFORT=\(.effort // "balanced")",
     "CFG_AUTONOMY=\(.autonomy // "standard")",
     "CFG_AUTO_COMMIT=\(if .auto_commit == null then true else .auto_commit end)",
+    "CFG_PLANNING_TRACKING=\(.planning_tracking // "manual")",
+    "CFG_AUTO_PUSH=\(.auto_push // "never")",
     "CFG_VERIFICATION_TIER=\(.verification_tier // "standard")",
     "CFG_PREFER_TEAMS=\(.prefer_teams // "always")",
     "CFG_MAX_TASKS=\(.max_tasks_per_plan // 5)",
@@ -169,6 +175,8 @@ fi
 echo "config_effort=$CFG_EFFORT"
 echo "config_autonomy=$CFG_AUTONOMY"
 echo "config_auto_commit=$CFG_AUTO_COMMIT"
+echo "config_planning_tracking=$CFG_PLANNING_TRACKING"
+echo "config_auto_push=$CFG_AUTO_PUSH"
 echo "config_verification_tier=$CFG_VERIFICATION_TIER"
 echo "config_prefer_teams=$CFG_PREFER_TEAMS"
 echo "config_max_tasks_per_plan=$CFG_MAX_TASKS"

--- a/scripts/planning-git.sh
+++ b/scripts/planning-git.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# planning-git.sh — Manage planning artifact git behavior from config.
+#
+# Usage:
+#   planning-git.sh sync-ignore [CONFIG_FILE]
+#   planning-git.sh commit-boundary <action> [CONFIG_FILE]
+#   planning-git.sh push-after-phase [CONFIG_FILE]
+
+COMMAND="${1:-}"
+ARG2="${2:-}"
+ARG3="${3:-}"
+
+is_git_repo() {
+  git rev-parse --git-dir >/dev/null 2>&1
+}
+
+read_config() {
+  local config_file="$1"
+
+  CFG_PLANNING_TRACKING="manual"
+  CFG_AUTO_PUSH="never"
+
+  if [ -f "$config_file" ] && command -v jq >/dev/null 2>&1; then
+    CFG_PLANNING_TRACKING=$(jq -r '.planning_tracking // "manual"' "$config_file" 2>/dev/null || echo "manual")
+    CFG_AUTO_PUSH=$(jq -r '.auto_push // "never"' "$config_file" 2>/dev/null || echo "never")
+  fi
+}
+
+ensure_transient_ignore() {
+  local planning_dir=".vbw-planning"
+  local ignore_file="$planning_dir/.gitignore"
+
+  [ -d "$planning_dir" ] || return 0
+
+  cat > "$ignore_file" <<'EOF'
+# VBW transient runtime artifacts
+.execution-state.json
+.context-*.md
+.contracts/
+.locks/
+.token-state/
+EOF
+}
+
+sync_root_ignore() {
+  local mode="$1"
+  local root_ignore=".gitignore"
+
+  if [ "$mode" = "ignore" ]; then
+    if [ ! -f "$root_ignore" ]; then
+      printf '.vbw-planning/\n' > "$root_ignore"
+      return 0
+    fi
+
+    if ! grep -qx '\.vbw-planning/' "$root_ignore"; then
+      printf '\n.vbw-planning/\n' >> "$root_ignore"
+    fi
+    return 0
+  fi
+
+  if [ "$mode" = "commit" ] && [ -f "$root_ignore" ]; then
+    local tmp
+    tmp=$(mktemp)
+    awk '$0 != ".vbw-planning/"' "$root_ignore" > "$tmp"
+    mv "$tmp" "$root_ignore"
+  fi
+}
+
+push_if_configured() {
+  local push_mode="$1"
+  [ "$push_mode" = "always" ] || return 0
+
+  # Skip if current branch has no upstream yet.
+  if ! git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    return 0
+  fi
+
+  git push
+}
+
+if [ -z "$COMMAND" ]; then
+  echo "Usage: planning-git.sh sync-ignore [CONFIG_FILE] | commit-boundary <action> [CONFIG_FILE] | push-after-phase [CONFIG_FILE]" >&2
+  exit 1
+fi
+
+case "$COMMAND" in
+  sync-ignore)
+    CONFIG_FILE="${ARG2:-.vbw-planning/config.json}"
+
+    if ! is_git_repo; then
+      exit 0
+    fi
+
+    read_config "$CONFIG_FILE"
+    sync_root_ignore "$CFG_PLANNING_TRACKING"
+
+    if [ "$CFG_PLANNING_TRACKING" = "commit" ]; then
+      ensure_transient_ignore
+    fi
+    ;;
+
+  commit-boundary)
+    ACTION="${ARG2:-}"
+    CONFIG_FILE="${ARG3:-.vbw-planning/config.json}"
+
+    if [ -z "$ACTION" ]; then
+      echo "Usage: planning-git.sh commit-boundary <action> [CONFIG_FILE]" >&2
+      exit 1
+    fi
+
+    if ! is_git_repo; then
+      exit 0
+    fi
+
+    read_config "$CONFIG_FILE"
+
+    if [ "$CFG_PLANNING_TRACKING" != "commit" ]; then
+      exit 0
+    fi
+
+    ensure_transient_ignore
+
+    if [ -d ".vbw-planning" ]; then
+      git add .vbw-planning
+    fi
+
+    if [ -f "CLAUDE.md" ]; then
+      git add CLAUDE.md
+    fi
+
+    if git diff --cached --quiet; then
+      exit 0
+    fi
+
+    git commit -m "chore(vbw): $ACTION"
+    push_if_configured "$CFG_AUTO_PUSH"
+    ;;
+
+  push-after-phase)
+    CONFIG_FILE="${ARG2:-.vbw-planning/config.json}"
+
+    if ! is_git_repo; then
+      exit 0
+    fi
+
+    read_config "$CONFIG_FILE"
+
+    if [ "$CFG_AUTO_PUSH" = "after_phase" ]; then
+      # Skip if current branch has no upstream yet.
+      if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        git push
+      fi
+    fi
+    ;;
+
+  *)
+    echo "Unknown command: $COMMAND" >&2
+    echo "Usage: planning-git.sh sync-ignore [CONFIG_FILE] | commit-boundary <action> [CONFIG_FILE] | push-after-phase [CONFIG_FILE]" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -67,6 +67,8 @@ if [ -d "$PLANNING_DIR" ] && [ -f "$PLANNING_DIR/config.json" ] && command -v jq
   jq -r '
     "VBW_EFFORT=\(.effort // "balanced")",
     "VBW_AUTONOMY=\(.autonomy // "standard")",
+    "VBW_PLANNING_TRACKING=\(.planning_tracking // "manual")",
+    "VBW_AUTO_PUSH=\(.auto_push // "never")",
     "VBW_CONTEXT_COMPILER=\(if .context_compiler == null then true else .context_compiler end)",
     "VBW_V3_DELTA_CONTEXT=\(.v3_delta_context // false)",
     "VBW_V3_CONTEXT_CACHE=\(.v3_context_cache // false)",
@@ -318,6 +320,8 @@ CONFIG_FILE="$PLANNING_DIR/config.json"
 config_effort="balanced"
 config_autonomy="standard"
 config_auto_commit="true"
+config_planning_tracking="manual"
+config_auto_push="never"
 config_verification="standard"
 config_prefer_teams="always"
 config_max_tasks="5"
@@ -325,6 +329,8 @@ if [ -f "$CONFIG_FILE" ]; then
   config_effort=$(jq -r '.effort // "balanced"' "$CONFIG_FILE" 2>/dev/null)
   config_autonomy=$(jq -r '.autonomy // "standard"' "$CONFIG_FILE" 2>/dev/null)
   config_auto_commit=$(jq -r 'if .auto_commit == null then true else .auto_commit end' "$CONFIG_FILE" 2>/dev/null)
+  config_planning_tracking=$(jq -r '.planning_tracking // "manual"' "$CONFIG_FILE" 2>/dev/null)
+  config_auto_push=$(jq -r '.auto_push // "never"' "$CONFIG_FILE" 2>/dev/null)
   config_verification=$(jq -r '.verification_tier // "standard"' "$CONFIG_FILE" 2>/dev/null)
   config_prefer_teams=$(jq -r '.prefer_teams // "always"' "$CONFIG_FILE" 2>/dev/null)
   config_max_tasks=$(jq -r '.max_tasks_per_plan // 5' "$CONFIG_FILE" 2>/dev/null)
@@ -420,7 +426,7 @@ CTX="VBW project detected."
 CTX="$CTX Milestone: ${MILESTONE_SLUG}."
 CTX="$CTX Phase: ${phase_pos}/${phase_total} (${phase_name}) -- ${phase_status}."
 CTX="$CTX Progress: ${progress_pct}%."
-CTX="$CTX Config: effort=${config_effort}, autonomy=${config_autonomy}, auto_commit=${config_auto_commit}, verification=${config_verification}, prefer_teams=${config_prefer_teams}, max_tasks=${config_max_tasks}."
+CTX="$CTX Config: effort=${config_effort}, autonomy=${config_autonomy}, auto_commit=${config_auto_commit}, planning_tracking=${config_planning_tracking}, auto_push=${config_auto_push}, verification=${config_verification}, prefer_teams=${config_prefer_teams}, max_tasks=${config_max_tasks}."
 CTX="$CTX Next: ${NEXT_ACTION}."
 
 jq -n --arg ctx "$CTX" --arg update "$UPDATE_MSG" --arg welcome "$WELCOME_MSG" --arg flags "${FLAG_WARNINGS:-}" '{

--- a/tests/config-migration.bats
+++ b/tests/config-migration.bats
@@ -189,6 +189,44 @@ EOF
   [ "$output" = "always" ]
 }
 
+@test "migration adds planning_tracking and auto_push defaults" {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'
+{
+  "effort": "balanced"
+}
+EOF
+
+  run_migration
+
+  run jq -r '.planning_tracking' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "manual" ]
+
+  run jq -r '.auto_push' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "never" ]
+}
+
+@test "migration preserves existing planning_tracking and auto_push values" {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'
+{
+  "effort": "balanced",
+  "planning_tracking": "commit",
+  "auto_push": "after_phase"
+}
+EOF
+
+  run_migration
+
+  run jq -r '.planning_tracking' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "commit" ]
+
+  run jq -r '.auto_push' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "after_phase" ]
+}
+
 @test "migration preserves existing prefer_teams value" {
   # Create config with prefer_teams set to "never"
   cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'

--- a/tests/planning-git.bats
+++ b/tests/planning-git.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+
+  cd "$TEST_TEMP_DIR"
+  git init -q
+  git config user.name "VBW Test"
+  git config user.email "vbw-test@example.com"
+
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "chore(init): seed"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+@test "sync-ignore adds .vbw-planning to root gitignore when planning_tracking=ignore" {
+  cat > .vbw-planning/config.json <<'EOF'
+{
+  "planning_tracking": "ignore",
+  "auto_push": "never"
+}
+EOF
+
+  run bash "$SCRIPTS_DIR/planning-git.sh" sync-ignore .vbw-planning/config.json
+  [ "$status" -eq 0 ]
+
+  run grep -qx '\.vbw-planning/' .gitignore
+  [ "$status" -eq 0 ]
+}
+
+@test "sync-ignore removes root ignore and writes transient planning ignore when commit mode" {
+  cat > .gitignore <<'EOF'
+.vbw-planning/
+EOF
+
+  cat > .vbw-planning/config.json <<'EOF'
+{
+  "planning_tracking": "commit",
+  "auto_push": "never"
+}
+EOF
+
+  run bash "$SCRIPTS_DIR/planning-git.sh" sync-ignore .vbw-planning/config.json
+  [ "$status" -eq 0 ]
+
+  run grep -qx '\.vbw-planning/' .gitignore
+  [ "$status" -ne 0 ]
+
+  run grep -q '^\.execution-state\.json$' .vbw-planning/.gitignore
+  [ "$status" -eq 0 ]
+
+  run grep -q '^\.context-\*\.md$' .vbw-planning/.gitignore
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-boundary creates planning artifacts commit in commit mode" {
+  cat > .vbw-planning/config.json <<'EOF'
+{
+  "planning_tracking": "commit",
+  "auto_push": "never"
+}
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+Updated
+EOF
+
+  cat > CLAUDE.md <<'EOF'
+# CLAUDE
+
+Updated
+EOF
+
+  run bash "$SCRIPTS_DIR/planning-git.sh" commit-boundary "bootstrap project" .vbw-planning/config.json
+  [ "$status" -eq 0 ]
+
+  run git log -1 --pretty=%s
+  [ "$status" -eq 0 ]
+  [ "$output" = "chore(vbw): bootstrap project" ]
+}
+
+@test "commit-boundary is no-op in manual mode" {
+  cat > .vbw-planning/config.json <<'EOF'
+{
+  "planning_tracking": "manual",
+  "auto_push": "never"
+}
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+Updated
+EOF
+
+  BEFORE=$(git rev-list --count HEAD)
+
+  run bash "$SCRIPTS_DIR/planning-git.sh" commit-boundary "phase update" .vbw-planning/config.json
+  [ "$status" -eq 0 ]
+
+  AFTER=$(git rev-list --count HEAD)
+  [ "$BEFORE" = "$AFTER" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -25,6 +25,8 @@ create_test_config() {
   "effort": "balanced",
   "autonomy": "standard",
   "auto_commit": true,
+  "planning_tracking": "manual",
+  "auto_push": "never",
   "verification_tier": "standard",
   "skill_suggestions": true,
   "auto_install_skills": false,


### PR DESCRIPTION
## What

Implement planning artifact tracking controls and push behavior controls:

- Add config keys: `planning_tracking` (`manual|ignore|commit`) and `auto_push` (`never|after_phase|always`)
- Add planning git helper script for ignore sync, lifecycle boundary commits, and phase-end push behavior
- Wire lifecycle boundaries (bootstrap, plan, execute completion, archive) to optional planning artifact commits
- Clarify `auto_commit` semantics as source-task commits only

## Why

This addresses maintainer feedback on issue #42 comments:

- Commit boundary behavior should happen at lifecycle boundaries (not ad hoc)
- `CLAUDE.md` must be included with planning artifact commits
- `auto_commit` needs clearer scope, separate from planning-artifact tracking

Fixes: #42 

## How

- Updated defaults and migration test coverage for the new settings
- Added `scripts/planning-git.sh`:
  - `sync-ignore`
  - `commit-boundary`
  - `push-after-phase`
- Updated command/protocol guidance in:
  - `commands/init.md`
  - `commands/config.md`
  - `commands/vibe.md`
  - `references/execute-protocol.md`
  - `agents/vbw-dev.md`
- Exposed new config values in runtime context scripts:
  - `scripts/phase-detect.sh`
  - `scripts/session-start.sh`
- Added focused tests:
  - `tests/planning-git.bats`
  - `tests/config-migration.bats` updates

## Testing

- [ ] Loaded plugin locally with `claude --plugin-dir .`
- [ ] Tested affected commands against a real project
- [ ] No errors on plugin load
- [ ] Existing commands still work

Automated checks run in this branch:

- `bats tests/config-migration.bats tests/planning-git.bats` (20 passing)
- `bash testing/verify-commands-contract.sh` (pass)
- `bash testing/verify-bash-scripts-contract.sh` (pass)

## Notes

This branch currently includes dependency commits from the issue-52 migration work. If preferred, I can split and retarget as a strict stacked sequence after dependency merge.
