### PR TITLE
fix(help): add CLAUDE_CONFIG_DIR fallback to backtick expansion

### DIFF
--- a/commands/help.md
+++ b/commands/help.md
@@ -20,7 +20,7 @@ Plugin root: `!`echo ${CLAUDE_PLUGIN_ROOT:-$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/
 Run the help output script and display the result exactly as-is (pre-formatted terminal output):
 
 ```
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/help-output.sh`
+!`bash ${CLAUDE_PLUGIN_ROOT:-$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/vbw-marketplace/vbw/* 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1)}/scripts/help-output.sh`
 ```
 
 Display the output above verbatim. Do not reformat, summarize, or add commentary. The script dynamically reads all command files and generates grouped output.


### PR DESCRIPTION
## Summary

- Adds `:-` fallback to the `!`-backtick expansion in `help.md:23` so `/vbw:help` works when `CLAUDE_PLUGIN_ROOT` is unset (non-standard `CLAUDE_CONFIG_DIR`)
- Adds Phase 2 to `verify-plugin-root-resolution.sh` that catches bare `CLAUDE_PLUGIN_ROOT` in `!`-backtick expansions, preventing this class of regression

## Root Cause

`help.md:23` had:
```
!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/help-output.sh`
```
When `CLAUDE_CONFIG_DIR` is non-standard (e.g., `~/.config/claude-code`) and `CLAUDE_PLUGIN_ROOT` is unset, this expanded to `bash /scripts/help-output.sh`. The preamble on line 14 had the fallback, but it only echoed the value — didn't export it for subsequent expansions.

## Test plan

- [x] `bash testing/verify-plugin-root-resolution.sh` — 24 + 18 checks pass
- [x] `bash testing/run-all.sh` — all tests pass (2 pre-existing agent-health failures unrelated)
- [x] Verified `help-output.sh` runs correctly with empty `CLAUDE_PLUGIN_ROOT`
- [ ] Manual test: run `/vbw:help` with non-standard `CLAUDE_CONFIG_DIR`

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)