### PR TITLE
fix(hooks): skip commit gate for [analysis-only] tasks

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -52,7 +52,7 @@ Decision tree:
   ```
 - Display: `◆ Spawning Debugger (${DEBUGGER_MODEL})...`
 - Create Agent Team "debug-{timestamp}" via TeamCreate
-- Create 3 tasks via TaskCreate, each with: bug report, ONE hypothesis only (no cross-contamination), working dir, instruction to report via `debugger_report` schema (see `${CLAUDE_PLUGIN_ROOT}/references/handoff-schemas.md`)
+- Create 3 tasks via TaskCreate, each with: bug report, ONE hypothesis only (no cross-contamination), working dir, instruction to report via `debugger_report` schema (see `${CLAUDE_PLUGIN_ROOT}/references/handoff-schemas.md`). **Include `[analysis-only]` in each task subject** (e.g., "Hypothesis 1: race condition in sync handler [analysis-only]") so the TaskCompleted hook skips the commit-verification gate for report-only tasks.
 - Spawn 3 vbw-debugger teammates, one task each. **Add `model: "${DEBUGGER_MODEL}"` and `maxTurns: ${DEBUGGER_MAX_TURNS}` parameters to each Task spawn.**
 - Wait for completion. Synthesize: strongest evidence + highest confidence wins. Multiple confirmed = contributing factors.
 - Winning hypothesis with fix: apply + commit `fix({scope}): {description}`


### PR DESCRIPTION
## What

Add `[analysis-only]` tag convention to let report-only tasks (debugger hypothesis investigation, etc.) complete without a matching git commit.

## Why

The `TaskCompleted` hook (`task-verify.sh`) assumes every completed task must have a recent git commit. This blocks analysis-only tasks like debugger teammates in Teammate Mode, which are explicitly instructed *not* to apply fixes ("Do NOT apply fixes -- report only"). The Lead agent has to forcefully shut down debugger agents to work around this.

Fixes #70

## How

Three changes:

1. **`scripts/task-verify.sh`** — Added early-exit before the role-only check: if the task subject (or description fallback) contains `[analysis-only]`, allow completion (exit 0) without checking for commits.

2. **`commands/debug.md`** — Updated Path A (Competing Hypotheses) TaskCreate instruction to include `[analysis-only]` in each hypothesis task subject, e.g. `"Hypothesis 1: race condition in sync handler [analysis-only]"`.

3. **`tests/hooks-isolation-lifecycle.bats`** — Added 3 tests:
   - `[analysis-only]` tag in `task_subject` → allowed (exit 0)
   - `[analysis-only]` tag in `task_description` fallback → allowed (exit 0)
   - Normal task without tag and no matching commit → still blocked (exit 2)

The convention is available for any future command that spawns non-committing tasks (e.g., Scout research could adopt `[analysis-only]` as well).

## Testing

- [ ] Loaded plugin locally with `claude --plugin-dir .`
- [ ] Tested affected commands against a real project
- [x] No errors on plugin load
- [x] Existing commands still work
- [x] All 455 bats tests pass (0 failures)
- [x] `testing/run-all.sh` — 22 PASS, 0 FAIL

## Notes

- The tag is case-insensitive (`grep -qi`).
- Only `/vbw:debug` Path A currently emits the tag. Other commands can adopt it by adding `[analysis-only]` to task subjects.
- No config flag needed — the tag is purely opt-in via task subject text.