### PR TITLE
fix(compact): add role-matched snapshot restore and task-level resume context

### DIFF
--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -28,7 +28,7 @@ Set completed plans (with SUMMARY.md) to `"complete"`, others to `"pending"`.
 
 9. **V3 Snapshot Resume (REQ-18):** If `v3_snapshot_resume=true` in config:
    - On crash recovery (execution-state.json exists with `"status": "running"`): attempt restore:
-     `SNAPSHOT=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/snapshot-resume.sh restore {phase} 2>/dev/null || echo "")`
+     `SNAPSHOT=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/snapshot-resume.sh restore {phase} {preferred-role} 2>/dev/null || echo "")`
    - If snapshot found, log: `✓ Snapshot found: ${SNAPSHOT}` — use snapshot's `recent_commits` to cross-reference git log for more reliable resume-from detection.
 
 10. **V3 Schema Validation (REQ-17):** If `v3_schema_validation=true` in config:
@@ -248,8 +248,8 @@ Hooks handle continuous verification: PostToolUse validates SUMMARY.md, TaskComp
 
 **V3 Snapshot — per-plan checkpoint (REQ-18):** If `v3_snapshot_resume=true` in config:
 - After each plan completes (SUMMARY.md verified):
-  `bash ${CLAUDE_PLUGIN_ROOT}/scripts/snapshot-resume.sh save {phase} 2>/dev/null || true`
-- This captures execution state + recent git context for crash recovery.
+  `bash ${CLAUDE_PLUGIN_ROOT}/scripts/snapshot-resume.sh save {phase} .vbw-planning/.execution-state.json {agent-role} {trigger} 2>/dev/null || true`
+- This captures execution state + recent git context for crash recovery. The optional `{agent-role}` and `{trigger}` arguments add metadata to the snapshot for role-filtered restore.
 
 **V3 Metrics instrumentation (REQ-09):** If `v3_metrics=true` in config:
 - At phase start: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/collect-metrics.sh execute_phase_start {phase} plan_count={N} effort={effort}`

--- a/scripts/compaction-instructions.sh
+++ b/scripts/compaction-instructions.sh
@@ -48,7 +48,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [ -f ".vbw-planning/.execution-state.json" ] && [ -f "$SCRIPT_DIR/snapshot-resume.sh" ]; then
   SNAP_PHASE=$(jq -r '.phase // ""' ".vbw-planning/.execution-state.json" 2>/dev/null)
   if [ -n "$SNAP_PHASE" ]; then
-    bash "$SCRIPT_DIR/snapshot-resume.sh" save "$SNAP_PHASE" 2>/dev/null || true
+    bash "$SCRIPT_DIR/snapshot-resume.sh" save "$SNAP_PHASE" ".vbw-planning/.execution-state.json" "$AGENT_NAME" "$MATCHER" 2>/dev/null || true
     TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%d %H:%M:%S")
     echo "[$TIMESTAMP] Snapshot saved: phase=$SNAP_PHASE agent=$AGENT_NAME" >> ".vbw-planning/.hook-errors.log" 2>/dev/null || true
   fi

--- a/scripts/post-compact.sh
+++ b/scripts/post-compact.sh
@@ -12,12 +12,26 @@ rm -f .vbw-planning/.cost-ledger.json .vbw-planning/.compaction-marker 2>/dev/nu
 
 # Try to identify agent role from input context
 ROLE=""
-for pattern in vbw-lead vbw-dev vbw-qa vbw-scout vbw-debugger vbw-architect; do
+for pattern in vbw-lead vbw-dev vbw-qa vbw-scout vbw-debugger vbw-architect vbw-docs; do
   if echo "$INPUT" | grep -qi "$pattern"; then
     ROLE="$pattern"
     break
   fi
 done
+
+# Convert plan id (e.g. "05-01") to numeric plan number (e.g. "1")
+plan_id_to_num() {
+  local plan_id="$1"
+  echo "$plan_id" | sed 's/^[0-9]*-//' | sed 's/^0*//' | sed 's/^$/0/'
+}
+
+# Build next task id from last completed task id (e.g. 1-1-T3 -> 1-1-T4)
+next_task_from_completed() {
+  local task_id="$1"
+  if [[ "$task_id" =~ ^([0-9]+-[0-9]+-T)([0-9]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
+  fi
+}
 
 case "$ROLE" in
   vbw-lead)
@@ -49,12 +63,63 @@ SNAPSHOT_CONTEXT=""
 if [ -f ".vbw-planning/.execution-state.json" ] && [ -f "$SCRIPT_DIR/snapshot-resume.sh" ]; then
   SNAP_PHASE=$(jq -r '.phase // ""' ".vbw-planning/.execution-state.json" 2>/dev/null)
   if [ -n "$SNAP_PHASE" ]; then
-    SNAP_PATH=$(bash "$SCRIPT_DIR/snapshot-resume.sh" restore "$SNAP_PHASE" 2>/dev/null) || SNAP_PATH=""
+    SNAP_PATH=$(bash "$SCRIPT_DIR/snapshot-resume.sh" restore "$SNAP_PHASE" "${ROLE:-}" 2>/dev/null) || SNAP_PATH=""
     if [ -n "$SNAP_PATH" ] && [ -f "$SNAP_PATH" ]; then
-      SNAP_PLAN=$(jq -r '.execution_state.current_plan // "unknown"' "$SNAP_PATH" 2>/dev/null)
+      SNAP_PLAN=$(jq -r '
+        .execution_state.current_plan //
+        (
+          .execution_state.plans // []
+          | map(select(.status == "running" or .status == "pending"))
+          | sort_by(.id)
+          | .[0].id
+        ) //
+        (
+          .execution_state.plans // []
+          | sort_by(.id)
+          | .[0].id
+        ) //
+        "unknown"
+      ' "$SNAP_PATH" 2>/dev/null)
       SNAP_STATUS=$(jq -r '.execution_state.status // "unknown"' "$SNAP_PATH" 2>/dev/null)
       SNAP_COMMITS=$(jq -r '.recent_commits | join(", ")' "$SNAP_PATH" 2>/dev/null) || SNAP_COMMITS=""
+
+      # Task-level resume hint: prefer explicit cursor; fallback to event log.
+      SNAP_IN_PROGRESS_TASK=$(jq -r '.execution_state.current_task_id // ""' "$SNAP_PATH" 2>/dev/null)
+      SNAP_LAST_COMPLETED_TASK=""
+      SNAP_NEXT_TASK=""
+      if [ -n "$SNAP_PLAN" ] && [ "$SNAP_PLAN" != "unknown" ] && [ -f ".vbw-planning/.events/event-log.jsonl" ] && command -v jq >/dev/null 2>&1; then
+        PLAN_NUM=$(plan_id_to_num "$SNAP_PLAN")
+        if [ -n "$PLAN_NUM" ] && [[ "$PLAN_NUM" =~ ^[0-9]+$ ]] && [ "$PLAN_NUM" -gt 0 ]; then
+          LAST_STARTED_TASK=$(jq -r --argjson phase "$SNAP_PHASE" --argjson plan "$PLAN_NUM" '
+            select(.event == "task_started" and .phase == $phase and (.plan // 0) == $plan)
+            | .data.task_id // empty
+          ' ".vbw-planning/.events/event-log.jsonl" 2>/dev/null | tail -1)
+
+          LAST_COMPLETED_TASK=$(jq -r --argjson phase "$SNAP_PHASE" --argjson plan "$PLAN_NUM" '
+            select(.event == "task_completed_confirmed" and .phase == $phase and (.plan // 0) == $plan)
+            | .data.task_id // empty
+          ' ".vbw-planning/.events/event-log.jsonl" 2>/dev/null | tail -1)
+
+          if [ -z "$SNAP_IN_PROGRESS_TASK" ] && [ -n "$LAST_STARTED_TASK" ] && [ "$LAST_STARTED_TASK" != "$LAST_COMPLETED_TASK" ]; then
+            SNAP_IN_PROGRESS_TASK="$LAST_STARTED_TASK"
+          fi
+
+          if [ -n "$LAST_COMPLETED_TASK" ]; then
+            SNAP_LAST_COMPLETED_TASK="$LAST_COMPLETED_TASK"
+            SNAP_NEXT_TASK=$(next_task_from_completed "$LAST_COMPLETED_TASK")
+          fi
+        fi
+      fi
+
       SNAPSHOT_CONTEXT=" Pre-compaction state: phase=${SNAP_PHASE}, plan=${SNAP_PLAN}, status=${SNAP_STATUS}."
+      if [ -n "$SNAP_IN_PROGRESS_TASK" ]; then
+        SNAPSHOT_CONTEXT="${SNAPSHOT_CONTEXT} In-progress task before compact: ${SNAP_IN_PROGRESS_TASK}."
+      elif [ -n "$SNAP_NEXT_TASK" ]; then
+        SNAPSHOT_CONTEXT="${SNAPSHOT_CONTEXT} Resume candidate: ${SNAP_NEXT_TASK}."
+      fi
+      if [ -n "$SNAP_LAST_COMPLETED_TASK" ]; then
+        SNAPSHOT_CONTEXT="${SNAPSHOT_CONTEXT} Last completed task: ${SNAP_LAST_COMPLETED_TASK}."
+      fi
       if [ -n "$SNAP_COMMITS" ]; then
         SNAPSHOT_CONTEXT="${SNAPSHOT_CONTEXT} Recent commits: ${SNAP_COMMITS}."
       fi


### PR DESCRIPTION
## Summary

- **Role-matched snapshot restore**: Agents resuming after compaction now restore their own role-matched snapshot instead of potentially picking up another agent's state. Falls back to most-recent if no role match exists.
- **Cascading plan inference**: When `current_plan` is absent from the snapshot, a jq fallback chain resolves the active plan: `current_plan` → first running/pending plan → first plan → `"unknown"`.
- **Task-level resume hints**: In-progress and next-task context derived from the event log (`task_started` vs `task_completed_confirmed`) is injected into the compaction context string, so agents know exactly where they left off.

## Changed Files

| File | What |
|------|------|
| `scripts/compaction-instructions.sh` | Pass agent name + matcher to snapshot save |
| `scripts/post-compact.sh` | Role-matched restore, plan inference chain, task resume hints, `plan_id_to_num()` and `next_task_from_completed()` helpers, explicit numeric guard |
| `scripts/snapshot-resume.sh` | Save records `agent_role`/`compaction_trigger`; restore accepts optional role filter with fallback |
| `references/execute-protocol.md` | Updated snapshot-resume signatures to document new args |
| `tests/runtime-foundations.bats` | New: role-matched restore preference test + unit tests for both helpers |
| `tests/sessionstart-compact-hooks.bats` | New: end-to-end integration test (role + plan inference + task resume) |

## Conflict Check

Verified no conflicts with #64 (`fix/isolation-lifecycle-max-turns`). Both PRs touch `scripts/post-compact.sh` and `references/execute-protocol.md`, but in completely different hunks:
- **post-compact.sh**: #64 modifies line 9 (rm cleanup); this PR adds code at lines 20-32 and 64-120
- **execute-protocol.md**: #64 modifies lines ~139-163 and ~370-374 (max-turns); this PR modifies lines ~31 and ~247 (snapshot signatures)

## Test plan

- [ ] `bats tests/runtime-foundations.bats` — role-matched restore + helper unit tests
- [ ] `bats tests/sessionstart-compact-hooks.bats` — end-to-end integration test
- [ ] Verify multi-agent compaction recovery in a real phase execution