### PR TITLE
fix(planning-git): add missing transient runtime artifacts to gitignore

### DIFF
--- a/scripts/planning-git.sh
+++ b/scripts/planning-git.sh
@@ -47,7 +47,7 @@ ensure_transient_ignore() {
 .vbw-session
 .active-agent
 .active-agent-count
-.active-agent-count.lock
+.active-agent-count.lock/
 .agent-pids
 
 # Metrics & cost tracking
@@ -70,6 +70,14 @@ ensure_transient_ignore() {
 .compaction-marker
 .session-log.jsonl
 .session-log.jsonl.tmp
+.notification-log.jsonl
+.watchdog-pid
+.watchdog.log
+.claude-md-migrated
+.tmux-mode-patched
+
+# Baselines
+.baselines/
 
 # Codebase mapping
 codebase/

--- a/tests/planning-git.bats
+++ b/tests/planning-git.bats
@@ -70,45 +70,46 @@ EOF
   run bash "$SCRIPTS_DIR/planning-git.sh" sync-ignore .vbw-planning/config.json
   [ "$status" -eq 0 ]
 
-  # Session & agent tracking
-  run grep -q '^\.vbw-session$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.agent-pids$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.active-agent$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.active-agent-count$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.active-agent-count\.lock$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
+  expected_entries=(
+    '.execution-state.json'
+    '.execution-state.json.tmp'
+    '.context-*.md'
+    '.contracts/'
+    '.locks/'
+    '.token-state/'
+    '.vbw-session'
+    '.active-agent'
+    '.active-agent-count'
+    '.active-agent-count.lock/'
+    '.agent-pids'
+    '.metrics/'
+    '.cost-ledger.json'
+    '.cache/'
+    '.artifacts/'
+    '.events/'
+    '.event-log.jsonl'
+    '.snapshots/'
+    '.hook-errors.log'
+    '.compaction-marker'
+    '.session-log.jsonl'
+    '.session-log.jsonl.tmp'
+    '.notification-log.jsonl'
+    '.watchdog-pid'
+    '.watchdog.log'
+    '.claude-md-migrated'
+    '.tmux-mode-patched'
+    '.baselines/'
+    'codebase/'
+  )
 
-  # Metrics & cost
-  run grep -q '^\.metrics/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.cost-ledger\.json$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
+  for entry in "${expected_entries[@]}"; do
+    run grep -Fqx "$entry" .vbw-planning/.gitignore
+    [ "$status" -eq 0 ]
+  done
 
-  # Cache, artifacts, events, snapshots
-  run grep -q '^\.cache/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.artifacts/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.events/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.snapshots/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-
-  # Logging & markers
-  run grep -q '^\.hook-errors\.log$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.compaction-marker$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-  run grep -q '^\.session-log\.jsonl$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
-
-  # Codebase mapping
-  run grep -q '^codebase/$' .vbw-planning/.gitignore
-  [ "$status" -eq 0 ]
+  actual_entries="$(grep -Ev '^(#|$)' .vbw-planning/.gitignore | sort)"
+  expected_entries_sorted="$(printf '%s\n' "${expected_entries[@]}" | sort)"
+  [ "$actual_entries" = "$expected_entries_sorted" ]
 }
 
 @test "commit-boundary excludes transient files from commit" {
@@ -129,21 +130,46 @@ EOF
   echo "12345" > .vbw-planning/.agent-pids
   echo "session-abc" > .vbw-planning/.vbw-session
   echo "lead" > .vbw-planning/.active-agent
+  echo "migrated" > .vbw-planning/.claude-md-migrated
+  echo "patched" > .vbw-planning/.tmux-mode-patched
+  echo "99999" > .vbw-planning/.watchdog-pid
+  echo "watchdog started" > .vbw-planning/.watchdog.log
+  echo '{"type":"info"}' > .vbw-planning/.notification-log.jsonl
+  echo '{"status":"running"}' > .vbw-planning/.execution-state.json.tmp
   mkdir -p .vbw-planning/.metrics
   echo '{}' > .vbw-planning/.metrics/run-metrics.jsonl
+  mkdir -p .vbw-planning/.baselines
+  echo '{"baseline":1}' > .vbw-planning/.baselines/token-baseline.json
+  mkdir -p .vbw-planning/.active-agent-count.lock
+  echo 'stale' > .vbw-planning/.active-agent-count.lock/stale.lock
 
   run bash "$SCRIPTS_DIR/planning-git.sh" commit-boundary "phase complete" .vbw-planning/config.json
   [ "$status" -eq 0 ]
 
   # STATE.md should be committed
-  run git show HEAD -- .vbw-planning/STATE.md
+  run git cat-file -e 'HEAD:.vbw-planning/STATE.md'
   [ "$status" -eq 0 ]
 
   # Transient files should NOT be committed
-  run git show HEAD -- .vbw-planning/.agent-pids
-  [ "$output" = "" ] || [[ "$output" != *"12345"* ]]
-  run git show HEAD -- .vbw-planning/.vbw-session
-  [ "$output" = "" ] || [[ "$output" != *"session-abc"* ]]
+  transient_paths=(
+    '.agent-pids'
+    '.vbw-session'
+    '.active-agent'
+    '.claude-md-migrated'
+    '.tmux-mode-patched'
+    '.watchdog-pid'
+    '.watchdog.log'
+    '.notification-log.jsonl'
+    '.execution-state.json.tmp'
+    '.metrics/run-metrics.jsonl'
+    '.baselines/token-baseline.json'
+    '.active-agent-count.lock/stale.lock'
+  )
+
+  for path in "${transient_paths[@]}"; do
+    run git cat-file -e "HEAD:.vbw-planning/$path"
+    [ "$status" -ne 0 ]
+  done
 }
 
 @test "commit-boundary creates planning artifacts commit in commit mode" {


### PR DESCRIPTION
## What

Add 18+ missing transient runtime artifacts to `ensure_transient_ignore()` in `scripts/planning-git.sh`. When `planning_tracking=commit`, these session-specific files were either polluting `git status` or getting committed by `commit-boundary`'s `git add .vbw-planning`.

## Why

Fixes #67 — When running with `planning_tracking=commit` and `auto_push=always`, files like `.agent-pids`, `.vbw-session`, `.active-agent`, `.metrics/`, `.cache/`, `.events/`, `.snapshots/`, `.hook-errors.log`, `.session-log.jsonl`, `codebase/`, and others were not excluded from git tracking. The original implementation only excluded 5 patterns (`.execution-state.json`, `.context-*.md`, `.contracts/`, `.locks/`, `.token-state/`).

## How

- Updated `ensure_transient_ignore()` in `scripts/planning-git.sh` to write a comprehensive `.vbw-planning/.gitignore` covering all runtime artifacts identified via codebase audit:
  - Session & agent tracking: `.vbw-session`, `.active-agent`, `.active-agent-count`, `.active-agent-count.lock`, `.agent-pids`
  - Metrics & cost: `.metrics/`, `.cost-ledger.json`
  - Caching: `.cache/`
  - Artifacts & events (v2/v3 feature-gated): `.artifacts/`, `.events/`, `.event-log.jsonl`
  - Snapshots: `.snapshots/`
  - Logging & markers: `.hook-errors.log`, `.compaction-marker`, `.session-log.jsonl`, `.session-log.jsonl.tmp`
  - Codebase mapping: `codebase/`
  - Temp files: `.execution-state.json.tmp`
- Added 2 new test cases in `tests/planning-git.bats`:
  - Verifies all transient entries exist in the generated `.gitignore`
  - Verifies `commit-boundary` excludes transient files from commits

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] Tested affected commands against a real project
- [x] No errors on plugin load
- [x] Existing commands still work
- [x] All 6 `planning-git.bats` tests pass (4 existing + 2 new)
- [x] Full `testing/run-all.sh` passes (22/22)

## Notes

The audit identified every script that creates files inside `.vbw-planning/` — many are behind v2/v3 feature flags (`.artifacts/`, `.events/`, `.snapshots/`) so they won't exist in most setups, but excluding them preemptively prevents future issues when those flags are enabled.