### PR TITLE
docs(analysis): source-validated VBW vs GSD comparison + PAUL doc rename

### DIFF
--- a/docs/vbw-vs-gsd-source-validated.md
+++ b/docs/vbw-vs-gsd-source-validated.md
@@ -1,0 +1,488 @@
+# VBW vs GSD — Source-Code-Validated Comparison
+
+**Date:** 2026-07-22
+**GSD version reviewed:** v1.20.5 (commit `131f24b`)
+**VBW version reviewed:** v1.30.0+
+**Source:** GSD repository at `gsd-build/get-shit-done`, VBW local workspace
+**Method:** Every claim validated against actual source code via GitHub API, not READMEs or marketing
+
+---
+
+## Executive Summary
+
+VBW and GSD both solve the same core problem — replacing ad-hoc AI coding with structured, phased development workflows. Both are mature, thoughtfully designed systems with significant overlap in philosophy and capability. The key difference is enforcement mechanism: VBW enforces quality gates via platform hooks (bash scripts that return exit code 2 to block tool execution), while GSD enforces quality standards via instruction-level workflows (markdown directing agent behavior) combined with a comprehensive Node.js CLI for verification tooling and 3 advisory hooks.
+
+This document corrects factual inaccuracies in the earlier `vbw-vs-paul-vs-gsd-analysis.md`, which inherited unverified claims about GSD from PAUL's comparison document rather than examining GSD's source code directly.
+
+---
+
+## Corrections to Prior Analysis
+
+The earlier analysis (`vbw-vs-paul-vs-gsd-analysis.md`) made several claims about GSD that do not hold up against the actual source code. These corrections are listed with source references.
+
+### 1. "GSD's primary goal is to ship fast"
+
+**Prior claim:** GSD optimizes for speed. PAUL optimizes for quality. VBW does both.
+
+**Source reality:** GSD's `README.md` describes itself as "a meta-prompting, context engineering and spec-driven development system." Its core value proposition is solving **context rot** — the problem where AI assistants lose coherent state across long development tasks. GSD's workflow includes mandatory discussion phases (`discuss-phase.md`, 18.6KB), research phases with parallel researcher agents (`gsd-phase-researcher`, `gsd-project-researcher`, `gsd-research-synthesizer`), plan verification with 8 dimensions (`gsd-plan-checker`, 24.2KB), and goal-backward verification (`gsd-verifier`, 16.9KB).
+
+The name "Get Shit Done" is branding, not an optimization target. GSD's planner explicitly targets ~50% context usage per plan to leave room for verification. The context monitor warns at 35%/25% remaining context.
+
+**Corrected position:** Both GSD and VBW optimize for structured, quality development. The speed-vs-quality framing was from PAUL's marketing comparison and does not reflect GSD's actual design.
+
+### 2. "GSD has flexible loop closure"
+
+**Prior claim:** GSD's review is implicit. VBW enforces mandatory loop closure.
+
+**Source reality:** GSD's gsd-executor agent (`agents/gsd-executor.md`, 17.5KB) creates SUMMARY.md as part of its execution protocol — this is mandatory per the agent's instructions. The execute-phase workflow (`get-shit-done/workflows/execute-phase.md`, 16.7KB) spot-checks SUMMARY claims. The gsd-verifier creates VERIFICATION.md documenting goal achievement. `gsd-tools.cjs` provides `verify-summary`, `verify phase-completeness`, and `verify artifacts` commands.
+
+**The real difference:** GSD enforces loop closure via agent instructions + CLI verification tools. VBW enforces it via agent instructions + platform hooks with exit code 2 (`hard-gate.sh`, `qa-gate.sh`, `archive-uat-guard.sh`). Both systems require SUMMARY.md — VBW blocks tool execution if it's missing, GSD relies on agents following their instructions.
+
+**Corrected position:** Both enforce loop closure. VBW's enforcement is mechanically stronger (platform hooks that the model cannot bypass). GSD's enforcement is instruction-level but comprehensive (agent protocols + CLI verification suite).
+
+### 3. "GSD quality gates are completion-based"
+
+**Prior claim:** GSD checks completion. VBW and PAUL check acceptance.
+
+**Source reality:** GSD has **goal-backward verification** via `gsd-verifier` (`agents/gsd-verifier.md`, 16.9KB). The verifier starts from desired outcomes and derives testable conditions. GSD's `get-shit-done/references/verification-patterns.md` (16.5KB) defines a 4-level artifact verification framework:
+
+| Level | Check | Automatable? |
+|-------|-------|-------------|
+| 1. Exists | File present at expected path | Yes |
+| 2. Substantive | Real implementation, not stub/placeholder | Yes |
+| 3. Wired | Connected to rest of system | Yes |
+| 4. Functional | Actually works when invoked | Often human-required |
+
+The plan checker (`gsd-plan-checker`, 24.2KB) verifies plans across 8 dimensions including requirement coverage, task completeness, dependency correctness, key links, scope sanity, verification derivation, context compliance, and Nyquist compliance.
+
+**Corrected position:** GSD is acceptance-based, not completion-based. Both systems use goal-backward/acceptance-driven verification.
+
+### 4. "GSD presents menus / has multiple decision flows"
+
+**Prior claim:** GSD shows multiple options. VBW routes to a single best path.
+
+**Source reality:** GSD's resume-project workflow (`get-shit-done/workflows/resume-project.md`, 9KB) detects project state and routes to a single next action. It checks for incomplete work (`.continue-here` files, plans without summaries, interrupted agents), presents a status box, and routes to the appropriate next workflow. GSD's `AskUserQuestion` API provides structured option selection throughout, but the default flow is state-detected routing.
+
+**Corrected position:** Both systems detect state and suggest a single next action. Feature parity.
+
+### 5. "GSD session handoff is implicit"
+
+**Prior claim:** GSD uses implicit `.continue-here.md`. VBW has auto-persistent state.
+
+**Source reality:** GSD's `pause-work.md` (2.9KB) creates **explicit** `.continue-here.md` files with structured sections: position in workflow, completed work summary, remaining work, key decisions made, current blockers, mental context, and next concrete action. The file is committed as a WIP commit. `resume-project.md` reads `.continue-here`, STATE.md, and PROJECT.md and reconstructs full context.
+
+**The real difference:** GSD requires explicit `/gsd:pause-work` to create a handoff file. VBW auto-persists state via `.execution-state.json` + `event-log.jsonl`, so `/vbw:resume` works from cold without prior `/vbw:pause`. VBW's crash recovery via event-sourced state reconstruction (`recover-state.sh`) is genuinely more robust.
+
+**Corrected position:** GSD's handoff is explicit (structured files), not implicit. VBW's advantage is auto-persistence and crash recovery — state survives without explicit pause.
+
+### 6. "GSD scope control is guidance-only"
+
+**Prior claim:** GSD uses scope guidance. VBW enforces boundaries with hooks.
+
+**Source reality:** GSD's `discuss-phase.md` (18.6KB) includes a `<scope_guardrail>` section with explicit heuristics: "Does this clarify how we implement what's already in the phase, or does it add a new capability that could be its own phase?" It captures out-of-scope suggestions in a "Deferred Ideas" section. GSD's executor (`gsd-executor.md`) defines exactly 4 allowed deviation types: auto-fix bugs, auto-add missing critical functionality, auto-fix blocking issues, and ask about architectural changes. Everything else requires stopping.
+
+**The real difference:** GSD's scope enforcement is instruction-level (agent follows rules in markdown). VBW's scope enforcement is instruction-level + hook-level (`file-guard.sh` blocks writes to undeclared files, `lease-lock.sh` provides file-level locking, `bash-guard.sh` intercepts destructive commands).
+
+**Corrected position:** GSD has structured scope rules with deviation constraints. VBW adds platform-enforced file access control on top of instruction-level rules. VBW's enforcement is stronger.
+
+### 7. "GSD has no platform hooks"
+
+**Prior claim:** GSD has no platform-level hooks (compared to VBW's 21 handlers).
+
+**Source reality:** GSD has 3 JavaScript hooks compiled via esbuild:
+
+| Hook | Event | Function |
+|------|-------|----------|
+| `gsd-context-monitor.js` | PostToolUse | Warns agent at ≤35% remaining context (WARNING), ≤25% (CRITICAL). Debounced. Injects warnings as `additionalContext` |
+| `gsd-statusline.js` | PostToolUse | Displays model, current task, directory, context usage bar. Writes bridge JSON for context monitor |
+| `gsd-check-update.js` | SessionStart | Background npm version check. Spawns detached child process |
+
+**The real difference:** GSD's 3 hooks are all **advisory** (informational/warning). VBW's 25 hooks include **blocking** hooks (exit code 2) that prevent tool execution. GSD has no PreToolUse hooks — no platform-level file access control, no destructive command interception, no security filtering.
+
+**Corrected position:** GSD has 3 hooks (advisory). VBW has 25 hooks (mix of advisory and blocking). Both use the platform hook system; VBW uses it for enforcement, GSD uses it for awareness.
+
+### 8. "GSD has no formal QA"
+
+**Prior claim in capabilities table:** GSD has no three-tier automated QA.
+
+**Source reality:** GSD has:
+- `gsd-verifier` agent (16.9KB): Goal-backward verification, creates VERIFICATION.md
+- `verify-work.md` workflow (14.9KB): Conversational UAT testing with pass/fail/skip, auto-diagnosis via parallel debug agents, auto-plans gap closure
+- `gsd-tools.cjs` verification suite: `verify plan-structure`, `verify phase-completeness`, `verify references`, `verify commits`, `verify artifacts`, `verify key-links`
+- `gsd-plan-checker` agent (24.2KB): 8-dimension plan verification
+
+**The real difference:** GSD's QA is one tier (verifier agent + UAT), invoked per workflow. VBW has three tiers (Quick 5-10 checks, Standard 15-25, Deep 30+) with the tier selected based on effort profile. VBW's QA is a dedicated agent role (`vbw-qa`) with platform-enforced read-only permissions; GSD's verifier has full tool access.
+
+**Corrected position:** GSD has formal QA via its verifier agent and UAT workflow. VBW has tiered QA with platform-enforced agent permissions.
+
+### 9. "GSD's codebase mapping is less capable than VBW's 4 scouts"
+
+**Prior claim:** VBW's codebase mapping with "4 parallel Scout teammates" exceeds GSD's single-command map.
+
+**Source reality:** GSD's `/gsd:map-codebase` spawns **4 parallel** `gsd-codebase-mapper` agents, each with a focus area:
+
+| Agent Focus | Output Documents |
+|-------------|-----------------|
+| `tech` | STACK.md, INTEGRATIONS.md |
+| `arch` | ARCHITECTURE.md, STRUCTURE.md |
+| `quality` | CONVENTIONS.md, TESTING.md |
+| `concerns` | CONCERNS.md |
+
+This produces 7 structured analysis documents consumed by downstream agents during planning and execution. The codebase mapper agent (`agents/gsd-codebase-mapper.md`, large file) includes detailed templates for each document type with prescriptive guidance.
+
+**Corrected position:** Both systems use 4 parallel agents for codebase mapping. GSD produces 7 output documents; VBW's scouts produce consolidated codebase maps. Comparable capability.
+
+---
+
+## Architecture Comparison
+
+### System Scale
+
+| Metric | VBW | GSD |
+|--------|-----|-----|
+| **Slash commands** | 24 | 30 |
+| **Workflows/protocols** | 11 references + execute protocol | 30 workflow files |
+| **Agents** | 7 (Lead, Dev, QA, Scout, Debugger, Architect, Docs) | 11 (Executor, Verifier, Planner, Plan-Checker, Debugger, Codebase-Mapper, Phase-Researcher, Project-Researcher, Research-Synthesizer, Roadmapper, Integration-Checker) |
+| **Platform hooks** | 25 handlers across 11 event types | 3 handlers across 2 event types |
+| **Scripts** | ~97 bash scripts | 1 build script + gsd-tools.cjs (22KB CLI with ~30 subcommands) |
+| **Test files** | testing/ + tests/ directories | 7 test files (.cjs, Node's test runner) |
+| **Implementation language** | Bash + Markdown | JavaScript + Markdown |
+| **Distribution** | Claude Code marketplace plugin | npm package (`get-shit-done-cc`) |
+| **State directory** | `.vbw-planning/` | `.planning/` |
+| **Platform support** | Claude Code only | Claude Code, OpenCode, Gemini CLI |
+
+### Enforcement Philosophy
+
+Both systems implement the same lifecycle (question → plan → execute → verify → archive) with the same artifacts (PROJECT.md, ROADMAP.md, STATE.md, PLAN.md, SUMMARY.md, VERIFICATION.md). The critical difference is HOW rules are enforced:
+
+**GSD: Instruction-Level + Advisory Hooks + CLI Tooling**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Workflow .md files define steps → Agent .md files define    │
+│ rules → gsd-tools.cjs provides verification CLI → 3 hooks  │
+│ provide context awareness (advisory)                        │
+│                                                             │
+│ Enforcement: Agent follows instructions. CLI verifies       │
+│ artifacts. Hooks warn about context. Nothing blocks tool    │
+│ execution at platform level.                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**VBW: Instruction-Level + Blocking Hooks + Script Enforcement**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Commands define steps → Agent .md files define rules →      │
+│ ~97 bash scripts enforce + verify → 25 hooks intercept      │
+│ tool calls (mix of advisory and blocking)                   │
+│                                                             │
+│ Enforcement: Agent follows instructions. Scripts verify     │
+│ artifacts. Hooks BLOCK tool execution on violations         │
+│ (exit code 2). Platform enforces agent tool permissions.    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Where This Matters
+
+| Scenario | GSD | VBW |
+|----------|-----|-----|
+| Agent tries to write undeclared file | Instruction says don't → agent may or may not comply | `file-guard.sh` PreToolUse hook → exit 2, write blocked |
+| Agent skips SUMMARY.md | Instruction says create it → agent may skip under pressure | `hard-gate.sh` + `qa-gate.sh` → exit 2, execution blocked |
+| Agent runs `rm -rf` | No interception | `bash-guard.sh` PreToolUse hook → exit 2, command blocked |
+| Agent accesses `.env` file | No interception | `security-filter.sh` PreToolUse hook → exit 2, read blocked |
+| Context running low | `gsd-context-monitor.js` warns at 35%/25% | No equivalent real-time hook (VBW uses token budgets per-role) |
+| Read-only agent tries to write | Agent instructions say read-only | Platform-enforced `disallowedTools` in agent YAML |
+| Context compacted | No hook | `compaction-instructions.sh` injects preservation priorities; `post-compact.sh` verifies critical context survived |
+
+---
+
+## Feature-by-Feature Comparison
+
+### Project Initialization
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Command** | `/vbw:init` + `/vbw:vibe Bootstrap` | `/gsd:new-project` |
+| **Questioning** | Structured discussion via `discussion-engine.md` | Deep questioning via `questioning.md` with checklist |
+| **Brownfield detection** | Stack detection via `detect-stack.sh` | Existing code detection + `/gsd:map-codebase` offer |
+| **Auto mode** | Pure-vibe autonomy loops all phases | `--auto` flag chains discuss → plan → execute |
+| **Config options** | Effort (4 levels) + Autonomy (4 levels) + Work profiles | Mode (YOLO/Interactive) + Depth (3 levels) + Agent toggles |
+| **Artifacts created** | PROJECT.md, REQUIREMENTS.md, ROADMAP.md, STATE.md, CLAUDE.md, config.json | PROJECT.md, ROADMAP.md, STATE.md, config.json |
+
+GSD's questioning methodology (`get-shit-done/references/questioning.md`) is comprehensive, with techniques for challenging vagueness, surfacing assumptions, and finding edges. VBW's discussion engine auto-calibrates between Builder and Architect modes. Both serve the same purpose.
+
+GSD produces PROJECT.md with a Requirements section (validated/active/out-of-scope). VBW produces a separate REQUIREMENTS.md. Equivalent data, different file organization.
+
+### Phase Discussion
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Command** | `/vbw:vibe Discuss` | `/gsd:discuss-phase` |
+| **Gray area identification** | Auto-generated from phase domain analysis | Auto-generated from phase domain analysis |
+| **Scope enforcement** | Instruction-level in discussion engine | `<scope_guardrail>` with heuristics + "Deferred Ideas" capture |
+| **Output** | Decisions captured in phase execution context | `CONTEXT.md` with decisions, Claude's discretion areas, deferred ideas |
+| **Discussion depth** | Auto-calibrating Builder/Architect modes | 4 questions per area then check, iterative deepening |
+
+Both systems handle phase discussion with comparable sophistication. GSD's discuss-phase.md (18.6KB) has detailed downstream awareness — it explicitly documents how CONTEXT.md feeds into the researcher and planner. VBW's discussion engine integrates into the execution pipeline differently.
+
+### Planning
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Research before planning** | Configurable via effort profile | Configurable via `workflow.research` toggle |
+| **Plan format** | YAML frontmatter + markdown body with `must_haves` | XML-structured `<task>` elements in PLAN.md with `must_haves` |
+| **Plan verification** | Instruction-level checks in execute protocol | `gsd-plan-checker` agent (24.2KB), 8 verification dimensions, max 3 iteration loop |
+| **Plan scope** | Per-plan task lists | 2-3 tasks per plan, designed to fit within ~50% context |
+| **Dependency handling** | Cross-phase deps in frontmatter | Wave assignment from dependency graph analysis |
+| **Quick tasks** | `/vbw:fix` (turbo mode, one commit) | `/gsd:quick` with optional `--full` mode (plan checking + verification) |
+
+GSD's plan checker is notably thorough — 8 verification dimensions with a revision loop (max 3 iterations between planner and checker). VBW's plan validation is part of the execute protocol instructions rather than a dedicated verification agent.
+
+GSD's Nyquist compliance check (ensuring plans don't exceed ~50% context) is a unique feature designed to prevent context overflow during execution.
+
+### Execution
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Parallelism** | Agent Teams (persistent teammates with shared task lists) | Wave-based parallel execution (dependency graph → wave grouping) |
+| **Isolation** | Worktree isolation (physical filesystem separation) | No filesystem isolation |
+| **File access control** | `file-guard.sh` hook + `lease-lock.sh` locking | Instruction-level per-plan file boundaries |
+| **Deviation handling** | Event logging, SUMMARY.md deviation section | 4 structured deviation rules in executor agent |
+| **Checkpoints** | `autonomous: false` + UAT CHECKPOINTs | 3 formal checkpoint types (human-verify, decision, human-action) |
+| **Atomic commits** | One commit per task | One commit per task |
+| **SUMMARY.md** | Mandatory (hook-enforced, exit 2) | Mandatory (instruction-enforced) |
+| **Context awareness** | Token budgets per agent role | Context monitor hook warns at 35%/25% remaining |
+| **Crash recovery** | `.execution-state.json` + `event-log.jsonl` + `recover-state.sh` | `.continue-here.md` + STATE.md |
+| **Smart routing** | `assess-plan-risk.sh` auto-downgrades to turbo | No automatic downgrading |
+
+GSD's checkpoint system is more formally specified than VBW's. Three distinct types with structured XML (`checkpoint:human-verify`, `checkpoint:decision`, `checkpoint:human-action`) each with documented presentation formats, usage frequency (90%/9%/1%), and auto-mode bypass rules. GSD's `checkpoints.md` reference (29KB) includes service CLI references, authentication gate protocols, and environment automation patterns.
+
+VBW's worktree isolation and lease locking provide stronger parallel execution guarantees. GSD relies on instruction-level file boundaries.
+
+GSD's 4 deviation rules are well-defined:
+1. Auto-fix bugs discovered during implementation
+2. Auto-add missing critical functionality with same commit
+3. Auto-fix blocking issues from earlier tasks
+4. ASK about architectural changes (never auto-deviate)
+
+This is more structured than a general "log deviations" instruction.
+
+### Verification
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Automated QA** | 3-tier (Quick/Standard/Deep) via `vbw-qa` agent | Single-tier via `gsd-verifier` agent |
+| **QA agent permissions** | Platform-enforced read-only (`disallowedTools`) | Full tool access (read+write) |
+| **Verification methodology** | Goal-backward | Goal-backward |
+| **Artifact verification** | SUMMARY.md + VERIFICATION.md | SUMMARY.md + VERIFICATION.md |
+| **Verification reference** | `verification-protocol.md` | `verification-patterns.md` (16.5KB, 4-level framework) |
+| **Human acceptance testing** | `/vbw:verify` with per-test CHECKPOINTs | `verify-work.md` with conversational UAT |
+| **Gap auto-closure** | UAT issues → discuss → plan → execute pipeline | UAT issues → parallel debug agents → auto-plan gaps |
+| **Hook enforcement** | `qa-gate.sh` (exit 2) + `hard-gate.sh` (exit 2) | None (instruction-level) |
+
+GSD's `verification-patterns.md` is particularly notable — it provides detailed bash patterns for stub detection, component verification, API route verification, database schema verification, and wiring verification across React/Next.js, Express, Prisma, and other stacks. This is practical, language-specific guidance that VBW's protocol doesn't include.
+
+VBW's tiered QA with platform-enforced read-only agent permissions is genuinely unique. A QA agent that literally cannot write files provides stronger verification independence.
+
+### Session Continuity
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Explicit pause** | `/vbw:pause` creates RESUME.md | `/gsd:pause-work` creates `.continue-here.md` |
+| **Cold resume** | `/vbw:resume` works without prior pause | `/gsd:resume-work` reads STATE.md + PROJECT.md + `.continue-here` |
+| **Crash recovery** | Event-sourced recovery from `event-log.jsonl` | STATE.md + SUMMARY.md reconstruction |
+| **State persistence** | `.execution-state.json` (real-time) + `event-log.jsonl` (13 event types) | STATE.md + `.continue-here.md` |
+| **Compaction handling** | `PreCompact` + `SessionStart(compact)` hooks | No compaction hooks |
+| **Snapshot resume** | `snapshot-resume.sh` captures execution state + git context | Not available |
+
+VBW's session continuity is genuinely more robust. Event-sourced state recovery, real-time execution state, compaction hooks (preservation priorities before compaction + verification after), and cold resume without prior pause are capabilities GSD lacks.
+
+GSD's `.continue-here.md` is well-structured (7 sections) but requires explicit creation via `/gsd:pause-work`.
+
+### Model Routing
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Profiles** | 3 presets (quality/balanced/budget) | 3 presets (quality/balanced/budget) |
+| **Per-agent overrides** | Config-based overrides per agent role | Config-based overrides per agent type |
+| **Resolution** | `resolve-agent-model.sh` | `resolve-model` command in gsd-tools.cjs |
+
+Feature parity. Both systems support model profiles with per-agent overrides.
+
+### Phase Management
+
+| Feature | VBW | GSD |
+|---------|-----|-----|
+| **Insert phase** | `/vbw:vibe --insert N` (auto-renumbers everything downstream) | `/gsd:insert-phase` (decimal phases: 8.1, 8.2) |
+| **Add phase** | `/vbw:vibe --add` | `/gsd:add-phase` |
+| **Remove phase** | Not available | `/gsd:remove-phase` (renumbers subsequent) |
+| **Phase completion** | Execute protocol + archive flow | `phase complete` command in gsd-tools.cjs |
+
+Different approaches to interruptions: VBW renumbers directories, file prefixes, frontmatter references, and `depends_on` links. GSD uses decimal phase numbering (cleaner for quick insertions, but creates non-obvious ordering). GSD additionally supports explicit phase removal.
+
+---
+
+## Capabilities Unique to Each System
+
+### VBW-Only Capabilities
+
+| Capability | Implementation | Why It Matters |
+|------------|---------------|----------------|
+| **Blocking platform hooks (exit 2)** | `hard-gate.sh`, `qa-gate.sh`, `file-guard.sh`, `bash-guard.sh`, `security-filter.sh`, `archive-uat-guard.sh` | Model cannot bypass these during compaction or context overflow |
+| **Platform-enforced agent permissions** | `disallowedTools` in agent YAML — Scout and QA cannot write files | Verified tool restriction at the platform level, not instruction level |
+| **Worktree isolation** | `worktree-create.sh`, `worktree-target.sh`, `worktree-agent-map.sh` | Physical filesystem separation for parallel agents |
+| **Lease locks** | `lease-lock.sh` | File-level exclusive locking during parallel execution |
+| **Contract system** | `generate-contract.sh`, `validate-contract.sh` with hash integrity | Tasks operate within declared boundaries, hash prevents tampering |
+| **Event-sourced state** | `event-log.jsonl` (13 event types) + `recover-state.sh` | Crash recovery via event replay, not just checkpoint files |
+| **Database safety guard** | `bash-guard.sh` with 40+ destructive command patterns | Prevents accidental `DROP TABLE`, `rm -rf`, etc. regardless of agent instructions |
+| **Compaction hooks** | `compaction-instructions.sh` (PreCompact) + `post-compact.sh` (SessionStart compact) | Preserves critical context through compaction and verifies survival |
+| **Tiered QA** | Quick (5-10), Standard (15-25), Deep (30+ checks) with effort-based selection | Right-sized verification based on work complexity |
+| **Effort profiles** | 4 levels (thorough/balanced/fast/turbo) controlling planning depth, QA tier, agent behavior | One config controls the depth dial across the entire pipeline |
+| **Autonomy levels** | 4 levels (cautious/standard/confident/pure-vibe) controlling confirmation gates | Separate config for human-in-the-loop requirements |
+| **Work profiles** | Bundled presets (default/prototype/production/yolo) | One-command switch of effort + autonomy + verification |
+| **Skills.sh ecosystem** | Stack detection → skill recommendation → `/vbw:skills` install from registry | Community skill distribution |
+| **Observability and metrics** | 7 V2 metrics, per-phase reports, cost attribution | Quantified execution tracking |
+| **Agent health monitoring** | `agent-health.sh` lifecycle tracking, orphan detection, circuit breakers | Prevents runaway or orphaned agent processes |
+| **Plugin marketplace** | Claude Code marketplace distribution with version management, migration scripts | Brownfield update handling for existing installations |
+| **Typed communication schemas** | 6 typed message schemas with JSON validation (`handoff-schemas.md`) | Structured inter-agent communication |
+
+### GSD-Only Capabilities
+
+| Capability | Implementation | Why It Matters |
+|------------|---------------|----------------|
+| **Multi-platform support** | Claude Code, OpenCode, Gemini CLI | Not locked to one AI coding platform |
+| **3 formal checkpoint types** | `checkpoint:human-verify` (90%), `checkpoint:decision` (9%), `checkpoint:human-action` (1%) with structured XML | More precisely categorized human interaction points |
+| **8-dimension plan checking** | `gsd-plan-checker` with requirement coverage, task completeness, dependency correctness, key links, scope sanity, verification derivation, context compliance, Nyquist compliance | Dedicated plan verification agent with revision loop |
+| **Nyquist compliance** | Plans must fit within ~50% context budget | Prevents context overflow during execution |
+| **Language-specific verification patterns** | `verification-patterns.md` (16.5KB) with React, API route, database, and wiring verification patterns | Practical stub detection and wiring verification for common stacks |
+| **Context monitor hook** | Real-time context usage tracking with WARNING (35%) and CRITICAL (25%) thresholds | Model awareness of remaining context budget during execution |
+| **Statusline** | Real-time progress bar, model, task, directory display after every response | Visual execution tracking (VBW has statusline too but GSD's is hook-based) |
+| **Comprehensive CLI tool** | `gsd-tools.cjs` (22KB) with ~30 subcommands for state, phases, roadmap, frontmatter, templates, verification, milestones | Centralized tooling with consistent JSON output |
+| **Authentication gate protocol** | Dynamic checkpoint creation when CLI encounters auth errors, with service CLI reference | Structured handling of credential requirements during automated deployment |
+| **YOLO mode** | Single toggle for auto-approve everything | Simpler autonomy model for rapid iteration |
+| **Milestone audit** | `/gsd:audit-milestone` pre-completion verification | Dedicated quality check before milestone closure |
+| **Phase removal** | `/gsd:remove-phase` with auto-renumbering | Can remove phases from roadmap, not just add/insert |
+| **Todo system** | `/gsd:add-todo`, `/gsd:check-todos` with area-based organization | Integrated task tracking outside the phase system |
+| **Global defaults** | `~/.gsd/defaults.json` for cross-project preferences | Project-independent settings persistence |
+
+---
+
+## Enforcement Comparison: The Core Difference
+
+This is the most important distinction between VBW and GSD. Both systems want the same outcomes — atomic commits, SUMMARY.md closure, verified artifacts, scoped file access. They differ in how they ensure those outcomes.
+
+### GSD's Enforcement Model
+
+GSD relies on **instruction-level enforcement** backed by a comprehensive CLI:
+
+1. **Agent instructions** (markdown): "You MUST create SUMMARY.md", "Only 4 deviation types allowed", "Do NOT modify files outside the plan"
+2. **CLI verification** (gsd-tools.cjs): `verify-summary`, `verify plan-structure`, `verify phase-completeness`, `verify artifacts`, `verify key-links`, `verify commits`
+3. **Advisory hooks** (3 JS hooks): Context monitor warns about budget, statusline shows progress, update checker runs at session start
+4. **Workflow checkpoints** (markdown): Plan checker revision loops, UAT testing, spot-checking
+
+This works well when the model follows instructions faithfully. The risk is that under context pressure (compaction, long sessions, complex multi-agent chains), instruction-level rules can be dropped or degraded.
+
+### VBW's Enforcement Model
+
+VBW layers **platform hook enforcement** on top of instruction-level rules:
+
+1. **Agent instructions** (markdown): Same as GSD — agents told what to do and not do
+2. **Script verification** (~97 bash scripts): Equivalent to gsd-tools.cjs but distributed across separate scripts
+3. **Blocking hooks** (exit 2): `file-guard.sh`, `bash-guard.sh`, `security-filter.sh`, `qa-gate.sh`, `hard-gate.sh`, `archive-uat-guard.sh`
+4. **Platform tool permissions** (YAML): `disallowedTools` enforced by the platform itself
+5. **Lifecycle hooks** (advisory): Agent health, session start/stop, compaction, state updates
+
+The blocking hooks (exit 2) are the key differentiator. These run as bash subprocesses BEFORE tool execution reaches the model. The model cannot bypass them through compaction, context overflow, or instruction degradation. They execute at zero model token cost.
+
+### The Trade-Off
+
+| Aspect | GSD Approach | VBW Approach |
+|--------|-------------|-------------|
+| **Enforcement reliability** | Depends on model instruction adherence | Platform-guaranteed for hook-enforced rules |
+| **Enforcement coverage** | Comprehensive via CLI + instructions | Comprehensive via hooks + scripts + instructions |
+| **Context cost** | Rules loaded into model context (CLI output consumed) | Hooks run as subprocesses at zero context cost |
+| **Platform dependency** | Works across Claude Code, OpenCode, Gemini CLI | Requires Claude Code (hooks, Agent Teams, tool permissions) |
+| **Debugging** | Read agent instructions + CLI output | Read hook scripts + hook error logs |
+| **Maintenance** | ~22KB JS CLI + ~300KB agent/workflow markdown | ~97 bash scripts + ~200KB agent/command/reference markdown |
+| **Token overhead** | CLI output enters context window | Hook scripts invisible to context |
+
+---
+
+## Philosophy Comparison (Corrected)
+
+| Aspect | GSD | VBW |
+|--------|-----|-----|
+| **Primary goal** | Structured AI development via context engineering | Structured AI development via phased workflows |
+| **Optimization target** | Token-to-value efficiency (Nyquist compliance, ~50% context budgets) | Token efficiency (86% overhead reduction vs stock, per-role budgets) |
+| **Loop closure** | Instruction-enforced + CLI verification | Instruction-enforced + hook-enforced (exit 2) |
+| **Parallel execution** | Wave-based (dependency graph → wave grouping) | Agent Teams (persistent teammates + worktree isolation) |
+| **Decision flow** | State-detected single path (resume-project.md) | State-detected single path (phase-detect.sh) |
+| **Session continuity** | Explicit pause → `.continue-here.md` with 7 sections | Auto-persistent (`.execution-state.json` + `event-log.jsonl`) |
+| **Quality gates** | Goal-backward verification (verifier + plan checker) | Goal-backward verification (QA agent, tiered) + hook gates |
+| **Scope control** | Instruction-level (scope guardrails + deviation rules) | Instruction-level + hook-level (file-guard + lease locks) |
+| **Enforcement** | Instruction + CLI + advisory hooks | Instruction + scripts + blocking hooks + tool permissions |
+| **Multi-platform** | Claude Code, OpenCode, Gemini CLI | Claude Code only |
+
+---
+
+## When to Choose Which
+
+### Choose GSD When
+
+- **You use multiple AI coding tools** — GSD supports Claude Code, OpenCode, and Gemini CLI
+- **You prefer Node.js tooling** — `gsd-tools.cjs` is a single CLI tool vs VBW's ~97 bash scripts
+- **You want a YOLO mode** — GSD's auto mode chains the full pipeline unattended
+- **You trust instruction-level enforcement** — If you're comfortable with model compliance, GSD's advisory approach is lighter-weight
+- **You want detailed checkpoint types** — GSD's 3 formal checkpoint types with documented presentation formats are more precisely categorized
+- **You want language-specific verification** — GSD's `verification-patterns.md` has practical React/API/DB verification patterns
+
+### Choose VBW When
+
+- **You need platform-enforced quality gates** — VBW's blocking hooks prevent the model from bypassing rules
+- **You run long, complex sessions** — VBW's event-sourced state recovery and compaction hooks handle multi-hour sessions and crashes
+- **You want tiered QA** — VBW's Quick/Standard/Deep tiers let you right-size verification effort
+- **You want filesystem isolation** — VBW's worktree isolation provides physical separation for parallel agents
+- **You want fine-grained control** — 4 effort levels × 4 autonomy levels × bundled work profiles
+- **You want security enforcement** — `bash-guard.sh` (40+ patterns), `security-filter.sh` (.env, .pem, credentials), and `file-guard.sh` (undeclared file access)
+- **You use the Claude Code marketplace** — VBW distributes as a marketplace plugin with migration handling
+
+### Both Are Good Choices When
+
+- You want structured, phased AI development instead of ad-hoc prompting
+- You want acceptance-based verification, not just task completion tracking
+- You want session continuity across context compactions
+- You want model routing with quality/balanced/budget profiles
+- You want codebase mapping with parallel agents
+- You want discussion/questioning before planning
+
+---
+
+## Data That Matters
+
+### Raw Numbers (Source-Code-Counted)
+
+| Metric | VBW | GSD |
+|--------|-----|-----|
+| Total markdown content (agents + commands + workflows + references) | ~200KB | ~350KB |
+| Executable code (scripts) | ~97 bash scripts | 1 JS CLI (~22KB) + 3 JS hooks (~10KB) + 1 build script |
+| Hook handlers | 25 | 3 |
+| Blocking hooks (exit 2) | 6+ | 0 |
+| Agent count | 7 | 11 |
+| Slash commands | 24 | 30 |
+| Checkpoint types | 1 (autonomous flag + UAT) | 3 (human-verify, decision, human-action) |
+| Platform support | 1 (Claude Code) | 3 (Claude Code, OpenCode, Gemini CLI) |
+| Effort/depth profiles | 4 | 3 |
+| Verification tiers | 3 | 1 |
+| Plan verification dimensions | Execute protocol checks | 8 formal dimensions |
+
+### What the Numbers Don't Tell You
+
+- More hooks ≠ better. VBW's hooks are valuable because specific hooks solve specific problems (file access control, destructive command prevention). Having 25 vs 3 matters only because of what those hooks DO.
+- More agents ≠ better. GSD's 11 agents decompose work more granularly; VBW's 7 agents cover the same lifecycle with broader role definitions.
+- More markdown ≠ better. GSD's ~350KB of agent/workflow content reflects a different design — detailed inline workflow definitions rather than protocol references.
+- Multi-platform support matters if you use multiple tools. If you only use Claude Code, VBW's deeper Claude Code integration is an advantage.
+
+---
+
+*Report prepared from source code analysis of VBW v1.30.0+ repository and GSD v1.20.5 repository (commit 131f24b, accessed via GitHub API 2026-07-22). Every claim is traceable to specific files in each repository.*

--- a/docs/vbw-vs-paul-analysis.md
+++ b/docs/vbw-vs-paul-analysis.md
@@ -1,0 +1,410 @@
+# VBW vs PAUL — Evaluating PAUL's Claimed Differentiators
+
+**Date:** 2026-02-21
+**Prepared for:** VBW framework users
+**Source material:** [PAUL-VS-GSD.md](https://github.com/ChristopherKahler/paul/blob/main/PAUL-VS-GSD.md), PAUL README, VBW source code and README
+
+> **Note:** This document evaluates PAUL's claims about its own differentiators versus VBW and GSD. Claims about GSD in this document are inherited from PAUL's marketing material and were not validated against GSD's source code. For a source-code-validated VBW vs GSD comparison, see [vbw-vs-gsd-source-validated.md](vbw-vs-gsd-source-validated.md).
+
+---
+
+## Executive Summary
+
+PAUL (Plan-Apply-Unify Loop) positions itself as an evolution beyond GSD (Get Shit Done), emphasizing quality over speed, in-session context over subagent sprawl, and mandatory loop closure. After a thorough review of PAUL's claims against VBW's actual implementation, **VBW already implements every differentiator PAUL claims over GSD — and in most cases goes significantly further.** VBW is not "more like PAUL than GSD" — it's a superset of both philosophies, combining PAUL's quality-first principles with execution capabilities neither PAUL nor GSD offer.
+
+---
+
+## Code-Level Deep Dive: APPLY/UNIFY Enforcement
+
+*This section was generated from actual source code inspection of both codebases, not READMEs.*
+
+### What PAUL Actually Does (Source: `src/commands/apply.md`, `src/workflows/apply-phase.md`, `src/commands/unify.md`, `src/workflows/unify-phase.md`, `src/carl/PAUL`)
+
+**APPLY — Sequential Execution**
+
+PAUL's `apply-phase.md` workflow (9KB) defines a detailed sequential execution protocol:
+
+| Feature | Implementation | Enforcement mechanism |
+|---|---|---|
+| Sequential task execution | `<step name="execute_tasks">` iterates `<task>` elements in order | Instruction to the model |
+| Per-task verification | Each task MUST have `<verify>` step run; FAIL stops execution | Instruction to the model |
+| Checkpoints (3 types) | `checkpoint:decision`, `checkpoint:human-verify`, `checkpoint:human-action` — all blocking, model presents formatted prompt and waits | Instruction to the model |
+| Deviation logging | `track_progress` step maintains mental log of completed/failed/deviated tasks | Instruction to the model |
+| Boundary respect | "Ignoring boundaries: If a task would modify a protected file, STOP" | Instruction to the model |
+| Skill verification | `verify_required_skills` blocks execution if required skills not loaded (with "override" escape hatch) | Instruction to the model |
+
+At completion, APPLY reports: *"APPLY complete. Run /paul:unify to close loop."* — a **suggestion**, not an automated transition.
+
+**UNIFY — Loop Closure**
+
+PAUL's `unify-phase.md` workflow (7KB) defines SUMMARY.md creation and state reconciliation:
+
+| Feature | Implementation | Enforcement mechanism |
+|---|---|---|
+| SUMMARY.md creation | Creates `{plan}-SUMMARY.md` with frontmatter, What Was Built, AC Results, Deviations, Decisions | Instruction to the model |
+| Plan vs actual comparison | `compare_plan_vs_actual` step — per-AC pass/fail, per-task completion check, deviation notes | Instruction to the model |
+| STATE.md update | Loop position markers (`PLAN ✓ → APPLY ✓ → UNIFY ✓`), milestone progress | Instruction to the model |
+| Phase transition | When last plan complete: triggers `transition-phase.md` with PROJECT.md evolution, ROADMAP.md update, git commit, state consistency verification | Instruction to the model |
+| State consistency check | Re-reads STATE.md, PROJECT.md, ROADMAP.md; verifies alignment across all fields; **blocking error** if misaligned | Instruction to the model |
+
+**CARL Rule 3:** `"Every APPLY must be followed by UNIFY. UNIFY reconciles plan vs actual, updates STATE.md, logs decisions."`
+
+This is a CARL domain rule injected into the model's context. CARL is instruction-level — it adds rules to the prompt that the model is expected to follow.
+
+**Critical finding: PAUL has ZERO bash scripts, ZERO hooks, ZERO platform gates.** Everything is markdown instructions. The entire enforcement mechanism is the model reading `apply.md` / `unify.md` and following the workflow documents. CARL rules reinforce this with instruction-level `MUST` directives, but nothing prevents the model from:
+- Not running `/paul:unify` after `/paul:apply`
+- Skipping verification steps during compaction
+- Ignoring boundary declarations when context overflows
+
+PAUL's `"Never skip UNIFY"` is backed by **social contract with the model**, not by code.
+
+### What VBW Actually Does (Source: `references/execute-protocol.md`, `scripts/hard-gate.sh`, `scripts/validate-summary.sh`, `scripts/qa-gate.sh`, `scripts/archive-uat-guard.sh`, `hooks/hooks.json`)
+
+**VBW's SUMMARY.md Enforcement — 4 Independent Layers**
+
+| Layer | Script/Hook | When it fires | Blocking? | Skippable? |
+|---|---|---|---|---|
+| **Execute protocol Step 3c** | Inline in execute-protocol.md | After Dev reports plan completion, BEFORE QA | YES — "This is a hard gate. Do NOT proceed to QA or mark a plan as complete without verifying its SUMMARY.md" | NO — the execute protocol is the core loop |
+| **PostToolUse hook** | `validate-summary.sh` | Every Write/Edit to a SUMMARY.md file | Advisory (exit 0) — surfaces missing sections | N/A — runs automatically on every write |
+| **SubagentStop hook** | `validate-summary.sh` | When any VBW agent stops | Advisory (exit 0) — checks for crash recovery fallbacks | N/A — platform fires this automatically |
+| **TeammateIdle hook** | `qa-gate.sh` | When any teammate goes idle | YES (exit 2) when 2+ plans lack summaries | NO — platform hook, fires automatically |
+| **Post-plan hard gate** | `hard-gate.sh artifact_persistence` | After all tasks in a plan complete | YES (exit 2) — "missing SUMMARY.md for: {plans}" | NO — fires regardless of autonomy level |
+| **Archive guard** | `archive-uat-guard.sh` | On `/vbw:vibe Archive` | YES (exit 2) — 7-point audit including SUMMARY.md presence | NO — not overridable by `--skip-audit` or `--force` |
+
+**What IS skippable in VBW:**
+
+| Component | When skipped | SUMMARY.md still required? |
+|---|---|---|
+| QA (automated verification) | `--skip-qa` flag, turbo effort, `qa_skip_agents` config | YES — Step 3c fires BEFORE QA |
+| UAT (human acceptance testing) | `confident` or `pure-vibe` autonomy | YES — SUMMARY.md + QA gates are independent of UAT |
+| Approval gates | `confident` or `pure-vibe` autonomy | YES |
+
+**VBW's SUMMARY.md is NEVER skippable.** The skippable items are QA (automated testing) and UAT (human testing) — these are downstream verification steps. Loop closure (SUMMARY.md = what was built, deviations, files modified) is enforced at the hard gate level and cannot be bypassed.
+
+### Direct Comparison: Enforcement Quality
+
+| Claim | PAUL | VBW |
+|---|---|---|
+| "Tasks run sequentially" | Instruction in workflow markdown | Instruction in execute-protocol.md (Dev agents execute tasks in order) |
+| "Each task has verification" | Instruction: `<verify>` step required per task | Instruction + `hard-gate.sh required_checks` (exit 2) + `validate-contract.sh` after each task |
+| "Checkpoints pause for human input" | 3 checkpoint types — instruction to stop and wait | `autonomous: false` flag on plans + UAT CHECKPOINTs with per-test persistence |
+| "Deviations are logged" | Instruction: mental log during APPLY, recorded in UNIFY | SUMMARY.md template + event log (13 types, always-on) + deviation count in phase completion output |
+| "Create SUMMARY.md" | Instruction in UNIFY workflow | Hard gate (Step 3c, exit 2) + hook (qa-gate.sh, exit 2) + archive guard |
+| "Compare plan vs actual" | Instruction in `compare_plan_vs_actual` step | SUMMARY.md template requires "What Was Built" + "Files Modified" — validated by hook |
+| "Record decisions and deferred issues" | Instruction to add to STATE.md Decisions table | Event log captures decisions; SUMMARY.md requires deviations section |
+| "Update STATE.md" | Instruction in UNIFY workflow | Execute protocol Step 5 updates STATE.md, ROADMAP.md, .execution-state.json |
+| "Never skip UNIFY" | CARL Rule 3 (instruction) | `hard-gate.sh artifact_persistence` (bash, exit code 2) + `qa-gate.sh` (bash, exit code 2) |
+
+### The Honest Assessment
+
+**Where PAUL is instruction-only, VBW has code gating:**
+- SUMMARY.md existence: PAUL = instruction. VBW = bash script exits 2 → platform blocks.
+- Boundary enforcement: PAUL = "DO NOT CHANGE" declarations. VBW = `file-guard.sh` PreToolUse hook + `lease-lock.sh` + worktree isolation.
+- UNIFY mandatory: PAUL = CARL Rule 3. VBW = hard-gate.sh + qa-gate.sh + archive-uat-guard.sh.
+
+**Where PAUL has an advantage:**
+- In-session context means the model has full execution memory for UNIFY. VBW delegates to Dev agents who may not carry full context back to the Lead.
+- PAUL's 3 structured checkpoint types (decision, human-verify, human-action) are more formally specified than VBW's `autonomous: false` flag.
+- PAUL's explicit plan vs actual comparison step is a dedicated workflow phase. VBW's SUMMARY.md template captures the same data but the comparison is less ritualized.
+
+**Where VBW has skip paths that PAUL doesn't:**
+- QA can be skipped (`--skip-qa`, turbo, `qa_skip_agents`) — PAUL has no formal QA, so nothing to skip.
+- UAT can be skipped (confident/pure-vibe autonomy) — PAUL's checkpoints can be "overridden" at the skill level, but UAT isn't a distinct concept in PAUL.
+- However: these skip paths don't affect loop closure. SUMMARY.md is mandatory in both frameworks — the difference is VBW enforces it with code, PAUL enforces it with instructions.
+
+---
+
+## PAUL's 8 Claimed Differentiators vs VBW
+
+### 1. Explicit Loop Discipline
+
+**PAUL's claim:** GSD has implicit review. PAUL enforces PLAN → APPLY → UNIFY with mandatory SUMMARY.md closure.
+
+**VBW's reality:** VBW enforces this at four levels, not one:
+
+| Enforcement Layer | Mechanism |
+|---|---|
+| **Instruction-level** | Every PLAN.md requires a corresponding SUMMARY.md. Execute mode Step 3c is a hard gate — plans cannot be marked complete without verified SUMMARY.md |
+| **Hook-level** | `PostToolUse` validates SUMMARY.md structure on write. `SubagentStop` validates SUMMARY.md exists before agent cleanup. `TeammateIdle` runs a tiered SUMMARY.md gate — 2+ missing summaries block regardless |
+| **TaskCompleted hook** | Verifies task-related commits exist via keyword matching with circuit breaker |
+| **Archive guard** | `archive-uat-guard.sh` + 7-point audit blocks archiving if any plan lacks SUMMARY.md or has `status != complete` |
+
+PAUL enforces loop closure via instructions to the model. VBW enforces it via platform hooks that **cannot be ignored during compaction**. PAUL's UNIFY is conceptually identical to VBW's SUMMARY.md requirement — but VBW's enforcement is mechanically stronger.
+
+**Verdict:** VBW exceeds PAUL. Same philosophy, harder enforcement.
+
+---
+
+### 2. Context-Aware Execution (Token Economics)
+
+**PAUL's claim:** GSD wastes tokens on subagent sprawl. PAUL keeps execution in-session. Subagents are reserved for discovery/research only.
+
+**VBW's reality:** VBW takes a more nuanced position — it uses Agent Teams (not subagents) with surgical context management:
+
+| Mechanism | What it does |
+|---|---|
+| **Context compiler** | `compile-context.sh` produces role-specific `.context-{role}.md` files — Lead gets requirements, Dev gets phase goal + conventions, QA gets verification targets. Each agent loads only relevant context |
+| **Token budgets** | Per-role caps (Scout 200 lines, Dev/Debugger 800 lines) with per-task complexity scoring from contract metadata |
+| **86% overhead reduction** | Measured and documented: 12,100 tokens vs stock Agent Teams' 87,100 tokens |
+| **Smart routing** | `assess-plan-risk.sh` downgrades low-risk plans to turbo (single agent, no team) automatically |
+| **`prefer_teams` setting** | `auto` mode creates teams only when 2+ plans exist — single plan = single agent, zero coordination overhead |
+
+PAUL's argument that "subagents produce ~70% quality work" is valid criticism of vanilla subagent spawning. But VBW doesn't use vanilla subagents — Agent Teams are persistent teammates with shared task lists, typed communication schemas, and compiled context. The quality delta PAUL describes doesn't apply.
+
+More importantly: VBW's parallel execution with context compilation achieves **both** speed and quality. PAUL forces a false dichotomy — "quality OR speed." VBW's token analysis proves you can have parallel execution at 86% lower overhead than stock implementation.
+
+**Verdict:** VBW exceeds PAUL. VBW solved the token economics problem PAUL avoids by refusing to parallelize.
+
+---
+
+### 3. Single Next Action
+
+**PAUL's claim:** GSD presents menus. PAUL suggests ONE best path based on current state.
+
+**VBW's reality:** `/vbw:vibe` with no arguments does exactly this. `phase-detect.sh` pre-computes project state and routes to the single correct next action:
+
+| State | Auto-routed action |
+|---|---|
+| No project | Bootstrap |
+| No phases | Scope |
+| UAT issues | Remediation |
+| Needs discussion | Discussion |
+| Needs plan + execute | Plan + Execute |
+| Needs execute | Execute |
+| All done | Archive |
+
+The entire state detection is a priority-ordered cascade — first match wins, one action suggested. The user can override with flags, but the default is always a single recommendation.
+
+VBW also provides `suggest-next.sh` which produces contextual "Next Up" suggestions after every command. This is the same pattern PAUL describes.
+
+**Verdict:** Feature parity. Both frameworks do this identically.
+
+---
+
+### 4. Structured Session Continuity
+
+**PAUL's claim:** GSD uses implicit `.continue-here.md`. PAUL has explicit `HANDOFF-{date}.md` files.
+
+**VBW's reality:** VBW's session continuity is more comprehensive than PAUL's:
+
+| Mechanism | What it persists |
+|---|---|
+| **STATE.md** | Phase position, velocity metrics, decisions, accumulated todos, blockers, session history |
+| **`.execution-state.json`** | Real-time execution state — phase, plan statuses, wave number, correlation ID. Survives crashes |
+| **`event-log.jsonl`** | Full event-sourced history (13 event types). Enables replay-based state recovery |
+| **`recover-state.sh`** | Reconstructs execution state from event log + SUMMARY.md files after crashes |
+| **`/vbw:resume`** | Reads ground truth from all `.vbw-planning/` files — no prior `/vbw:pause` needed. Detects interrupted builds, reconciles stale state |
+| **RESUME.md** | Optional sticky notes (equivalent to PAUL's HANDOFF, but state persists without it) |
+| **Snapshot resume** | `snapshot-resume.sh` captures execution state + git context for crash recovery |
+| **PreCompact hook** | Injects agent-specific preservation priorities before context compaction |
+| **Post-compaction verification** | SessionStart hook verifies critical context survived compaction |
+
+PAUL requires explicit `/paul:handoff` to persist state. VBW auto-persists everything — `/vbw:resume` works from cold with zero prior preparation. The `.execution-state.json` + event log combination enables crash recovery that PAUL's handoff files cannot match.
+
+**Verdict:** VBW significantly exceeds PAUL. Event-sourced recovery vs dated handoff files.
+
+---
+
+### 5. Acceptance Criteria as First-Class Citizens
+
+**PAUL's claim:** GSD tasks describe what to do. PAUL links tasks to numbered AC with Given/When/Then format.
+
+**VBW's reality:** VBW implements this through multiple mechanisms:
+
+| Mechanism | How AC are handled |
+|---|---|
+| **ROADMAP.md** | Each phase has explicit success criteria mapped to requirement IDs |
+| **PLAN.md frontmatter** | `must_haves` field with artifacts, truths, key_links, contains — machine-verifiable acceptance criteria |
+| **Verification protocol** | Goal-backward methodology: starts from desired outcomes, derives testable conditions, verifies against artifacts |
+| **Three-tier QA** | Quick (5-10 checks), Standard (15-25), Deep (30+) — each tier verifies progressively deeper against criteria |
+| **Requirement mapping (VRFY-08)** | Deep tier traces requirement IDs to implementing artifacts — OK/WARN/FAIL per requirement |
+| **UAT (`/vbw:verify`)** | Human acceptance testing with per-test CHECKPOINT prompts, pass/fail/partial verdicts, resume support |
+| **Archive UAT guard** | Unresolved UAT issues block archiving — hard gate, not bypassable |
+
+PAUL uses BDD-style AC in PLAN.md and reports pass/fail in SUMMARY.md. VBW uses structured `must_haves` in PLAN.md frontmatter, runs automated verification via the QA agent, and then runs human acceptance testing via `/vbw:verify`. The AC are verified at two levels (automated + human) rather than one.
+
+**Verdict:** VBW exceeds PAUL. Automated + human verification vs manual UNIFY reporting.
+
+---
+
+### 6. Boundaries That Stick
+
+**PAUL's claim:** GSD has scope guidance. PAUL has explicit `## Boundaries` with DO NOT CHANGE declarations.
+
+**VBW's reality:** VBW enforces boundaries through multiple runtime mechanisms:
+
+| Mechanism | What it enforces |
+|---|---|
+| **`file-guard.sh` hook** | PreToolUse hook blocks writes to files not declared in the active plan |
+| **Lease locks** | `lease-lock.sh` provides file-level locking — tasks must acquire exclusive leases before writing |
+| **Worktree isolation** | Physical filesystem isolation — each Dev works in a separate git worktree, literally cannot access other agents' files |
+| **Contract validation** | `generate-contract.sh` creates `allowed_paths` sidecar; `validate-contract.sh` checks modified files against contract post-task |
+| **Hard gates** | `hard-gate.sh` runs `protected_file` checks before each task, `contract_compliance` checks, and `artifact_persistence` checks after |
+| **`security-filter.sh`** | Blocks access to `.env`, credentials, `.pem`, `.key` files |
+| **`bash-guard.sh`** | Intercepts destructive bash commands (40+ patterns) before they reach the shell |
+| **Agent tool permissions** | Platform-enforced `disallowedTools` — Scout and QA literally cannot write files |
+
+PAUL relies on instructions (DO NOT CHANGE declarations) that the model is expected to respect. CARL adds dynamic rule injection, but rules are still instruction-level — nothing prevents the model from violating them during compaction or context overflow.
+
+VBW uses hooks that execute **before** tool invocations reach the model. `file-guard.sh` runs as a PreToolUse hook — it's not a suggestion, it's an interceptor. Tool permissions are platform-enforced via YAML `disallowedTools`.
+
+**Verdict:** VBW significantly exceeds PAUL. Hook-enforced boundaries vs instruction-level declarations.
+
+---
+
+### 7. Skill Tracking and Verification
+
+**PAUL's claim:** GSD has no skill tracking. PAUL's `SPECIAL-FLOWS.md` declares required skills and UNIFY audits whether they were invoked.
+
+**VBW's reality:** VBW integrates with the Skills.sh ecosystem:
+
+| Mechanism | What it does |
+|---|---|
+| **Stack detection** | `/vbw:init` scans project, identifies tech stack, recommends skills from curated `stack-mappings.json` |
+| **Skills.sh integration** | `/vbw:skills` browses and installs community skills from the open-source registry |
+| **Skill bundling in context** | `compile-context.sh` reads `skills_used` from plan frontmatter and bundles SKILL.md content into agent context |
+| **PLAN.md `skills_used`** | Frontmatter field declaring which skills a plan requires |
+| **Verified in CLAUDE.md** | Installed skills tracked in the `Installed Skills` section |
+
+VBW's approach is broader than PAUL's — PAUL tracks whether required skills were invoked; VBW detects skills from the stack, installs them, bundles them into agent context, and verifies conventions they define via QA.
+
+**Verdict:** VBW exceeds PAUL. Ecosystem integration vs manual declaration.
+
+---
+
+### 8. Decimal Phases for Interruptions
+
+**PAUL's claim:** GSD has integer phases only. PAUL supports decimal phases (8.1, 8.2) for urgent interruptions.
+
+**VBW's reality:** VBW handles interruptions through three mechanisms:
+
+| Mechanism | How it works |
+|---|---|
+| **`/vbw:vibe --insert N`** | Insert a phase at any position — all subsequent phases auto-renumber (dirs renamed, frontmatter updated, cross-refs adjusted) |
+| **`/vbw:vibe --add`** | Append a phase without disrupting existing numbering |
+| **`/vbw:fix`** | Quick task in Turbo mode — one commit, no ceremony, no phase mutation needed |
+| **`/vbw:debug`** | Systematic bug investigation — at Thorough effort spawns 3 parallel debugger teammates |
+
+VBW's `--insert` literally renumbers everything downstream — directory names, file prefixes, frontmatter references, `depends_on` links. It's more disruptive than PAUL's decimal approach, but also more structurally clean. Decimal phases preserve numbering but create a non-obvious secondary ordering.
+
+More importantly: VBW's `/vbw:fix` handles the common case (urgent fix needed) without touching phases at all. PAUL requires creating a decimal phase even for trivial interruptions.
+
+**Verdict:** Different but equivalent. PAUL's decimal phases are elegant; VBW's auto-renumbering + `/vbw:fix` is more practical.
+
+---
+
+## Capabilities VBW Has That PAUL Lacks
+
+Beyond addressing every PAUL differentiator, VBW includes substantial capabilities that have no PAUL equivalent:
+
+| Capability | VBW | PAUL |
+|---|---|---|
+| **Platform hooks (21 handlers, 11 event types)** | Continuous verification, security filtering, lifecycle management, compaction recovery — all running as platform hooks, not instructions | None — CARL adds dynamic rules but no platform-level hooks |
+| **Agent tool permissions (platform-enforced)** | 4 of 7 agents have `disallowedTools` enforced by Claude Code itself | None — PAUL is single-agent |
+| **Database safety guard** | 40+ destructive command patterns blocked across all major frameworks | None |
+| **Parallel execution with isolation** | Agent Teams + worktree isolation + lease locks + file guards | Explicitly rejected — in-session only |
+| **Three-tier automated QA** | Goal-backward verification at Quick/Standard/Deep tiers with 5-30+ checks | Manual UNIFY reconciliation |
+| **Human acceptance testing (UAT)** | `/vbw:verify` with per-test CHECKPOINT prompts, severity classification, resume support | `/paul:verify` exists but is guide-based, not structured |
+| **UAT remediation pipeline** | Automatic detection of unresolved UAT → discuss → plan → execute chain, including milestone recovery | None |
+| **Token budget enforcement** | Per-role caps, per-task complexity scoring, escalation tracking | None — token awareness is philosophical, not implemented |
+| **Event-sourced state recovery** | 13 event types in `event-log.jsonl` + `recover-state.sh` for crash recovery | None |
+| **Smart routing** | `assess-plan-risk.sh` auto-downgrades simple plans to turbo | None |
+| **Model routing** | 3 preset profiles (quality/balanced/budget) with per-agent overrides | None — single model assumed |
+| **Effort profiles** | 4 levels (thorough/balanced/fast/turbo) controlling planning depth, QA tier, agent behavior | None — one depth |
+| **Autonomy levels** | 4 levels (cautious/standard/confident/pure-vibe) controlling confirmation gates | None |
+| **Work profiles** | Bundled presets (default/prototype/production/yolo) switching effort + autonomy + verification in one command | None |
+| **Codebase mapping** | 4 parallel Scout teammates analyzing tech/architecture/quality/concerns | `/paul:map-codebase` exists as a single command |
+| **Structured handoff schemas** | 6 typed message schemas with JSON validation | None |
+| **Observability and metrics** | 7 V2 metrics, per-phase reports, cost attribution | None |
+| **Agent health monitoring** | Lifecycle tracking, orphan detection, circuit breakers | N/A (single agent) |
+| **Discussion engine** | Auto-calibrating Builder/Architect modes, phase-specific gray area generation, conversational exploration | `/paul:discuss` exists but is simpler |
+| **Statusline** | Real-time progress dashboard after every response | None |
+| **Plugin architecture** | Marketplace distribution, version management, migration scripts for brownfield installs | npm package |
+| **845 bats tests** | Comprehensive test suite validating scripts and contracts | Unknown test coverage |
+
+---
+
+## PAUL's Philosophy Comparison Table — Fact-Checked
+
+PAUL's PAUL-VS-GSD.md includes a philosophy comparison table. Here it is with VBW's actual position:
+
+| Aspect | GSD | PAUL | VBW |
+|---|---|---|---|
+| Primary goal | Ship fast | Ship correctly | Ship correctly AND fast (parallel execution with quality gates) |
+| Optimization target | Speed to done | Token-to-value efficiency | Measured token efficiency (86% reduction vs stock) |
+| Loop closure | Flexible | Mandatory | Mandatory + hook-enforced + archive-guarded |
+| Subagent role | Execution (parallel speed) | Discovery only | Execution (Agent Teams with context compilation) + Discovery (Scout) |
+| Decision flow | Multiple options | Single best path | Single best path (`phase-detect.sh` → one action) |
+| Session handoff | Implicit | Explicit + dated | Automatic (no prior action needed) + event-sourced crash recovery |
+| Quality gates | Completion-based | Acceptance-based | Automated QA + Human UAT + hook-enforced gates |
+| Scope control | Guidance | Enforcement (instructions) | Enforcement (platform hooks + tool permissions + lease locks) |
+
+---
+
+## PAUL's "When to Use Which" — Where VBW Fits
+
+PAUL suggests using PAUL when:
+- ✅ Quality and traceability matter → VBW does this with stronger enforcement
+- ✅ Work spans multiple sessions → VBW has superior session continuity
+- ✅ You need verifiable acceptance criteria → VBW has automated + human verification
+- ✅ Scope creep is a concern → VBW has hook-level scope enforcement
+- ✅ You want explicit reconciliation of plan vs. reality → VBW's SUMMARY.md + QA + UAT pipeline
+
+PAUL suggests using GSD when:
+- Speed is the primary constraint → VBW's turbo mode and parallel execution handle this
+- Project scope is small → VBW's `/vbw:fix` handles trivial changes without ceremony
+- Single-session completion is likely → VBW's pure-vibe autonomy loops all phases unattended
+- You don't need audit trails → VBW's event log is always-on but zero overhead
+
+VBW covers both use cases. It doesn't force a choice between speed and quality.
+
+---
+
+## CARL vs VBW Hooks
+
+PAUL relies on CARL (Context Augmentation & Reinforcement Layer) for dynamic rule injection — rules load based on what you're working on and disappear when you're not. This is clever for context management but fundamentally limited:
+
+| Aspect | CARL | VBW Hooks |
+|---|---|---|
+| Mechanism | Dynamic prompt injection | Platform hook handlers (PreToolUse, PostToolUse, etc.) |
+| Enforcement | Instructions — model can ignore during compaction | Hook code runs before tool execution — model cannot bypass |
+| Integration | Separate tool (must install CARL alongside PAUL) | Built into the plugin (hooks.json ships with VBW) |
+| Context cost | Rules loaded just-in-time to keep context lean | Scripts run as bash subprocesses at zero model token cost |
+| Scope | 14 PAUL-specific rules | 21 handlers across 11 event types |
+
+CARL solves a real problem (context bloat from static rules) but VBW solves the same problem differently — scripts run as bash subprocesses outside the model's context window. VBW's 85 scripts execute at zero model token cost. CARL's rules, however lightweight, still consume context tokens when loaded.
+
+---
+
+## The PAUL "AI Is Already Fast" Argument
+
+PAUL's core philosophical claim deserves direct response:
+
+> "AI is already the speed enhancement. We don't need to optimize speed at the cost of quality."
+
+This is a false dichotomy. VBW demonstrates that parallel execution does not require sacrificing quality:
+
+1. **Context compilation** ensures every agent gets exactly the context it needs — no cold-start duplication
+2. **Hook enforcement** runs continuously during parallel execution — not after, during
+3. **Typed communication schemas** prevent the "garbage output" PAUL warns about
+4. **86% token overhead reduction** means parallel execution is actually MORE token-efficient than in-session execution with full context loading
+5. **Worktree isolation** eliminates the merge conflict risk that makes parallel work unreliable
+
+PAUL's argument applies to stock subagent spawning. It does not apply to VBW's architecture.
+
+---
+
+## Bottom Line
+
+| Question | Answer |
+|---|---|
+| Is VBW more like PAUL than GSD? | VBW shares PAUL's quality-first philosophy but implements it with mechanically stronger enforcement than PAUL provides. VBW also retains (and improves upon) GSD's execution speed through context-compiled parallel Agent Teams. |
+| Does VBW address PAUL's criticisms of GSD? | Yes, every one of them — and in most cases goes further than PAUL does. |
+| Should VBW users worry about PAUL's claims? | No. Every claimed advantage in PAUL-VS-GSD.md is already present in VBW, typically with stronger implementation. |
+| Is PAUL a competitor to VBW? | PAUL is a lightweight framework (~26 commands, markdown-only, single-agent) with good principles. VBW is a full-stack development lifecycle platform (24 commands, 85 scripts, 21 hooks, 7 agents, 845 tests). They operate at different scales. |
+
+**VBW is not PAUL. VBW is not GSD. VBW is what happens when you take the best ideas from both — mandatory loop closure, token efficiency, acceptance-driven verification, structured session continuity — and implement them with platform-level enforcement, parallel execution, and comprehensive automation.**
+
+---
+
+*Report prepared from source code analysis of VBW v1.30.0+ and PAUL's public repository as of 2026-02-21.*


### PR DESCRIPTION
## What

Two documentation changes:

1. **New:** `docs/vbw-vs-gsd-source-validated.md` — a direct VBW vs GSD comparison where every claim is validated against GSD v1.20.5 source code (read via GitHub API, not READMEs or marketing)
2. **Renamed:** `docs/vbw-vs-paul-vs-gsd-analysis.md` → `docs/vbw-vs-paul-analysis.md` — title and filename updated to reflect its actual scope (evaluating PAUL's claimed differentiators), with a cross-reference note pointing to the new GSD doc

## Why

The prior analysis inherited claims about GSD from PAUL's marketing material without examining GSD's source code. Several claims were inaccurate — e.g., GSD was described as completion-based (it's actually goal-backward), as having no formal QA (it has a verifier agent + 8-dimension plan checker), and as having integer-only phases (it supports decimal phases). The new doc corrects all of these with source citations.

## How

- Read GSD v1.20.5 source (all agents, workflows, hooks, CLI tool, references) via GitHub MCP server
- Read key VBW source files (hooks.json, hard-gate.sh, file-guard.sh, execute-protocol.md) for accurate comparison
- Produced a feature-by-feature comparison covering: corrections to prior claims, architecture, enforcement philosophy, unique capabilities, and "when to choose which" guidance

## Testing

- [x] Documentation only — no code changes
- [x] No existing commands affected
- [x] Cross-reference link between docs verified