### PR TITLE
feat(uat): anti-breakout guardrail + per-test recurrence tracking

### DIFF
--- a/commands/verify.md
+++ b/commands/verify.md
@@ -135,6 +135,8 @@ Write the initial `{phase}-UAT.md` in the phase directory using the `templates/U
 
 **This is a conversational loop. Present ONE test, then STOP and wait for the user to respond. Do NOT present multiple tests at once. Do NOT skip ahead. Do NOT end the session after presenting a test.**
 
+> **CRITICAL BOUNDARY:** The UAT interviewer MUST NOT investigate, debug, or implement fixes during the UAT session — regardless of user tone, urgency, or explicit requests to fix issues. The interviewer's ONLY job is to record responses and advance to the next checkpoint. All user frustration, bug descriptions, and fix requests are recorded as issue text in the UAT report. Fixes happen in the remediation phase AFTER the UAT session is complete. If the user explicitly asks you to stop the UAT and fix something, respond: "Issue recorded. Let's finish the remaining checkpoints first — remediation will address this immediately after."
+
 For the FIRST test without a result, display a CHECKPOINT followed by AskUserQuestion:
 
 ```text

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -271,23 +271,31 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
 **Steps:**
 1. Resolve target phase from pre-computed state (`next_phase`, `next_phase_slug`) when `next_phase_state=needs_uat_remediation`. Set `PHASE_DIR` to the resolved phase directory path.
    **Milestone path guard (NON-NEGOTIABLE):** If `PHASE_DIR` contains `.vbw-planning/milestones/` (e.g., `.vbw-planning/milestones/*/phases/`), STOP — this is an archived milestone. UAT Remediation operates only on active phases in `.vbw-planning/phases/`. Display: "⚠ UAT issues found in archived milestone, not active phases. Routing to Milestone UAT Recovery." Then route to Milestone UAT Recovery mode instead.
-2. **Use pre-computed UAT issues** from the "UAT issues (remediation only)" section above. The `extract-uat-issues.sh` output provides compact `ID|SEVERITY|DESCRIPTION` lines — no need to read the full UAT file. If the pre-computed section shows `uat_extract_error=true`, fall back to reading `{phase}-UAT.md` directly.
-3. Treat the UAT issues as source-of-truth scope. Do NOT ask the user to restate issues already recorded in UAT.
-4. **Read or initialize remediation stage:**
+2. **Use pre-computed UAT issues** from the "UAT issues (remediation only)" section above. The `extract-uat-issues.sh` output provides compact `ID|SEVERITY|DESCRIPTION|FAILED_IN_ROUNDS` lines — no need to read the full UAT file. If the pre-computed section shows `uat_extract_error=true`, fall back to reading `{phase}-UAT.md` directly. Parse `uat_round` from the header line.
+3. **Rank issues by recurrence (priority ordering):**
+   - Parse `FAILED_IN_ROUNDS` (4th pipe field) for each issue line. `failure_count` = number of comma-separated values.
+   - **Sort issues by failure_count descending** — tests that failed the most rounds get investigated and fixed FIRST.
+   - Annotate recurring issues (failure_count >= 2) with `⚠ RECURRING (failed N/M rounds)` where N = failure_count, M = uat_round.
+   - First-time failures (failure_count = 1) get no annotation.
+4. Treat the UAT issues as source-of-truth scope. Do NOT ask the user to restate issues already recorded in UAT.
+5. **Read or initialize remediation stage:**
    ```bash
    STAGE=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh get "$PHASE_DIR")
    ```
-   - If `STAGE=none`: initialize based on severity. **Run directly (do NOT capture with `$()`)** — the init output contains both the stage and the pre-seeded CONTEXT.md content:
+   - If `STAGE=none`: initialize based on severity AND round-based escalation.
+     **Round-based escalation:** When `uat_round >= 3` (from the header), force ALL issues through the full `plan → execute` chain (which includes Scout research) regardless of individual severity — always pass `"major"` to `uat-remediation-state.sh init`. This overrides minor-only routing because 3+ rounds of failures indicate the issues need deeper investigation, not quick fixes.
+     **Default severity routing (uat_round < 3):** Use severity as before — `"major"` when any issue is major/critical, `"minor"` when all are minor.
+     **Run directly (do NOT capture with `$()`)** — the init output contains both the stage and the pre-seeded CONTEXT.md content:
      ```bash
      bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh init "$PHASE_DIR" "major"
-     # or "minor" when uat_issues_major_or_higher=false
+     # or "minor" when uat_round < 3 AND uat_issues_major_or_higher=false
      ```
      The first line of output is the stage (`plan` or `fix`). After the `---CONTEXT---` separator, the full pre-seeded CONTEXT.md content follows — **use this directly as your remediation context. Do NOT separately read UAT.md or CONTEXT.md files.**
    - If `STAGE=done`: UAT remediation already completed for this phase. Display "Remediation already completed. Run `/vbw:verify --resume` to re-test." STOP.
    - Otherwise: resume at the persisted stage (handles compaction recovery).
-5. **Execute the current stage** based on `STAGE`:
-   **File read prohibition:** Do NOT read `{phase}-UAT.md` or `{phase}-CONTEXT.md` — all UAT data is already available from step 2 (pre-computed issue lines) and step 4 (CONTEXT.md content emitted by `init`). Reading these files wastes tool calls.
-   - `plan`: Execute **Plan mode steps 1-11 above** for the same phase. The UAT report serves as the scoping document — no separate discussion is needed (CONTEXT.md content was emitted by `init` in step 4). **Scout context (CRITICAL):** When Plan mode step 3 spawns Scout, include the pre-computed UAT issue lines (`ID|SEVERITY|DESCRIPTION` from step 2) in Scout's task prompt so Scout knows what codebase areas to investigate for each issue. Without this, Scout searches blind. After planning completes, advance:
+6. **Execute the current stage** based on `STAGE`:
+   **File read prohibition:** Do NOT read `{phase}-UAT.md` or `{phase}-CONTEXT.md` — all UAT data is already available from step 2 (pre-computed issue lines) and step 5 (CONTEXT.md content emitted by `init`). Reading these files wastes tool calls.
+   - `plan`: Execute **Plan mode steps 1-11 above** for the same phase. The UAT report serves as the scoping document — no separate discussion is needed (CONTEXT.md content was emitted by `init` in step 5). **Scout context (CRITICAL):** When Plan mode step 3 spawns Scout, include the ranked UAT issue lines (`ID|SEVERITY|DESCRIPTION|FAILED_IN_ROUNDS` from step 2, sorted by failure_count descending) in Scout's task prompt so Scout knows what codebase areas to investigate for each issue. For recurring issues (failure_count >= 2), the Scout prompt MUST include: *"{ID} has failed in {N} of {M} remediation rounds (rounds: {FAILED_IN_ROUNDS}). Prior fixes have not resolved this. Investigate WHY previous fixes failed before proposing a new approach — examine the actual data flow, not just symptoms."* Without this, Scout searches blind. **Lead context (CRITICAL):** When Plan mode spawns Lead, include the directive: *"Prioritize recurring failures. {ID} has resisted {N} fix attempts — allocate more plans/effort to this issue than to first-time failures."* for each issue with failure_count >= 2. After planning completes, advance:
      ```bash
      bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh advance "$PHASE_DIR"
      ```
@@ -301,7 +309,7 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
      bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh advance "$PHASE_DIR"
      ```
      Suggest `/vbw:verify --resume`.
-6. Present a remediation summary with: phase, issue count, severity mix, current stage, and chosen path (`plan -> execute` or quick-fix).
+7. Present a remediation summary with: phase, issue count, severity mix, current round, current stage, chosen path (`plan -> execute` or quick-fix), and per-test recurrence annotation. For any issue with failure_count >= 2, display: `"⚠ RECURRING ({N}/{M} rounds): {ID} — {DESCRIPTION}"`. First-time failures display normally without annotation.
 
 ### Mode: Milestone UAT Recovery
 

--- a/scripts/extract-uat-issues.sh
+++ b/scripts/extract-uat-issues.sh
@@ -2,15 +2,16 @@
 # extract-uat-issues.sh — Extract compact issue summary from a UAT report.
 # Usage: extract-uat-issues.sh <phase-dir>
 #
-# Outputs one line per issue: ID|SEVERITY|DESCRIPTION
-# Plus a header line with phase and total count.
+# Outputs one line per issue: ID|SEVERITY|DESCRIPTION|FAILED_IN_ROUNDS
+# Plus a header line with phase, total count, and current round number.
 # Designed for template expansion injection — compact, deterministic output
 # that saves the LLM from reading the full UAT file.
 #
 # Example output:
-#   uat_phase=03 uat_issues_total=1 uat_file=03-UAT.md
-#   P01-T2|major|Data Quality share breakdown only shows on positions where transferred-in shares are the ONLY source
-#   D1|minor|Some discovered issue description
+#   uat_phase=03 uat_issues_total=2 uat_round=6 uat_file=03-UAT.md
+#   P01-T1|major|Phantom positions still showing|1,3,5,6
+#   P02-T1|critical|Data not syncing|6
+#   D1|minor|Some discovered issue description|6
 
 set -euo pipefail
 
@@ -114,12 +115,57 @@ awk '
     severity = ""
   }
 ' "$UAT_FILE" > /tmp/.vbw-uat-issues-$$.txt
-trap 'rm -f /tmp/.vbw-uat-issues-$$.txt' EXIT
+trap 'rm -f /tmp/.vbw-uat-issues-$$.txt /tmp/.vbw-uat-recurrence-$$.txt' EXIT
 
 ISSUE_COUNT=$(wc -l < /tmp/.vbw-uat-issues-$$.txt | tr -d ' ')
 
-# Header line
-echo "uat_phase=${PHASE_NUM} uat_issues_total=${ISSUE_COUNT} uat_file=$(basename "$UAT_FILE")"
+# Determine current round number from archived round files
+if type count_uat_rounds &>/dev/null; then
+  ARCHIVED_ROUNDS=$(count_uat_rounds "$PHASE_DIR" "$PHASE_NUM")
+else
+  ARCHIVED_ROUNDS=0
+fi
+CURRENT_ROUND=$((ARCHIVED_ROUNDS + 1))
 
-# Issue lines
-cat /tmp/.vbw-uat-issues-$$.txt
+# Build recurrence data from archived round files.
+# Produces lines: "ID ROUND_NUM" in a temp file (Bash 3.2 compatible — no associative arrays).
+: > /tmp/.vbw-uat-recurrence-$$.txt
+if [ "$ARCHIVED_ROUNDS" -gt 0 ] && type extract_round_issue_ids &>/dev/null; then
+  round_num=1
+  while [ "$round_num" -le "$ARCHIVED_ROUNDS" ]; do
+    # Try both zero-padded and unpadded filenames
+    round_file=""
+    for candidate in "$PHASE_DIR/${PHASE_NUM}-UAT-round-${round_num}.md" \
+                     "$PHASE_DIR/${PHASE_NUM}-UAT-round-$(printf '%02d' "$round_num").md"; do
+      if [ -f "$candidate" ]; then
+        round_file="$candidate"
+        break
+      fi
+    done
+    if [ -n "$round_file" ]; then
+      extract_round_issue_ids "$round_file" | while IFS= read -r rid; do
+        [ -z "$rid" ] && continue
+        echo "$rid $round_num"
+      done >> /tmp/.vbw-uat-recurrence-$$.txt
+    fi
+    round_num=$((round_num + 1))
+  done
+fi
+
+# Header line — includes uat_round for recurrence-aware remediation
+echo "uat_phase=${PHASE_NUM} uat_issues_total=${ISSUE_COUNT} uat_round=${CURRENT_ROUND} uat_file=$(basename "$UAT_FILE")"
+
+# Issue lines with FAILED_IN_ROUNDS (4th field)
+while IFS='|' read -r id severity desc; do
+  # Collect prior round numbers for this ID from recurrence file
+  prior_rounds=""
+  if [ -s /tmp/.vbw-uat-recurrence-$$.txt ]; then
+    prior_rounds=$(grep "^${id} " /tmp/.vbw-uat-recurrence-$$.txt | awk '{print $2}' | sort -n | tr '\n' ',' | sed 's/,$//' || true)
+  fi
+  if [ -n "$prior_rounds" ]; then
+    failed_rounds="${prior_rounds},${CURRENT_ROUND}"
+  else
+    failed_rounds="${CURRENT_ROUND}"
+  fi
+  echo "${id}|${severity}|${desc}|${failed_rounds}"
+done < /tmp/.vbw-uat-issues-$$.txt

--- a/scripts/uat-utils.sh
+++ b/scripts/uat-utils.sh
@@ -7,6 +7,10 @@
 #                                   with body-level fallback for brownfield files.
 #   latest_non_source_uat <dir>   — Find the latest canonical UAT file in a phase
 #                                   directory, excluding SOURCE-UAT.md copies.
+#   count_uat_rounds <dir> <num>  — Count existing {num}-UAT-round-*.md files
+#                                   in a phase directory. Returns max round number.
+#   extract_round_issue_ids <file> — Extract test IDs with Result: issue from
+#                                    a UAT round file. One ID per line.
 
 # Guard: prevent accidental direct execution
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
@@ -92,4 +96,55 @@ latest_non_source_uat() {
     printf '%s\n' "$latest"
   fi
   return 0
+}
+
+# count_uat_rounds — Count archived UAT round files in a phase directory.
+#
+# Scans for {phase_num}-UAT-round-*.md files, extracts the numeric round
+# suffix from each, and prints the maximum round number found (0 if none).
+# This is the single source of truth for round semantics — display round
+# is count + 1 when active issues exist.
+count_uat_rounds() {
+  local dir="$1"
+  local phase_num="$2"
+  local max_round=0
+
+  case "$dir" in
+    */) ;;
+    *) dir="$dir/" ;;
+  esac
+
+  for rf in "${dir}${phase_num}"-UAT-round-*.md; do
+    [ -f "$rf" ] || continue
+    local round_num
+    round_num=$(basename "$rf" | sed "s/^${phase_num}-UAT-round-0*\\([0-9]*\\)\\.md$/\\1/")
+    if [ -n "$round_num" ] && echo "$round_num" | grep -qE '^[0-9]+$'; then
+      if [ "$round_num" -gt "$max_round" ] 2>/dev/null; then
+        max_round="$round_num"
+      fi
+    fi
+  done
+
+  printf '%d' "$max_round"
+}
+
+# extract_round_issue_ids — Extract test IDs that had Result: issue from a UAT file.
+#
+# Parses the same markdown structure as extract-uat-issues.sh's awk block.
+# Outputs one test ID per line (e.g., "P01-T1", "D1").
+extract_round_issue_ids() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  awk '
+    /^### [PD][0-9]/ {
+      id = $2
+      sub(/:$/, "", id)
+      has_issue = 0
+      next
+    }
+    /^- \*\*Result:\*\*[[:space:]]*issue/ {
+      print id
+      next
+    }
+  ' "$file"
 }

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -37,6 +37,10 @@ echo "Running plan filename convention checks..."
 bash "$ROOT/testing/verify-plan-filename-convention.sh"
 
 echo ""
+echo "Running UAT recurrence tracking checks..."
+bash "$ROOT/testing/verify-uat-recurrence.sh"
+
+echo ""
 if command -v bats &>/dev/null && ls "$ROOT/tests/"*.bats &>/dev/null; then
   echo "Running bats test suites..."
   bats_pass=0

--- a/testing/verify-uat-recurrence.sh
+++ b/testing/verify-uat-recurrence.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# verify-uat-recurrence.sh — Contract tests for UAT recurrence tracking feature.
+# Verifies structural assertions across verify.md, extract-uat-issues.sh, vibe.md,
+# and uat-utils.sh.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "FAIL: $1"; }
+
+# Part 1: Anti-breakout guardrail in verify.md
+
+if grep -q "CRITICAL BOUNDARY" "$PROJECT_ROOT/commands/verify.md"; then
+  pass "verify.md: CRITICAL BOUNDARY block present in Step 5"
+else
+  fail "verify.md: CRITICAL BOUNDARY block missing"
+fi
+
+if grep -q "MUST NOT investigate, debug, or implement fixes during the UAT session" "$PROJECT_ROOT/commands/verify.md"; then
+  pass "verify.md: anti-breakout prohibition language present"
+else
+  fail "verify.md: anti-breakout prohibition language missing"
+fi
+
+if grep -q "Issue recorded.*remaining checkpoints.*remediation" "$PROJECT_ROOT/commands/verify.md"; then
+  pass "verify.md: scripted deflection response present"
+else
+  fail "verify.md: scripted deflection response missing"
+fi
+
+# Part 2: Recurrence tracking in extract-uat-issues.sh
+
+if grep -q "FAILED_IN_ROUNDS" "$PROJECT_ROOT/scripts/extract-uat-issues.sh"; then
+  pass "extract-uat-issues.sh: FAILED_IN_ROUNDS field referenced"
+else
+  fail "extract-uat-issues.sh: FAILED_IN_ROUNDS field missing"
+fi
+
+if grep -q "uat_round=" "$PROJECT_ROOT/scripts/extract-uat-issues.sh"; then
+  pass "extract-uat-issues.sh: uat_round header field present"
+else
+  fail "extract-uat-issues.sh: uat_round header field missing"
+fi
+
+if grep -q "count_uat_rounds" "$PROJECT_ROOT/scripts/extract-uat-issues.sh"; then
+  pass "extract-uat-issues.sh: uses count_uat_rounds from uat-utils"
+else
+  fail "extract-uat-issues.sh: missing count_uat_rounds usage"
+fi
+
+if grep -q "extract_round_issue_ids" "$PROJECT_ROOT/scripts/extract-uat-issues.sh"; then
+  pass "extract-uat-issues.sh: uses extract_round_issue_ids from uat-utils"
+else
+  fail "extract-uat-issues.sh: missing extract_round_issue_ids usage"
+fi
+
+# Part 2b: uat-utils.sh helpers
+
+if grep -q "^count_uat_rounds()" "$PROJECT_ROOT/scripts/uat-utils.sh"; then
+  pass "uat-utils.sh: count_uat_rounds function defined"
+else
+  fail "uat-utils.sh: count_uat_rounds function missing"
+fi
+
+if grep -q "^extract_round_issue_ids()" "$PROJECT_ROOT/scripts/uat-utils.sh"; then
+  pass "uat-utils.sh: extract_round_issue_ids function defined"
+else
+  fail "uat-utils.sh: extract_round_issue_ids function missing"
+fi
+
+# Part 2c: No Bash 4+ features (associative arrays)
+if grep -q 'declare -A' "$PROJECT_ROOT/scripts/extract-uat-issues.sh"; then
+  fail "extract-uat-issues.sh: uses 'declare -A' (Bash 4+ only, breaks macOS 3.2)"
+else
+  pass "extract-uat-issues.sh: no Bash 4+ associative arrays"
+fi
+
+# Part 3: Recurrence-aware remediation in vibe.md
+
+if grep -q "FAILED_IN_ROUNDS" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: FAILED_IN_ROUNDS field referenced in UAT Remediation"
+else
+  fail "vibe.md: FAILED_IN_ROUNDS field not referenced"
+fi
+
+if grep -q "failure_count descending" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: priority ordering by failure_count descending"
+else
+  fail "vibe.md: priority ordering directive missing"
+fi
+
+if grep -q "RECURRING" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: RECURRING annotation directive present"
+else
+  fail "vibe.md: RECURRING annotation directive missing"
+fi
+
+if grep -q "uat_round >= 3" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: round-based escalation threshold (>= 3) present"
+else
+  fail "vibe.md: round-based escalation threshold missing"
+fi
+
+if grep -q "Investigate WHY previous fixes failed" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: Scout root-cause investigation directive present"
+else
+  fail "vibe.md: Scout root-cause investigation directive missing"
+fi
+
+if grep -q "Prioritize recurring failures" "$PROJECT_ROOT/commands/vibe.md"; then
+  pass "vibe.md: Lead priority directive present"
+else
+  fail "vibe.md: Lead priority directive missing"
+fi
+
+echo ""
+echo "TOTAL: $PASS PASS, $FAIL FAIL out of $TOTAL"
+[ "$FAIL" -eq 0 ]

--- a/tests/extract-uat-issues.bats
+++ b/tests/extract-uat-issues.bats
@@ -65,7 +65,7 @@ issues: 1
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == *"uat_phase=03"* ]]
   [[ "${lines[0]}" == *"uat_issues_total=1"* ]]
-  [[ "${lines[1]}" == "P01-T2|major|Widget fails on edge case" ]]
+  [[ "${lines[1]}" == "P01-T2|major|Widget fails on edge case|1" ]]
 }
 
 @test "extract-uat-issues: multiple issues with mixed severity" {
@@ -109,9 +109,9 @@ issues: 3
 
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == *"uat_issues_total=3"* ]]
-  [[ "${lines[1]}" == "P01-T1|critical|First problem" ]]
-  [[ "${lines[2]}" == "P02-T2|minor|Second problem" ]]
-  [[ "${lines[3]}" == "D1|major|Found during testing" ]]
+  [[ "${lines[1]}" == "P01-T1|critical|First problem|1" ]]
+  [[ "${lines[2]}" == "P02-T2|minor|Second problem|1" ]]
+  [[ "${lines[3]}" == "D1|major|Found during testing|1" ]]
 }
 
 @test "extract-uat-issues: long description is preserved in full" {
@@ -140,7 +140,7 @@ issues: 1
   [ "$status" -eq 0 ]
   # Description must NOT be truncated — full 250 chars preserved
   [[ "${lines[1]}" != *"..."* ]]
-  [[ "${lines[1]}" == "P01-T1|major|${long_desc}" ]]
+  [[ "${lines[1]}" == "P01-T1|major|${long_desc}|1" ]]
 }
 
 @test "extract-uat-issues: no UAT file returns error marker" {
@@ -393,8 +393,8 @@ EOF
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == *"uat_phase=03"* ]]
   [[ "${lines[0]}" == *"uat_issues_total=2"* ]]
-  [[ "${lines[1]}" == "P01-T1|critical|Milestone issue one" ]]
-  [[ "${lines[2]}" == "P02-T1|minor|Milestone issue two" ]]
+  [[ "${lines[1]}" == "P01-T1|critical|Milestone issue one|1" ]]
+  [[ "${lines[2]}" == "P02-T1|minor|Milestone issue two|1" ]]
 }
 
 @test "extract-uat-issues: milestone path with no UAT file" {
@@ -431,4 +431,224 @@ EOF
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"uat_extract_status=complete"* ]]
+}
+
+# ============= Recurrence tracking tests =============
+
+@test "extract-uat-issues: header includes uat_round=1 when no archived rounds" {
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 1
+---
+
+### P01-T1: Failing test
+
+- **Result:** issue
+- **Issue:**
+  - Description: First failure
+  - Severity: major'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"uat_round=1"* ]]
+}
+
+@test "extract-uat-issues: issue line includes FAILED_IN_ROUNDS as 4th field" {
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 1
+---
+
+### P01-T1: Failing test
+
+- **Result:** issue
+- **Issue:**
+  - Description: First failure
+  - Severity: major'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  # 4th field should be "1" (current round only, no prior rounds)
+  [[ "${lines[1]}" == "P01-T1|major|First failure|1" ]]
+}
+
+@test "extract-uat-issues: recurrence detected from archived round files" {
+  # Create archived round 1 with P01-T1 failing
+  cat > "$PHASE_DIR/03-UAT-round-1.md" <<'EOF'
+---
+phase: 03
+status: issues_found
+---
+
+### P01-T1: Failing test
+
+- **Result:** issue
+- **Issue:**
+  - Description: Old failure
+  - Severity: major
+
+### P02-T1: Passing test
+
+- **Result:** pass
+EOF
+
+  # Current UAT has P01-T1 failing again
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 1
+---
+
+### P01-T1: Failing test
+
+- **Result:** issue
+- **Issue:**
+  - Description: Still failing
+  - Severity: major'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"uat_round=2"* ]]
+  # P01-T1 failed in round 1 and current round 2
+  [[ "${lines[1]}" == "P01-T1|major|Still failing|1,2" ]]
+}
+
+@test "extract-uat-issues: multiple archived rounds with mixed recurrence" {
+  # Round 1: P01-T1 and P02-T1 fail
+  cat > "$PHASE_DIR/03-UAT-round-1.md" <<'EOF'
+---
+phase: 03
+status: issues_found
+---
+
+### P01-T1: Test A
+
+- **Result:** issue
+- **Issue:**
+  - Description: Test A fails
+  - Severity: major
+
+### P02-T1: Test B
+
+- **Result:** issue
+- **Issue:**
+  - Description: Test B fails
+  - Severity: minor
+EOF
+
+  # Round 2: only P01-T1 fails (P02-T1 was fixed)
+  cat > "$PHASE_DIR/03-UAT-round-2.md" <<'EOF'
+---
+phase: 03
+status: issues_found
+---
+
+### P01-T1: Test A
+
+- **Result:** issue
+- **Issue:**
+  - Description: Test A still fails
+  - Severity: major
+
+### P02-T1: Test B
+
+- **Result:** pass
+EOF
+
+  # Current round 3: P01-T1 fails again, new P03-T1 also fails
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 2
+---
+
+### P01-T1: Test A
+
+- **Result:** issue
+- **Issue:**
+  - Description: Test A persistent
+  - Severity: major
+
+### P03-T1: Test C
+
+- **Result:** issue
+- **Issue:**
+  - Description: New failure
+  - Severity: minor'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"uat_round=3"* ]]
+  # P01-T1 failed in rounds 1, 2, and current round 3
+  [[ "${lines[1]}" == "P01-T1|major|Test A persistent|1,2,3" ]]
+  # P03-T1 is new — only current round 3
+  [[ "${lines[2]}" == "P03-T1|minor|New failure|3" ]]
+}
+
+@test "extract-uat-issues: zero-padded round filenames are handled" {
+  # Archived round with zero-padded filename
+  cat > "$PHASE_DIR/03-UAT-round-01.md" <<'EOF'
+---
+phase: 03
+status: issues_found
+---
+
+### P01-T1: Test
+
+- **Result:** issue
+- **Issue:**
+  - Description: Fails
+  - Severity: major
+EOF
+
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 1
+---
+
+### P01-T1: Test
+
+- **Result:** issue
+- **Issue:**
+  - Description: Still fails
+  - Severity: major'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"uat_round=2"* ]]
+  [[ "${lines[1]}" == "P01-T1|major|Still fails|1,2" ]]
+}
+
+@test "extract-uat-issues: discovered issues get FAILED_IN_ROUNDS field" {
+  create_uat_file '---
+phase: 03
+status: issues_found
+issues: 1
+---
+
+### D1: Discovered issue
+
+- **Result:** issue
+- **Issue:**
+  - Description: Found during testing
+  - Severity: minor'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-issues.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[1]}" == "D1|minor|Found during testing|1" ]]
 }


### PR DESCRIPTION
## What

UAT anti-breakout guardrail and per-test recurrence tracking for remediation prioritization.

Fixes #222

## Why

During UAT checkpoint interviews, Claude sometimes breaks out of the interview role to investigate/debug/fix issues. This wastes time and contaminates the user feedback loop. Additionally, tests that fail across multiple UAT rounds indicate deeper root-cause issues that need escalation — without recurrence tracking, these persistent failures get the same treatment as first-time issues.

## How

### Part 1: Anti-breakout guardrail (`commands/verify.md`)
- Added CRITICAL BOUNDARY block at Step 5 (checkpoint loop entry point)
- Prohibits investigating, debugging, or fixing bugs during UAT interviews
- Provides scripted deflection: "Issue recorded. Let's finish the remaining checkpoints first — remediation will address this immediately after."

### Part 2: Recurrence tracking (`scripts/extract-uat-issues.sh`, `scripts/uat-utils.sh`)
- New `count_uat_rounds(dir, phase_num)` — scans archived `{N}-UAT-round-*.md` files, returns max round number
- New `extract_round_issue_ids(round_file)` — AWK parser extracting test IDs with `Result: issue`
- Header now includes `uat_round={N}` (current round = archived + 1)
- Issue lines now have 4th pipe field: `ID|SEVERITY|DESCRIPTION|FAILED_IN_ROUNDS` (comma-separated list of prior rounds where the same test ID failed)
- Bash 3.2 compatible: uses temp file + grep instead of associative arrays

### Part 3: Recurrence-aware remediation (`commands/vibe.md`)
- Step 3: Priority ordering — sorts by failure_count descending, annotates recurring issues with `⚠ RECURRING (failed N/M rounds)`
- Step 5: Round-based escalation — when `uat_round >= 3`, forces ALL issues through `plan → execute` (overrides minor-only routing)
- Step 6: Scout prompt includes root-cause investigation directive for recurring issues; Lead prompt includes prioritization directive
- Step 7: Remediation summary includes per-test recurrence annotations

## Testing

- [x] Load plugin locally with `claude --plugin-dir .`
- [x] Test affected commands — 16 contract tests in `testing/verify-uat-recurrence.sh` (all pass)
- [x] 19 bats tests in `tests/extract-uat-issues.bats` (6 new + 6 updated, all pass)
- [x] No load errors
- [x] Existing commands still work — full `testing/run-all.sh` suite passes (1 pre-existing failure in crash-recovery.bats unrelated to this change)