### PR TITLE
feat(skills): add installation scope selection step

### DIFF
--- a/commands/skills.md
+++ b/commands/skills.md
@@ -53,9 +53,17 @@ Run `npx skills find "<query>"`. Display results with `(registry)` tag. If npx u
 
 Combine curated + registry, deduplicate, rank (curated first). AskUserQuestion multiSelect, max 4 options + "Skip". If >4: show top 4, suggest --search for more.
 
+### Step 5b: Choose installation scope
+
+AskUserQuestion (single select) — "Where should these skills be installed?":
+- **Project (Recommended)** — "Installed to `./.claude/skills/`, scoped to this project only."
+- **Global** — "Installed to `~/.agents/skills/`, available in all projects."
+
+Store the choice as SCOPE. If "Skip" was selected in Step 5: skip this step.
+
 ### Step 6: Install selected
 
-`npx skills add <skill> -g -y` per selection. Display ✓ or ✗ per skill. "➜ Skills take effect immediately — no restart needed."
+`npx skills add <skill> -y` (project scope) or `npx skills add <skill> -g -y` (global scope) per selection, based on SCOPE from Step 5b. Display ✓ or ✗ per skill. "➜ Skills take effect immediately — no restart needed."
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Adds **Step 5b** to `/vbw:skills` allowing users to choose between project-scope and global-scope installation
- Project scope installs to `./.claude/skills/` (recommended), global scope installs to `~/.agents/skills/`
- Updates **Step 6** to pass `-g` flag only when global scope is selected

## Motivation

Currently `/vbw:skills` always installs globally (`-g` flag). Users working on multiple projects may prefer project-scoped skills to avoid polluting their global config. This change gives users the choice.

## Test plan

- [ ] Run `/vbw:skills` with no args — verify Step 5b scope prompt appears after skill selection
- [ ] Select "Project" scope — verify install runs without `-g` flag
- [ ] Select "Global" scope — verify install runs with `-g` flag
- [ ] Select "Skip" in Step 5 — verify Step 5b is skipped entirely