### PR TITLE
fix(release): correct git date format and clarify tag existence checks

### DIFF
--- a/internal/release.md
+++ b/internal/release.md
@@ -44,7 +44,7 @@ Git status:
    - If `{failed} > 0` and `{cleaned} == 0` → STOP: "All branch deletions failed. Check permissions and retry."
    - If `{failed} > 0` → display: "⚠ {failed} branch deletion(s) failed ({failed_branches} could not be fully cleaned) — check warnings above."
    - Display cleanup summary: "ℹ Cleaned up {cleaned} stale release branch(es). Proceeding with fresh release."
-   - **Remote deletion error classification:** When `git push origin --delete` exits non-zero, classify the error by stderr content: (1) if stderr contains `remote ref does not exist`, `does not exist`, `not found`, or `unable to delete.*not found` → treat as success (branch already gone), increment `{cleaned}`; (2) for any other stderr content → treat as failure, increment `{failed}`. This list covers Git's known not-found messages across versions and transports (HTTPS, SSH). If a future Git version changes the message, the worst case is a false failure (conservative), not a false success.
+   - **Remote deletion error classification:** When `git push origin --delete` exits non-zero, classify the error by stderr content: (1) if stderr contains `remote ref does not exist`, `does not exist`, or `unable to delete.*not found` → treat as success (branch already gone), increment `{cleaned}`; (2) for any other stderr content → treat as failure, increment `{failed}`. **Do not match bare `not found`** — it is too broad and would misclassify repo-level errors like `repository 'X' not found` as success. The specific patterns above cover Git's known branch-not-found messages across versions and transports (HTTPS, SSH). If a future Git version changes the message, the worst case is a false failure (conservative), not a false success.
 
 ## Pre-release Audit
 
@@ -175,7 +175,7 @@ Otherwise: Extract changelog for this version from CHANGELOG.md. Auth resolution
 ### Finalize Step 4: Clean up release branch
 
 Delete local release branch if it still exists: `git branch -d release/v{version} 2>/dev/null || true`
-Delete remote release branch: `git push origin --delete release/v{version} 2>&1`. If stderr contains a not-found message (`remote ref does not exist`, `does not exist`, `not found`, `unable to delete.*not found`), treat as success (already gone). If deletion fails for another reason, display: "⚠ Could not delete remote branch `release/v{version}` — delete manually." This is non-fatal (release is already tagged); continue to Step 5 regardless.
+Delete remote release branch: `git push origin --delete release/v{version} 2>&1`. If stderr contains a branch-not-found message (`remote ref does not exist`, `does not exist`, `unable to delete.*not found`), treat as success (already gone). Do not match bare `not found` (too broad — see Guard 7 classification note). If deletion fails for another reason, display: "⚠ Could not delete remote branch `release/v{version}` — delete manually." This is non-fatal (release is already tagged); continue to Step 5 regardless.
 
 ### Finalize Step 5: Present summary
 

--- a/tests/release-changelog-generation.bats
+++ b/tests/release-changelog-generation.bats
@@ -470,7 +470,10 @@ extract_version_precompute() {
   guard7=$(extract_guard "7. Existing release branch")
   # Must list multiple not-found patterns for cross-version/transport robustness
   echo "$guard7" | grep -qi 'remote ref does not exist'
-  echo "$guard7" | grep -qi 'not found'
+  echo "$guard7" | grep -qi 'does not exist'
+  echo "$guard7" | grep -qi 'unable to delete'
+  # Must NOT use bare 'not found' (over-broad — catches repo-level errors)
+  echo "$guard7" | grep -qi 'do not match bare\|too broad'
   # Must describe conservative fallback for unknown messages
   echo "$guard7" | grep -qi 'conservative\|false failure'
 }
@@ -522,11 +525,9 @@ extract_version_precompute() {
   local guard5_content
   guard5_content=$(echo "$finalize_guard" | awk '/^5\. \*\*Tag already exists/{found=1; print; next} found && /^[0-9]+\./{found=0} found && /^###/{found=0} found{print}')
   if [ -z "$guard5_content" ]; then
-    # Fallback: search within Finalize Guard section (not full Finalize Phase)
-    # This is less precise but still scoped to guards, not steps.
-    # NOTE: finalize_guard extraction stops at ^### (next heading), so this
-    # fallback is guard-scoped and cannot leak Finalize Step content.
-    guard5_content="$finalize_guard"
+    # No fallback — if the Guard 5 anchor drifts (renumbered/reworded),
+    # fail explicitly so the test is updated, rather than broadening scope.
+    fail "Guard 5 anchor '5. **Tag already exists' not found in Finalize Guard section — update test if guard was renumbered/reworded"
   fi
   # Must explicitly warn that git tag -l always exits 0
   echo "$guard5_content" | grep -qi 'always exits 0\|exit code'


### PR DESCRIPTION
## What

Fix two bugs in the release command spec (`internal/release.md`) that caused Session 4 (4f3d58b0) errors during `/vbw:release` after PR #173 was merged.

## Why

**Bug 1 — Wrong date format specifier (Audit 1, line 59):**
The spec used `git log -1 --format=%Y-%m-%d {hash}` which uses strftime-style specifiers. In git's `--format` language, `%Y` outputs literally, `%m` outputs left/right boundary mark (`>`), and `%d` outputs ref decorations (e.g., `(tag: v1.31.0)`). This produced `%Y->- (tag: v1.31.0)` instead of a `YYYY-MM-DD` date string.

**Bug 2 — Ambiguous tag existence check (Audit 5, line 79 & Finalize Guard 5, line 156):**
The spec said `git tag -l "v{version}"` "returns empty" / "returns a match" without clarifying that `git tag -l` **always exits 0** regardless of whether any tags match. The agent interpreted this as an exit-code check (`git tag -l "v1.32.0" && echo TAG_EXISTS`), which always reported TAG_EXISTS, causing 3 wasted tool calls investigating a phantom tag.

## How

- **Audit 1:** Changed `--format=%Y-%m-%d` to `--format='%cd' --date=short` with an explicit warning about why strftime specifiers don't work in git format strings.
- **Audit 5 & Finalize Guard 5:** Added explicit documentation that `git tag -l` always exits 0 and that stdout content (not exit code) must be checked.
- **Tests:** Added 3 new BATS tests verifying:
  1. Audit 1 uses `%cd`/`%ci` format, not `%Y-%m-%d`
  2. Audit 5 warns about exit-code pitfall
  3. Finalize Guard 5 warns about exit-code pitfall

## Testing

- [x] All 56 release-changelog-generation tests pass
- [x] Full test suite (`testing/run-all.sh`) passes with 0 failures
- [x] New tests confirmed to fail before fix (TDD red), pass after fix (TDD green)

Fixes #174