### PR TITLE
chore(gitignore): ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ node_modules/
 .env.*.local
 
 # Claude Code local settings
-.claude/settings.local.json
+.claude
 
 # GitHub Copilot instructions
 .github/copilot-instructions.md


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore the `.claude` directory instead of only `.claude/settings.local.json`

## Why
- ensure all local Claude settings/artifacts remain untracked