### PR TITLE
refactor(bootstrap): remove Key Decisions section from CLAUDE.md template

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -159,7 +159,7 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
   ```
   bash ${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap/bootstrap-claude.sh CLAUDE.md "$PROJECT_NAME" "$CORE_VALUE" [CLAUDE.md]
   ```
-  Script handles: new file generation (heading + core value + VBW sections), existing file preservation (replaces only VBW-managed sections: Active Context, VBW Rules, Key Decisions, Installed Skills, Project Conventions, Commands, Plugin Isolation; preserves all other content). Omit the fourth argument if no existing CLAUDE.md. Max 200 lines.
+  Script handles: new file generation (heading + core value + VBW sections), existing file preservation (replaces only VBW-managed sections: Active Context, VBW Rules, Installed Skills, Project Conventions, Commands, Plugin Isolation; preserves all other content). Omit the fourth argument if no existing CLAUDE.md. Max 200 lines.
 - **B7: Planning commit boundary (conditional)** -- Run:
    ```bash
    bash ${CLAUDE_PLUGIN_ROOT}/scripts/planning-git.sh commit-boundary "bootstrap project files" .vbw-planning/config.json

--- a/scripts/bootstrap/bootstrap-claude.sh
+++ b/scripts/bootstrap/bootstrap-claude.sh
@@ -16,11 +16,16 @@ set -euo pipefail
 VBW_SECTIONS=(
   "## Active Context"
   "## VBW Rules"
-  "## Key Decisions"
   "## Installed Skills"
   "## Project Conventions"
   "## Commands"
   "## Plugin Isolation"
+)
+
+# Formerly VBW-managed sections — still stripped during brownfield regeneration
+# to clean up stale content from existing CLAUDE.md files.
+VBW_DEPRECATED_SECTIONS=(
+  "## Key Decisions"  # Removed: tracked in .vbw-planning/PROJECT.md and STATE.md
 )
 
 # Strong GSD-managed section headers (always stripped when present)
@@ -94,11 +99,6 @@ generate_vbw_sections() {
 - **Do not fabricate content.** Only use what the user explicitly states in project-defining flows.
 - **Do not bump version or push until asked.** Never run `scripts/bump-version.sh` or `git push` unless the user explicitly requests it, except when `.vbw-planning/config.json` intentionally sets `auto_push` to `always` or `after_phase`.
 
-## Key Decisions
-
-| Decision | Date | Rationale |
-|----------|------|-----------|
-
 ## Installed Skills
 
 _(Run /vbw:skills to list)_
@@ -147,9 +147,20 @@ is_gsd_section() {
   return 1
 }
 
-# Check if a line is a managed section header (VBW or GSD — both get stripped)
+# Check if a line is a deprecated VBW section header (stripped but not regenerated)
+is_deprecated_vbw_section() {
+  local line="$1"
+  for header in "${VBW_DEPRECATED_SECTIONS[@]}"; do
+    if [[ "$line" == "$header" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Check if a line is a managed section header (VBW, deprecated VBW, or GSD — all get stripped)
 is_managed_section() {
-  is_vbw_section "$1" || is_gsd_section "$1"
+  is_vbw_section "$1" || is_deprecated_vbw_section "$1" || is_gsd_section "$1"
 }
 
 # If existing file provided and it exists, preserve non-managed content
@@ -164,17 +175,216 @@ if [[ -n "$EXISTING_PATH" && -f "$EXISTING_PATH" ]]; then
   NON_VBW_CONTENT=""
   IN_MANAGED_SECTION=false
   FOUND_NON_VBW=false
+  IN_DEPRECATED_SECTION=false
+  DEPRECATED_SECTION_BUFFER=""
+  DEPRECATED_HAS_USER_CONTENT=false
+
+  # Migrate data rows from a deprecated Key Decisions table to STATE.md.
+  # Appends any non-header, non-separator, non-placeholder table rows.
+  # Deduplicates against rows already present in STATE.md.
+  migrate_key_decisions_to_state() {
+    local buffer="$1"
+    local state_path
+    state_path="$(dirname "$OUTPUT_PATH")/.vbw-planning/STATE.md"
+
+    # Extract data rows: lines starting with | that aren't the header, separator, or placeholder
+    local data_rows=""
+    local row_count=0
+    while IFS= read -r row; do
+      # Skip header row, separator row, and placeholder row
+      [[ "$row" =~ ^\|\ *Decision ]] && continue
+      [[ "$row" =~ ^\|[-[:space:]|]+\|$ ]] && continue
+      [[ "$row" =~ _\(No\ decisions\ yet\)_ ]] && continue
+      # Must be a table data row (starts with |)
+      [[ "$row" =~ ^\| ]] || continue
+      data_rows+="${row}"$'\n'
+      row_count=$((row_count + 1))
+    done <<< "$buffer"
+
+    if [[ $row_count -eq 0 ]]; then
+      return 0
+    fi
+
+    # Only migrate if STATE.md exists and has a Key Decisions section.
+    # Return 1 to signal the caller should preserve the section as user-owned.
+    if [[ ! -f "$state_path" ]]; then
+      echo "Warning: Cannot migrate $row_count Key Decisions row(s) — STATE.md not found at $state_path" >&2
+      return 1
+    fi
+
+    if ! grep -q '^## Key Decisions' "$state_path"; then
+      echo "Warning: Cannot migrate $row_count Key Decisions row(s) — no ## Key Decisions section in STATE.md" >&2
+      return 1
+    fi
+
+    # Deduplicate: remove rows that already exist in STATE.md
+    local unique_rows=""
+    local unique_count=0
+    while IFS= read -r drow; do
+      [[ -z "$drow" ]] && continue
+      # Normalize whitespace for comparison (handles minor spacing differences)
+      if ! tr -s ' ' < "$state_path" | grep -qF "$(printf '%s' "$drow" | tr -s ' ')"; then
+        unique_rows+="${drow}"$'\n'
+        unique_count=$((unique_count + 1))
+      fi
+    done <<< "$data_rows"
+
+    if [[ $unique_count -eq 0 ]]; then
+      echo "Skipped migration — all $row_count Key Decisions row(s) already in STATE.md" >&2
+      return 0
+    fi
+
+    # Remove placeholder row if present, skip blank lines between table rows
+    # and next section, then append unique data rows after the separator.
+    local tmp_state
+    tmp_state="$(mktemp)"
+    trap 'rm -f "${tmp_state:-}"' RETURN
+    local in_kd_section=false
+    local past_separator=false
+    local rows_inserted=false
+
+    while IFS= read -r sline || [[ -n "$sline" ]]; do
+      if [[ "$sline" == "## Key Decisions" ]]; then
+        in_kd_section=true
+        past_separator=false
+        rows_inserted=false
+        echo "$sline" >> "$tmp_state"
+        continue
+      fi
+      # Detect next section — insert migrated rows, then blank line, then header
+      if [[ "$in_kd_section" == true && "$sline" =~ ^##\  ]]; then
+        if [[ "$past_separator" == true && "$rows_inserted" == false ]]; then
+          printf '%s' "$unique_rows" >> "$tmp_state"
+          rows_inserted=true
+        fi
+        echo "" >> "$tmp_state"
+        in_kd_section=false
+        echo "$sline" >> "$tmp_state"
+        continue
+      fi
+      if [[ "$in_kd_section" == true ]]; then
+        # Detect separator row
+        if [[ "$sline" =~ ^\|[-[:space:]|]+\|$ && ! "$sline" =~ ^\|\ *Decision ]]; then
+          past_separator=true
+          echo "$sline" >> "$tmp_state"
+          continue
+        fi
+        # Skip placeholder row
+        if [[ "$sline" =~ _\(No\ decisions\ yet\)_ ]]; then
+          continue
+        fi
+        # Skip blank lines after separator (before data rows or next section)
+        if [[ "$past_separator" == true && -z "$sline" ]]; then
+          continue
+        fi
+        echo "$sline" >> "$tmp_state"
+      else
+        echo "$sline" >> "$tmp_state"
+      fi
+    done < "$state_path"
+
+    # If Key Decisions was the last section (no next ## header), append rows at EOF
+    if [[ "$in_kd_section" == true && "$past_separator" == true && "$rows_inserted" == false ]]; then
+      printf '%s' "$unique_rows" >> "$tmp_state"
+      rows_inserted=true
+    fi
+
+    # Guard: if no separator was found, the Key Decisions section has no table.
+    # Abort migration to avoid data loss — caller will preserve the section.
+    if [[ "$past_separator" == false ]]; then
+      rm -f "$tmp_state"
+      echo "Warning: Cannot migrate $unique_count Key Decisions row(s) — STATE.md Key Decisions section has no table" >&2
+      return 1
+    fi
+
+    mv "$tmp_state" "$state_path"
+    echo "Migrated $unique_count Key Decisions row(s) from CLAUDE.md to STATE.md" >&2
+  }
+
+  # Flush a buffered deprecated section.
+  # - Strips the ## header and the markdown table (header/separator/data rows)
+  # - Migrates table data rows to STATE.md
+  # - Preserves any non-table content (free text, lists, etc.) as user-owned
+  flush_deprecated_buffer() {
+    if [[ "$IN_DEPRECATED_SECTION" == true ]]; then
+      if [[ "$DEPRECATED_HAS_USER_CONTENT" == true ]]; then
+        if ! migrate_key_decisions_to_state "$DEPRECATED_SECTION_BUFFER"; then
+          # Migration target unavailable — preserve entire section as user-owned
+          NON_VBW_CONTENT+="${DEPRECATED_SECTION_BUFFER}"
+          FOUND_NON_VBW=true
+          IN_DEPRECATED_SECTION=false
+          DEPRECATED_SECTION_BUFFER=""
+          DEPRECATED_HAS_USER_CONTENT=false
+          return
+        fi
+      fi
+
+      # Extract non-table, non-header lines and preserve as user content
+      local preserved=""
+      local section_label=""
+      local first_line=true
+      while IFS= read -r bline; do
+        # Capture the ## header label for archived heading, then skip it
+        if [[ "$first_line" == true ]]; then
+          first_line=false
+          section_label="${bline#\#\# }"
+          continue
+        fi
+        # Skip table rows: header, separator, and data rows
+        [[ "$bline" =~ ^\|\ *Decision ]] && continue
+        [[ "$bline" =~ ^\|[-[:space:]|]+\|$ ]] && continue
+        [[ "$bline" =~ ^\| ]] && continue
+        preserved+="${bline}"$'\n'
+      done <<< "$DEPRECATED_SECTION_BUFFER"
+
+      # If there's non-blank content left, emit it as user-owned
+      # Strip leading/trailing blank lines to avoid cosmetic blanks
+      if [[ -n "${preserved//[[:space:]]/}" ]]; then
+        preserved="$(echo "$preserved" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')"
+        # Wrap orphaned text under an archived heading so it isn't headingless
+        NON_VBW_CONTENT+="## ${section_label} (Archived Notes)"$'\n'$'\n'"${preserved}"$'\n'$'\n'
+        FOUND_NON_VBW=true
+      fi
+
+      # Reset state
+      IN_DEPRECATED_SECTION=false
+      DEPRECATED_SECTION_BUFFER=""
+      DEPRECATED_HAS_USER_CONTENT=false
+    fi
+  }
 
   while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim trailing whitespace for reliable header matching
+    line="${line%"${line##*[![:space:]]}"}"
+
     # Check if this line starts a VBW or GSD managed section
     if is_managed_section "$line"; then
+      flush_deprecated_buffer
+      # Start tracking deprecated sections via buffer
+      if is_deprecated_vbw_section "$line"; then
+        IN_DEPRECATED_SECTION=true
+        DEPRECATED_SECTION_BUFFER="${line}"$'\n'
+        DEPRECATED_HAS_USER_CONTENT=false
+      fi
       IN_MANAGED_SECTION=true
       continue
     fi
 
     # Check if this line starts a new non-managed section (any ## header not in either list)
     if [[ "$line" =~ ^##\  ]] && ! is_managed_section "$line"; then
+      flush_deprecated_buffer
       IN_MANAGED_SECTION=false
+    fi
+
+    # Buffer lines in deprecated sections and detect user content
+    if [[ "$IN_DEPRECATED_SECTION" == true ]]; then
+      DEPRECATED_SECTION_BUFFER+="${line}"$'\n'
+      # Lines that are NOT part of the empty template: anything beyond
+      # blank lines, the table header row, and the separator row
+      if [[ -n "$line" && ! "$line" =~ ^\|[-[:space:]|]+\|$ && ! "$line" =~ ^\|\ *Decision ]]; then
+        DEPRECATED_HAS_USER_CONTENT=true
+      fi
+      continue
     fi
 
     # Also detect top-level heading (# Project Name) — skip it, we regenerate it
@@ -192,6 +402,9 @@ if [[ -n "$EXISTING_PATH" && -f "$EXISTING_PATH" ]]; then
       FOUND_NON_VBW=true
     fi
   done < "$EXISTING_PATH"
+
+  # Final check: flush any buffered deprecated section at EOF
+  flush_deprecated_buffer
 
   # Write: header + core value + preserved content + VBW sections
   {

--- a/scripts/compile-context.sh
+++ b/scripts/compile-context.sh
@@ -238,7 +238,7 @@ case "$ROLE" in
       echo ""
       echo "### Active Decisions"
       if [ -f "$PLANNING_DIR/STATE.md" ]; then
-        DECISIONS=$(sed -n '/^## Decisions/,/^## [A-Z]/p' "$PLANNING_DIR/STATE.md" 2>/dev/null | sed '$d' | tail -n +2) || true
+        DECISIONS=$(sed -n '/^## Key Decisions/,/^## [A-Z]/p' "$PLANNING_DIR/STATE.md" 2>/dev/null | sed '$d' | tail -n +2) || true
         if [ -n "$DECISIONS" ]; then
           echo "$DECISIONS"
         else

--- a/scripts/verify-claude-bootstrap.sh
+++ b/scripts/verify-claude-bootstrap.sh
@@ -51,8 +51,22 @@ check "greenfield has core value" grep -q '^\*\*Core value:\*\* Demo core value$
 check "greenfield has Active Context" grep -q '^## Active Context$' "$OUT"
 check "greenfield has Project Conventions" grep -q '^## Project Conventions$' "$OUT"
 check "greenfield has Plugin Isolation" grep -q '^## Plugin Isolation$' "$OUT"
+check_absent "greenfield omits Key Decisions (tracked in .vbw-planning/)" grep -q '^## Key Decisions$' "$OUT"
 
-# 3) Brownfield preservation + managed section replacement
+# 2) Brownfield preservation + managed section replacement
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
+
+## Todos
+EOF
+
 cat > "$TMP_DIR/existing.md" <<'EOF'
 # Legacy Project
 
@@ -63,6 +77,12 @@ Keep this section.
 
 ## VBW Rules
 OLD MANAGED CONTENT SHOULD BE REPLACED
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
 
 ## Codebase Intelligence
 OLD GSD CONTENT SHOULD BE STRIPPED
@@ -92,10 +112,14 @@ OLD GSD CONSTRAINTS HEADER
 Keep this too.
 EOF
 
-bash "$BOOTSTRAP" "$OUT" "Demo Project" "Demo core value" "$TMP_DIR/existing.md"
+bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Demo Project" "Demo core value" "$TMP_DIR/existing.md"
+OUT="$TMP_DIR/CLAUDE.md"
 check "brownfield preserves custom section" grep -q '^## Custom Notes$' "$OUT"
 check "brownfield preserves team section" grep -q '^## Team Notes$' "$OUT"
 check_absent "brownfield strips old managed VBW content" grep -q 'OLD MANAGED CONTENT SHOULD BE REPLACED' "$OUT"
+check_absent "brownfield strips deprecated Key Decisions section" grep -q '^## Key Decisions$' "$OUT"
+check_absent "brownfield strips deprecated Key Decisions content" grep -q 'Use widgets' "$OUT"
+check "brownfield migrates Key Decisions data to STATE.md" grep -q 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md"
 check_absent "brownfield strips old managed GSD section" grep -q '^## Codebase Intelligence$' "$OUT"
 
 for header in \
@@ -119,7 +143,7 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# 4) Idempotency: regenerate from generated file should be stable
+# 3) Idempotency: regenerate from generated file should be stable
 cp "$OUT" "$TMP_DIR/before.md"
 bash "$BOOTSTRAP" "$OUT" "Demo Project" "Demo core value" "$OUT"
 if cmp -s "$TMP_DIR/before.md" "$OUT"; then
@@ -130,7 +154,7 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# 5) Preserve generic custom Context/Constraints without strong GSD fingerprint
+# 4) Preserve generic custom Context/Constraints without strong GSD fingerprint
 cat > "$TMP_DIR/custom-generic.md" <<'EOF'
 # Team Project
 
@@ -152,6 +176,294 @@ check "preserve custom generic Constraints content" grep -q 'team-specific const
 # 5) Edge case: empty PROJECT_NAME and CORE_VALUE should be rejected
 check_absent "rejects empty PROJECT_NAME" bash "$BOOTSTRAP" "$OUT" "" "Some value"
 check_absent "rejects empty CORE_VALUE" bash "$BOOTSTRAP" "$OUT" "Some Name" ""
+
+# 6) Deprecated section migration: data rows migrate to STATE.md
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
+
+## Todos
+EOF
+
+cat > "$TMP_DIR/with-decisions.md" <<'EOF'
+# Test Project
+
+**Core value:** Test value
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
+
+## Custom Section
+Keep this.
+EOF
+
+MIGRATE_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/with-decisions.md" 2>&1 >/dev/null)"
+if echo "$MIGRATE_OUTPUT" | grep -q 'Migrated 1 Key Decisions row(s).*STATE.md'; then
+  echo "  PASS  deprecated section with data emits migration notice"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  deprecated section with data emits migration notice (got: $MIGRATE_OUTPUT)"
+  FAIL=$((FAIL + 1))
+fi
+
+check_absent "migrated Key Decisions stripped from CLAUDE.md" grep -q '^## Key Decisions$' "$TMP_DIR/CLAUDE.md"
+check "migrated data row appears in STATE.md" grep -q 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md"
+check_absent "placeholder row removed from STATE.md" grep -q 'No decisions yet' "$TMP_DIR/.vbw-planning/STATE.md"
+
+# F1/F5: Validate migrated table is contiguous (no blank line between separator and data)
+SEPARATOR_LINE=$(grep -n '^|[-|[:space:]]*|$' "$TMP_DIR/.vbw-planning/STATE.md" | head -1 | cut -d: -f1)
+DATA_LINE=$(grep -n 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md" | head -1 | cut -d: -f1)
+EXPECTED_DATA_LINE=$((SEPARATOR_LINE + 1))
+if [[ "$DATA_LINE" -eq "$EXPECTED_DATA_LINE" ]]; then
+  echo "  PASS  migrated table rows are contiguous (no blank line gap)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  migrated table rows are contiguous (separator L$SEPARATOR_LINE, data L$DATA_LINE, expected L$EXPECTED_DATA_LINE)"
+  FAIL=$((FAIL + 1))
+fi
+
+# F2: Validate blank line before ## Todos after migrated rows
+TODOS_LINE=$(grep -n '^## Todos$' "$TMP_DIR/.vbw-planning/STATE.md" | head -1 | cut -d: -f1)
+BEFORE_TODOS_LINE=$((TODOS_LINE - 1))
+BEFORE_TODOS_CONTENT=$(sed -n "${BEFORE_TODOS_LINE}p" "$TMP_DIR/.vbw-planning/STATE.md")
+if [[ -z "$BEFORE_TODOS_CONTENT" ]]; then
+  echo "  PASS  blank line before ## Todos after migration"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  blank line before ## Todos after migration (line $BEFORE_TODOS_LINE: '$BEFORE_TODOS_CONTENT')"
+  FAIL=$((FAIL + 1))
+fi
+
+# 7) Deprecated section migration: no migration for empty table
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
+EOF
+
+cat > "$TMP_DIR/empty-decisions.md" <<'EOF'
+# Test Project
+
+**Core value:** Test value
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+
+## Custom Section
+Keep this.
+EOF
+
+NOWARN_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/empty-decisions.md" 2>&1 >/dev/null)"
+if echo "$NOWARN_OUTPUT" | grep -q 'Key Decisions'; then
+  echo "  FAIL  empty deprecated section should not trigger migration (got: $NOWARN_OUTPUT)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  empty deprecated section does not trigger migration"
+  PASS=$((PASS + 1))
+fi
+check "placeholder row preserved in STATE.md for empty table" grep -q 'No decisions yet' "$TMP_DIR/.vbw-planning/STATE.md"
+
+# 7b) Migration preserves section when STATE.md Key Decisions has no table
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+## Todos
+EOF
+
+NOTABLE_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/with-decisions.md" 2>&1 >/dev/null)"
+if echo "$NOTABLE_OUTPUT" | grep -q 'Warning.*no table'; then
+  echo "  PASS  migration warns when STATE.md Key Decisions has no table"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  migration warns when STATE.md Key Decisions has no table (got: $NOTABLE_OUTPUT)"
+  FAIL=$((FAIL + 1))
+fi
+check "section preserved when STATE.md has no table" grep -q '^## Key Decisions$' "$TMP_DIR/CLAUDE.md"
+check "data preserved when STATE.md has no table" grep -q 'Use widgets' "$TMP_DIR/CLAUDE.md"
+
+# 8) Deprecated section migration: preserves section when STATE.md missing
+rm -rf "$TMP_DIR/.vbw-planning"
+NOSTATE_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/with-decisions.md" 2>&1 >/dev/null)"
+if echo "$NOSTATE_OUTPUT" | grep -q 'Warning.*Cannot migrate.*STATE.md not found'; then
+  echo "  PASS  migration warns when STATE.md missing"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  migration warns when STATE.md missing (got: $NOSTATE_OUTPUT)"
+  FAIL=$((FAIL + 1))
+fi
+check "Key Decisions preserved when STATE.md missing" grep -q '^## Key Decisions$' "$TMP_DIR/CLAUDE.md"
+check "data rows preserved when STATE.md missing" grep -q 'Use widgets' "$TMP_DIR/CLAUDE.md"
+
+# 9) Deprecated section migration: deduplicates rows already in STATE.md
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
+
+## Todos
+EOF
+
+cat > "$TMP_DIR/dup-decisions.md" <<'EOF'
+# Test Project
+
+**Core value:** Test value
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
+| New decision | 2025-02-01 | Fresh |
+
+## Custom Section
+Keep this.
+EOF
+
+DUP_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/dup-decisions.md" 2>&1 >/dev/null)"
+if echo "$DUP_OUTPUT" | grep -q 'Migrated 1 Key Decisions row(s)'; then
+  echo "  PASS  deduplication: only new row migrated"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  deduplication: only new row migrated (got: $DUP_OUTPUT)"
+  FAIL=$((FAIL + 1))
+fi
+WIDGET_COUNT=$(grep -c 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md")
+if [[ "$WIDGET_COUNT" -eq 1 ]]; then
+  echo "  PASS  deduplication: existing row not duplicated"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  deduplication: existing row not duplicated (found $WIDGET_COUNT)"
+  FAIL=$((FAIL + 1))
+fi
+check "deduplication: new row added to STATE.md" grep -q 'New decision' "$TMP_DIR/.vbw-planning/STATE.md"
+
+# 10) Deprecated section: non-table text preserved as user content
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
+EOF
+
+cat > "$TMP_DIR/mixed-decisions.md" <<'EOF'
+# Test Project
+
+**Core value:** Test value
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
+
+random text
+- random text 2
+
+## Custom Section
+Keep this.
+EOF
+
+bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/mixed-decisions.md" 2>/dev/null
+check_absent "mixed: Key Decisions header stripped" grep -q '^## Key Decisions$' "$TMP_DIR/CLAUDE.md"
+check_absent "mixed: table data row stripped from CLAUDE.md" grep -q 'Use widgets' "$TMP_DIR/CLAUDE.md"
+check "mixed: non-table text preserved in CLAUDE.md" grep -q 'random text' "$TMP_DIR/CLAUDE.md"
+check "mixed: non-table list preserved in CLAUDE.md" grep -q 'random text 2' "$TMP_DIR/CLAUDE.md"
+check "mixed: archived heading wraps orphaned text" grep -q '^## Key Decisions (Archived Notes)$' "$TMP_DIR/CLAUDE.md"
+check "mixed: table data migrated to STATE.md" grep -q 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md"
+
+# 11) Whitespace-normalized deduplication (F5)
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use widgets | 2025-01-01 | They work |
+
+## Todos
+EOF
+
+# CLAUDE.md has extra internal spacing in the same row
+cat > "$TMP_DIR/ws-dup-decisions.md" <<'EOF'
+# Test Project
+
+**Core value:** Test value
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+|  Use widgets  |  2025-01-01  |  They work  |
+
+## Custom Section
+Keep this.
+EOF
+
+WS_DUP_OUTPUT="$(bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/ws-dup-decisions.md" 2>&1 >/dev/null)"
+if echo "$WS_DUP_OUTPUT" | grep -q 'Skipped migration.*already in STATE.md'; then
+  echo "  PASS  whitespace-normalized dedup: extra spaces treated as duplicate"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  whitespace-normalized dedup: extra spaces treated as duplicate (got: $WS_DUP_OUTPUT)"
+  FAIL=$((FAIL + 1))
+fi
+
+# 12) Trailing whitespace on headers still matched (F6)
+mkdir -p "$TMP_DIR/.vbw-planning"
+cat > "$TMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# State
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
+
+## Todos
+EOF
+
+# Note: printf preserves trailing spaces; heredoc may strip them
+printf '%s\n' \
+  "# Test Project" "" \
+  "**Core value:** Test value" "" \
+  "## Key Decisions  " "" \
+  "| Decision | Date | Rationale |" \
+  "|----------|------|-----------|" \
+  "| Use widgets | 2025-01-01 | They work |" "" \
+  "## Custom Section" \
+  "Keep this." > "$TMP_DIR/trailing-ws.md"
+
+bash "$BOOTSTRAP" "$TMP_DIR/CLAUDE.md" "Test Project" "Test value" "$TMP_DIR/trailing-ws.md" 2>/dev/null
+check_absent "trailing whitespace: Key Decisions header still recognized" grep -q '^## Key Decisions' "$TMP_DIR/CLAUDE.md"
+check "trailing whitespace: data migrated to STATE.md" grep -q 'Use widgets' "$TMP_DIR/.vbw-planning/STATE.md"
 
 echo ""
 echo "TOTAL: $PASS PASS, $FAIL FAIL"

--- a/templates/STATE.md
+++ b/templates/STATE.md
@@ -8,8 +8,11 @@ Plans: {done}/{total}
 Progress: {N}%
 Status: {ready|active|complete}
 
-## Decisions
-- {decision}
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| _(No decisions yet)_ | | |
 
 ## Todos
 {todos-or-none}


### PR DESCRIPTION
## What

Remove the `## Key Decisions` section from the CLAUDE.md template generated by `bootstrap-claude.sh`.

## Why

Fixes #92. The section was never programmatically written to, duplicated data already tracked in `.vbw-planning/PROJECT.md` and `STATE.md`, and added permanent per-session token cost. Additionally, `bootstrap-claude.sh` silently wiped any manually-added decision rows on every bootstrap/archive cycle.

Decisions are loaded on-demand via `compile-context.sh` when agents need them — zero cost when unused.

## How

**5 files changed** (467 insertions, 16 deletions):

1. **`scripts/bootstrap/bootstrap-claude.sh`** — Core changes:
   - Removed `"## Key Decisions"` from the `VBW_SECTIONS` array and `generate_vbw_sections()` heredoc
   - Added `VBW_DEPRECATED_SECTIONS` array with `## Key Decisions` — brownfield regeneration strips the stale section from existing CLAUDE.md files instead of preserving it as orphaned user content
   - Added `migrate_key_decisions_to_state()` — extracts table data rows from CLAUDE.md, deduplicates against STATE.md, appends new rows. Fail-safe: preserves entire section as user-owned content if STATE.md is missing or has no table
   - Added `flush_deprecated_buffer()` — migrates table data, strips header + table, wraps any non-table text under an archived heading (`## Key Decisions (Archived Notes)`)
   - Trailing whitespace on headers is now trimmed before matching (prevents `## Section  ` from bypassing detection)
   - Deduplication uses whitespace-normalized comparison (`tr -s ' '`) to handle minor spacing differences
   - tmpfile cleanup via `trap ... RETURN` in migration function

2. **`scripts/verify-claude-bootstrap.sh`** — 56 regression checks (was 31):
   - Greenfield: Key Decisions absent
   - Brownfield: deprecated section stripped, data migrated to STATE.md
   - Fail-safe: section preserved when STATE.md missing or has no table
   - Deduplication: existing rows not duplicated, new rows added
   - Mixed content: table migrated, non-table text preserved under archived heading
   - Whitespace-normalized dedup: extra spaces treated as duplicate
   - Trailing whitespace on headers: still recognized as managed section

3. **`scripts/compile-context.sh`** — **Bonus bug fix**: the sed pattern searched for `## Decisions` but `bootstrap-state.sh` has always generated `## Key Decisions`. The two never matched — the Lead agent's compiled context never included decisions from STATE.md on the main branch. Now aligned to `## Key Decisions`.

4. **`templates/STATE.md`** — Converted `## Key Decisions` from bullet-list format (`- {decision}`) to markdown table format (`| Decision | Date | Rationale |`) matching what `bootstrap-state.sh` actually generates.

5. **`commands/vibe.md`** — Updated B6 step to reflect removed section.

## Known Limitations

- **Archive timing (one-cycle delay):** When archive mode moves STATE.md to `milestones/{slug}/` before regenerating CLAUDE.md, the migration can't find STATE.md and preserves the Key Decisions section with a warning. It gets stripped on the next bootstrap when a fresh STATE.md is created. No data loss.
- **Column schema divergence:** STATE.md uses `| Decision | Date | Rationale |` while PROJECT.md uses `| Decision | Rationale | Outcome |`. Pre-existing, not introduced by this PR.

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] `bash scripts/verify-claude-bootstrap.sh` — 56 PASS, 0 FAIL
- [x] `bash testing/run-all.sh` — 51 BATS suites pass, 0 failures
- [x] No errors on plugin load
- [x] Existing commands still work

## Notes

- 4 QA edge-case investigation rounds completed: 0 critical findings across all rounds.
- The `VBW_DEPRECATED_SECTIONS` array is a reusable mechanism for future section removals.
- The CHANGELOG entry at line 893 mentions "key decisions" in context of VBW's own CLAUDE.md — left as historical record, not edited.
- This repo's own CLAUDE.md still has Key Decisions (manually maintained for plugin development) — this change only affects the template for user projects.