### PR TITLE
fix(config): sync EXPECTED_FLAG_COUNT and test assertions after worktree_isolation added

### DIFF
--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -35,7 +35,7 @@ fi
 
 # Auto-migrate config if .vbw-planning exists.
 # Version marker retained here for backwards test compatibility.
-EXPECTED_FLAG_COUNT=22
+EXPECTED_FLAG_COUNT=23
 if [ -d "$PLANNING_DIR" ] && [ -f "$PLANNING_DIR/config.json" ]; then
   if ! bash "$SCRIPT_DIR/migrate-config.sh" "$PLANNING_DIR/config.json" >/dev/null 2>&1; then
     echo "WARNING: Config migration failed (jq error). Config may be missing flags (expected=$EXPECTED_FLAG_COUNT)." >&2

--- a/tests/config-migration.bats
+++ b/tests/config-migration.bats
@@ -71,10 +71,10 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "4" ]
 
-  # Verify all defaults.json keys are present (22 defaults + 2 pre-existing extra keys)
+  # Verify all defaults.json keys are present (23 defaults + 2 pre-existing extra keys)
   run jq 'keys | length' "$TEST_TEMP_DIR/.vbw-planning/config.json"
   [ "$status" -eq 0 ]
-  [ "$output" = "24" ]
+  [ "$output" = "25" ]
 
   # Verify existing values were preserved
   run jq -r '.context_compiler' "$TEST_TEMP_DIR/.vbw-planning/config.json"
@@ -124,10 +124,10 @@ EOF
   # Both runs should produce identical result
   [ "$AFTER_FIRST" = "$AFTER_SECOND" ]
 
-  # Verify flag count is correct (22 total, graduated flags removed)
+  # Verify flag count is correct (23 total, graduated flags removed)
   run jq 'keys | length' "$TEST_TEMP_DIR/.vbw-planning/config.json"
   [ "$status" -eq 0 ]
-  [ "$output" = "22" ]
+  [ "$output" = "23" ]
 }
 
 @test "migration detects malformed JSON" {
@@ -362,8 +362,8 @@ EOF
   [ "$output" = "$EXPECTED_ADDED" ]
 }
 
-@test "EXPECTED_FLAG_COUNT is 22 after flag graduation" {
-  # Verify session-start.sh has EXPECTED_FLAG_COUNT=22 (updated from 23 after v3 flag graduation)
+@test "EXPECTED_FLAG_COUNT is 23 after worktree_isolation addition" {
+  # Verify session-start.sh has EXPECTED_FLAG_COUNT=23 (incremented after worktree_isolation added to defaults.json)
   SCRIPT_COUNT=$(grep 'EXPECTED_FLAG_COUNT=' "$SCRIPTS_DIR/session-start.sh" | grep -oE '[0-9]+' | head -1)
-  [ "$SCRIPT_COUNT" = "22" ]
+  [ "$SCRIPT_COUNT" = "23" ]
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -50,7 +50,8 @@ create_test_config() {
     "dev": 75
   },
   "context_compiler": true,
-  "v2_token_budgets": false
+  "v2_token_budgets": false,
+  "worktree_isolation": "on"
 }
 CONF
 }


### PR DESCRIPTION
## What

Syncs `EXPECTED_FLAG_COUNT` and hardcoded key-count test assertions that went stale when `worktree_isolation` was added to `config/defaults.json` in #110.

## Why

`worktree_isolation` bumped the total key count in `defaults.json` from 22 → 23, but three places weren't updated:

1. `session-start.sh`: `EXPECTED_FLAG_COUNT` still `22`
2. `tests/config-migration.bats`: two `jq 'keys | length'` assertions hardcoded to the old count
3. `tests/test_helper.bash`: `create_test_config` missing `worktree_isolation`, causing the "migration handles full config" idempotency test to add the key and see a diff

This caused 4 test failures on any PR that merges against the current `main` (including #109).

## How

- `scripts/session-start.sh`: `22` → `23`
- `tests/config-migration.bats`: `24` → `25`, `22` → `23`, rename stale `is 22 after flag graduation` test
- `tests/test_helper.bash`: add `"worktree_isolation": "on"` to `create_test_config`

## Testing

- [x] Load plugin locally
- [x] `bats tests/config-migration.bats` — 18/18 pass (was 14/18)
- [x] `bash testing/run-all.sh` — no new regressions introduced
- [x] No load errors

Fixes #112