### PR TITLE
feat(config): add effort-aware per-agent maxTurns resolution

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -371,6 +371,7 @@ echo "✓ Model override: $AGENT ➜ $MODEL"
 | custom_profiles | object | user-defined profiles | {} |
 | model_profile | string | quality/balanced/budget | quality |
 | model_overrides | object | agent-to-model map | {} |
+| agent_max_turns | object | per-agent turns (number), 0/false disables | scout=15, qa=25, architect=30, debugger=80, lead=50, dev=75 |
 | context_compiler | boolean | true/false | true |
 | v3_delta_context | boolean | true/false | false |
 | v3_context_cache | boolean | true/false | false |

--- a/commands/fix.md
+++ b/commands/fix.md
@@ -25,8 +25,9 @@ Config: Pre-injected by SessionStart hook.
 3. **Spawn Dev:** Resolve model first:
 ```bash
 DEV_MODEL=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-model.sh dev .vbw-planning/config.json ${CLAUDE_PLUGIN_ROOT}/config/model-profiles.json)
+DEV_MAX_TURNS=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh dev .vbw-planning/config.json turbo)
 ```
-Spawn vbw-dev as subagent via Task tool with `model: "${DEV_MODEL}"`:
+Spawn vbw-dev as subagent via Task tool with `model: "${DEV_MODEL}"` and `maxTurns: ${DEV_MAX_TURNS}`:
 ```
 Quick fix (Turbo mode). Effort: low.
 Task: {fix description}.

--- a/commands/map.md
+++ b/commands/map.md
@@ -76,6 +76,7 @@ Scout A (Tech + Architecture): analyze tech stack, deps, architecture, structure
 Scout B (Quality + Concerns): analyze quality, conventions, testing, debt, risks. Send 2 scout_findings messages (domain: "quality" with CONVENTIONS.md+TESTING.md, domain: "concerns" with CONCERNS.md). Mode: {MAPPING_MODE}. Schema ref: `${CLAUDE_PLUGIN_ROOT}/references/handoff-schemas.md`
 
 **Scout model (effort-gated):** Fast/Turbo: `Model: haiku`. Thorough/Balanced: inherit session model.
+**Scout turn budget (effort-gated):** Resolve with `bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh scout .vbw-planning/config.json "{effort}"` and pass `maxTurns: ${SCOUT_MAX_TURNS}` to each Scout TaskCreate.
 Wait for all findings. Proceed to Step 3.5.
 
 ---
@@ -86,7 +87,7 @@ Wait for all findings. Proceed to Step 3.5.
 - Scout 3 (Quality): CONVENTIONS.md + TESTING.md
 - Scout 4 (Concerns): CONCERNS.md
 
-Security: PreToolUse hook handles enforcement. **Scout model:** same as duo.
+Security: PreToolUse hook handles enforcement. **Scout model:** same as duo. **Scout turn budget:** same as duo (`maxTurns: ${SCOUT_MAX_TURNS}` on each TaskCreate).
 
 **Scout communication (effort-gated):**
 

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -39,16 +39,18 @@ Note: Continuous verification handled by hooks. This command is for deep, on-dem
 
 ## Steps
 
-1. **Resolve tier:** Priority: --tier flag > --effort flag > config default > Standard. Effort mapping: turbo=skip (exit "QA skipped in turbo mode"), fast=quick, balanced=standard, thorough=deep. Read `${CLAUDE_PLUGIN_ROOT}/references/effort-profile-{profile}.md`. Context overrides: >15 requirements or last phase before ship → Deep.
+1. **Resolve tier:** Priority: --tier flag > --effort flag > config default > Standard. Keep effort profile as `QA_EFFORT_PROFILE` (thorough|balanced|fast|turbo). Effort mapping: turbo=skip (exit "QA skipped in turbo mode"), fast=quick, balanced=standard, thorough=deep. Read `${CLAUDE_PLUGIN_ROOT}/references/effort-profile-{profile}.md`. Context overrides: >15 requirements or last phase before ship → Deep.
 2. **Resolve milestone:** If .vbw-planning/ACTIVE exists, use milestone-scoped paths.
 3. **Spawn QA:**
    - Resolve QA model:
      ```bash
      QA_MODEL=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-model.sh qa .vbw-planning/config.json ${CLAUDE_PLUGIN_ROOT}/config/model-profiles.json)
      if [ $? -ne 0 ]; then echo "$QA_MODEL" >&2; exit 1; fi
+       QA_MAX_TURNS=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh qa .vbw-planning/config.json "$QA_EFFORT_PROFILE")
+       if [ $? -ne 0 ]; then echo "$QA_MAX_TURNS" >&2; exit 1; fi
      ```
    - Display: `◆ Spawning QA agent (${QA_MODEL})...`
-   - Spawn vbw-qa as subagent via Task tool. **Add `model: "${QA_MODEL}"` parameter.**
+     - Spawn vbw-qa as subagent via Task tool. **Add `model: "${QA_MODEL}"` and `maxTurns: ${QA_MAX_TURNS}` parameters.**
 ```
 Verify phase {N}. Tier: {ACTIVE_TIER}.
 Plans: {paths to PLAN.md files}

--- a/commands/research.md
+++ b/commands/research.md
@@ -28,17 +28,20 @@ Current project:
 3. **Spawn Scout:**
    - Resolve Scout model:
      ```bash
+    RESEARCH_EFFORT=$(jq -r '.effort // "balanced"' .vbw-planning/config.json 2>/dev/null)
      SCOUT_MODEL=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-model.sh scout .vbw-planning/config.json ${CLAUDE_PLUGIN_ROOT}/config/model-profiles.json)
      if [ $? -ne 0 ]; then echo "$SCOUT_MODEL" >&2; exit 1; fi
+    SCOUT_MAX_TURNS=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh scout .vbw-planning/config.json "$RESEARCH_EFFORT")
+    if [ $? -ne 0 ]; then echo "$SCOUT_MAX_TURNS" >&2; exit 1; fi
      ```
    - Display: `◆ Spawning Scout (${SCOUT_MODEL})...`
-   - Spawn vbw-scout as subagent(s) via Task tool. **Add `model: "${SCOUT_MODEL}"` parameter.**
+  - Spawn vbw-scout as subagent(s) via Task tool. **Add `model: "${SCOUT_MODEL}"` and `maxTurns: ${SCOUT_MAX_TURNS}` parameters.**
 ```
 Research: {topic or sub-topic}.
 Project context: {tech stack, constraints from PROJECT.md if relevant}.
 Return structured findings.
 ```
-   - Parallel: up to 4 simultaneous Tasks, each with same `model: "${SCOUT_MODEL}"`.
+  - Parallel: up to 4 simultaneous Tasks, each with same `model: "${SCOUT_MODEL}"` and `maxTurns: ${SCOUT_MAX_TURNS}`.
 4. **Synthesize:** Single: present directly. Parallel: merge, note contradictions, rank by confidence.
 5. **Persist:** Ask "Save findings? (y/n)". If yes: write to .vbw-planning/phases/{phase-dir}/RESEARCH.md or .vbw-planning/RESEARCH.md.
 ```

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -16,6 +16,14 @@
   "custom_profiles": {},
   "model_profile": "quality",
   "model_overrides": {},
+  "agent_max_turns": {
+    "scout": 15,
+    "qa": 25,
+    "architect": 30,
+    "debugger": 80,
+    "lead": 50,
+    "dev": 75
+  },
   "v3_delta_context": false,
   "v3_context_cache": false,
   "v3_plan_research_persist": false,

--- a/references/discovery-protocol.md
+++ b/references/discovery-protocol.md
@@ -42,9 +42,9 @@ Bootstrap Discovery follows an eight-step flow: domain research → round-based 
 
 **Process:**
 1. Extract domain from project description (e.g., "recipe app" → "recipe management", "e-commerce site" → "e-commerce")
-2. Resolve Scout agent model via `resolve-agent-model.sh`
+2. Resolve Scout agent model via `resolve-agent-model.sh` and turn budget via `resolve-agent-max-turns.sh` (using configured effort profile)
 3. Spawn Scout agent via Task tool with prompt: "Research the {domain} domain and write `.vbw-planning/domain-research.md` with four sections: ## Table Stakes (features every {domain} app has), ## Common Pitfalls (what projects get wrong), ## Architecture Patterns (how similar apps are structured), ## Competitor Landscape (existing products). Use WebSearch. Be concise (2-3 bullets per section)."
-4. Set 120-second timeout for research task
+4. Pass `maxTurns: ${SCOUT_MAX_TURNS}` and set 120-second timeout for research task
 
 **On Success:**
 - Read domain-research.md

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -139,9 +139,13 @@ If compilation fails, proceed without it — Dev reads files directly.
 ```bash
 DEV_MODEL=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-model.sh dev .vbw-planning/config.json ${CLAUDE_PLUGIN_ROOT}/config/model-profiles.json)
 if [ $? -ne 0 ]; then echo "$DEV_MODEL" >&2; exit 1; fi
+DEV_MAX_TURNS=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh dev .vbw-planning/config.json "{effort}")
+if [ $? -ne 0 ]; then echo "$DEV_MAX_TURNS" >&2; exit 1; fi
 
 QA_MODEL=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-model.sh qa .vbw-planning/config.json ${CLAUDE_PLUGIN_ROOT}/config/model-profiles.json)
 if [ $? -ne 0 ]; then echo "$QA_MODEL" >&2; exit 1; fi
+QA_MAX_TURNS=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-agent-max-turns.sh qa .vbw-planning/config.json "{effort}")
+if [ $? -ne 0 ]; then echo "$QA_MAX_TURNS" >&2; exit 1; fi
 ```
 
 For each uncompleted plan, TaskCreate:
@@ -159,7 +163,7 @@ activeForm: "Executing {NN-MM}"
 
 Display: `◆ Spawning Dev teammate (${DEV_MODEL})...`
 
-**CRITICAL:** Pass `model: "${DEV_MODEL}"` parameter to the Task tool invocation when spawning Dev teammates.
+**CRITICAL:** Pass `model: "${DEV_MODEL}"` and `maxTurns: ${DEV_MAX_TURNS}` parameters to the Task tool invocation when spawning Dev teammates.
 **CRITICAL:** When team was created (2+ plans), pass `team_name: "vbw-phase-{NN}"` and `name: "dev-{MM}"` parameters to each Task tool invocation. This enables colored agent labels and status bar entries.
 
 Wire dependencies via TaskUpdate: read `depends_on` from each plan's frontmatter, add `addBlockedBy: [task IDs of dependency plans]`. Plans with empty depends_on start immediately.
@@ -359,7 +363,7 @@ Display: `◆ Spawning QA agent (${QA_MODEL})...`
 
 **Post-build QA (Fast, QA_TIMING=post-build):** Spawn QA after ALL plans complete. Include in task description: "Phase context: {phase-dir}/.context-qa.md (if compiled). Model: ${QA_MODEL}. Your verification tier is {tier}. Run {5-10|15-25|30+} checks per the tier definitions in your agent protocol." Persist to `{phase-dir}/{phase}-VERIFICATION.md`.
 
-**CRITICAL:** Pass `model: "${QA_MODEL}"` parameter to the Task tool invocation when spawning QA agents.
+**CRITICAL:** Pass `model: "${QA_MODEL}"` and `maxTurns: ${QA_MAX_TURNS}` parameters to the Task tool invocation when spawning QA agents.
 **CRITICAL:** When team was created (2+ plans), pass `team_name: "vbw-phase-{NN}"` and `name: "qa"` (or `name: "qa-wave{W}"` for per-wave QA) parameters to each QA Task tool invocation.
 
 ### Step 4.5: Human acceptance testing (UAT)

--- a/references/model-profiles.md
+++ b/references/model-profiles.md
@@ -100,7 +100,8 @@ Displays before/after cost impact estimate.
 
 ## Implementation Notes
 - Model resolution: `scripts/resolve-agent-model.sh` reads config, applies profile preset, merges overrides
-- Task tool integration: All agent-spawning commands pass explicit `model` parameter
+- Turn-budget resolution: `scripts/resolve-agent-max-turns.sh` reads config `agent_max_turns` and scales by effort
+- Task tool integration: All agent-spawning commands pass explicit `model` and `maxTurns` parameters
 - Turbo effort bypasses model logic (no agents spawned, direct execution)
 - Model names: `opus` = Claude Opus 4.6, `sonnet` = Claude Sonnet 4.5, `haiku` = Claude Haiku 3.5
 

--- a/scripts/resolve-agent-max-turns.sh
+++ b/scripts/resolve-agent-max-turns.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# resolve-agent-max-turns.sh - Turn budget resolution for VBW agents
+#
+# Reads agent_max_turns from config.json and resolves maxTurns for a given
+# agent and effort profile.
+#
+# Usage: resolve-agent-max-turns.sh <agent-name> <config-path> <effort>
+#   agent-name: lead|dev|qa|scout|debugger|architect
+#   config-path: path to .vbw-planning/config.json
+#   effort: thorough|balanced|fast|turbo
+#
+# Returns: stdout = integer maxTurns (0 means "disabled"), exit 0
+# Errors: stderr = error message, exit 1
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: resolve-agent-max-turns.sh <agent-name> <config-path> <effort>" >&2
+  exit 1
+fi
+
+AGENT="$1"
+CONFIG_PATH="$2"
+EFFORT="$3"
+
+case "$AGENT" in
+  lead|dev|qa|scout|debugger|architect)
+    ;;
+  *)
+    echo "Invalid agent name '$AGENT'. Valid: lead, dev, qa, scout, debugger, architect" >&2
+    exit 1
+    ;;
+esac
+
+case "$EFFORT" in
+  thorough|balanced|fast|turbo)
+    ;;
+  *)
+    echo "Invalid effort '$EFFORT'. Valid: thorough, balanced, fast, turbo" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  echo "Config not found at $CONFIG_PATH. Run /vbw:init first." >&2
+  exit 1
+fi
+
+if ! jq empty "$CONFIG_PATH" >/dev/null 2>&1; then
+  echo "Malformed config JSON at $CONFIG_PATH" >&2
+  exit 1
+fi
+
+default_base_turns() {
+  case "$1" in
+    scout) echo 15 ;;
+    qa) echo 25 ;;
+    architect) echo 30 ;;
+    debugger) echo 80 ;;
+    lead) echo 50 ;;
+    dev) echo 75 ;;
+  esac
+}
+
+multiplier_for_effort() {
+  # Output "numerator denominator"
+  case "$1" in
+    thorough) echo "3 2" ;;   # 1.5x
+    balanced) echo "1 1" ;;   # 1.0x
+    fast) echo "4 5" ;;       # 0.8x
+    turbo) echo "3 5" ;;      # 0.6x
+  esac
+}
+
+normalize_turn_value() {
+  local value="$1"
+
+  case "$value" in
+    false|FALSE|False)
+      echo 0
+      return 0
+      ;;
+  esac
+
+  if [ "$value" = "null" ] || [ -z "$value" ]; then
+    echo ""
+    return 0
+  fi
+
+  if ! [[ "$value" =~ ^-?[0-9]+$ ]]; then
+    echo "Invalid turn budget value '$value' for agent '$AGENT'" >&2
+    return 1
+  fi
+
+  if [ "$value" -le 0 ]; then
+    echo 0
+    return 0
+  fi
+
+  echo "$value"
+}
+
+CONFIGURED_TYPE=$(jq -r ".agent_max_turns.$AGENT | type? // \"null\"" "$CONFIG_PATH")
+
+# Object mode: explicit per-effort values, no multiplier applied.
+if [ "$CONFIGURED_TYPE" = "object" ]; then
+  RAW_VALUE=$(jq -r ".agent_max_turns.$AGENT.$EFFORT // .agent_max_turns.$AGENT.balanced // empty" "$CONFIG_PATH")
+  EXPLICIT_VALUE=$(normalize_turn_value "$RAW_VALUE")
+  if [ -n "$EXPLICIT_VALUE" ]; then
+    echo "$EXPLICIT_VALUE"
+    exit 0
+  fi
+fi
+
+# Scalar mode: configured or default base value with effort multiplier.
+RAW_BASE=$(jq -r ".agent_max_turns.$AGENT" "$CONFIG_PATH")
+BASE=$(normalize_turn_value "$RAW_BASE")
+if [ -z "$BASE" ]; then
+  BASE=$(default_base_turns "$AGENT")
+fi
+
+if [ "$BASE" -eq 0 ]; then
+  echo 0
+  exit 0
+fi
+
+read -r NUM DEN <<<"$(multiplier_for_effort "$EFFORT")"
+RESOLVED=$(( (BASE * NUM + DEN / 2) / DEN ))
+
+if [ "$RESOLVED" -lt 1 ]; then
+  RESOLVED=1
+fi
+
+echo "$RESOLVED"
+exit 0

--- a/tests/config-migration.bats
+++ b/tests/config-migration.bats
@@ -206,6 +206,46 @@ EOF
   [ "$output" = "never" ]
 }
 
+@test "migration adds missing agent_max_turns defaults" {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'
+{
+  "effort": "balanced"
+}
+EOF
+
+  run_migration
+
+  run jq -r '.agent_max_turns.scout' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "15" ]
+
+  run jq -r '.agent_max_turns.debugger' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "80" ]
+}
+
+@test "migration preserves existing agent_max_turns values" {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'
+{
+  "effort": "balanced",
+  "agent_max_turns": {
+    "debugger": 120,
+    "dev": 90
+  }
+}
+EOF
+
+  run_migration
+
+  run jq -r '.agent_max_turns.debugger' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "120" ]
+
+  run jq -r '.agent_max_turns.dev' "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "90" ]
+}
+
 @test "migration renames agent_teams to prefer_teams and removes stale key" {
   cat > "$TEST_TEMP_DIR/.vbw-planning/config.json" <<'EOF'
 {

--- a/tests/resolve-agent-max-turns.bats
+++ b/tests/resolve-agent-max-turns.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  create_test_config
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+@test "resolves balanced default for debugger" {
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" debugger "$TEST_TEMP_DIR/.vbw-planning/config.json" balanced
+  [ "$status" -eq 0 ]
+  [ "$output" = "80" ]
+}
+
+@test "scales scalar turn budgets by effort" {
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" dev "$TEST_TEMP_DIR/.vbw-planning/config.json" thorough
+  [ "$status" -eq 0 ]
+  [ "$output" = "113" ]
+
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" dev "$TEST_TEMP_DIR/.vbw-planning/config.json" turbo
+  [ "$status" -eq 0 ]
+  [ "$output" = "45" ]
+}
+
+@test "returns zero when agent turn budget disabled via false" {
+  jq '.agent_max_turns.debugger = false' "$TEST_TEMP_DIR/.vbw-planning/config.json" > "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp"
+  mv "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp" "$TEST_TEMP_DIR/.vbw-planning/config.json"
+
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" debugger "$TEST_TEMP_DIR/.vbw-planning/config.json" thorough
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "returns zero when agent turn budget disabled via zero" {
+  jq '.agent_max_turns.debugger = 0' "$TEST_TEMP_DIR/.vbw-planning/config.json" > "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp"
+  mv "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp" "$TEST_TEMP_DIR/.vbw-planning/config.json"
+
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" debugger "$TEST_TEMP_DIR/.vbw-planning/config.json" balanced
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "supports explicit per-effort object values without multiplier" {
+  jq '.agent_max_turns.debugger = {"thorough": 140, "balanced": 90, "fast": 70, "turbo": 50}' "$TEST_TEMP_DIR/.vbw-planning/config.json" > "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp"
+  mv "$TEST_TEMP_DIR/.vbw-planning/config.json.tmp" "$TEST_TEMP_DIR/.vbw-planning/config.json"
+
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" debugger "$TEST_TEMP_DIR/.vbw-planning/config.json" fast
+  [ "$status" -eq 0 ]
+  [ "$output" = "70" ]
+}
+
+@test "rejects invalid agent name" {
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" invalid "$TEST_TEMP_DIR/.vbw-planning/config.json" balanced
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects invalid effort name" {
+  run bash "$SCRIPTS_DIR/resolve-agent-max-turns.sh" debugger "$TEST_TEMP_DIR/.vbw-planning/config.json" medium
+  [ "$status" -eq 1 ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -38,6 +38,14 @@ create_test_config() {
   "custom_profiles": {},
   "model_profile": "quality",
   "model_overrides": {},
+  "agent_max_turns": {
+    "scout": 15,
+    "qa": 25,
+    "architect": 30,
+    "debugger": 80,
+    "lead": 50,
+    "dev": 75
+  },
   "context_compiler": true,
   "v3_delta_context": false,
   "v3_context_cache": false,


### PR DESCRIPTION
## What

Implement issue #44 phase 1: configurable per-agent `maxTurns` with effort-aware resolution.

## Why

Upstream issue #44 requests a shippable first phase: config-driven max turns per agent tied to effort, with disable support (`0`/`false`).

Fixes #44

## How

- Added `agent_max_turns` defaults in `config/defaults.json`
- Added `scripts/resolve-agent-max-turns.sh`
- Added `tests/resolve-agent-max-turns.bats`
- Added migration + fixture coverage updates in `tests/config-migration.bats` and `tests/test_helper.bash`
- Wired maxTurns resolution guidance into command/protocol docs (`debug`, `fix`, `map`, `qa`, `research`, `vibe`, plus discovery/execute/model profile references)

## Testing

- `bats tests/resolve-agent-max-turns.bats` ✅
- `bash testing/run-all.sh` ✅

## Notes

- Phase 1 only from #44
- Checkpoint/resume remains out of scope pending platform investigation
- PR #59 is not a dependency (it addressed #42 and is already merged)
