### PR TITLE
fix(uat-remediation): skip legacy RESEARCH.md fallback during research stage

### DIFF
--- a/scripts/uat-remediation-state.sh
+++ b/scripts/uat-remediation-state.sh
@@ -259,13 +259,17 @@ emit_plan_metadata() {
     fi
   fi
 
-  # Check for existing research: per-plan first, then legacy
+  # Check for existing research: per-plan first, then legacy (plan/execute only).
+  # During the research stage, only per-plan research counts — the legacy file
+  # may be stale from a prior remediation round and must not trigger "already done".
   local per_plan_research="${PHASE_DIR}/${phase_prefix}-${next_mm}-RESEARCH.md"
-  local legacy_research="${PHASE_DIR}/${phase_prefix}-RESEARCH.md"
   if [ -f "$per_plan_research" ]; then
     research_path="$per_plan_research"
-  elif [ -f "$legacy_research" ]; then
-    research_path="$legacy_research"
+  elif [ "$stage" != "research" ]; then
+    local legacy_research="${PHASE_DIR}/${phase_prefix}-RESEARCH.md"
+    if [ -f "$legacy_research" ]; then
+      research_path="$legacy_research"
+    fi
   fi
 
   # Check if plan already exists for computed next_plan

--- a/tests/uat-remediation-state.bats
+++ b/tests/uat-remediation-state.bats
@@ -404,13 +404,41 @@ EOF
   echo "$output" | grep -q "^plan_path=$"
 }
 
-@test "get-or-init research_path finds legacy research" {
+@test "get-or-init research stage ignores legacy research" {
+  # Bug #232: legacy 03-RESEARCH.md from a prior round caused the research
+  # stage to report research_path as non-empty, making the orchestrator skip
+  # research for the new remediation round.
   echo "research" > "$PHASE_DIR/.uat-remediation-stage"
   touch "$PHASE_DIR/01-RESEARCH.md"
 
   run bash "$SCRIPTS_DIR/uat-remediation-state.sh" get-or-init "$PHASE_DIR" "major"
   [ "$status" -eq 0 ]
+  echo "$output" | grep -q "^research_path=$"
+}
+
+@test "get-or-init plan stage finds legacy research as fallback" {
+  # Legacy research IS a valid fallback for plan/execute stages (backward compat)
+  echo "plan" > "$PHASE_DIR/.uat-remediation-stage"
+  touch "$PHASE_DIR/01-RESEARCH.md"
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" get-or-init "$PHASE_DIR" "major"
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "^research_path=.*01-RESEARCH.md$"
+}
+
+@test "get-or-init research stage: many plans + legacy research still ignored" {
+  # Exact scenario from #232: 15 plans exist, per-plan research for some,
+  # plus stale legacy 03-RESEARCH.md. Research stage must NOT pick up the legacy.
+  echo "research" > "$PHASE_DIR/.uat-remediation-stage"
+  for i in $(seq -w 1 15); do touch "$PHASE_DIR/01-${i}-PLAN.md"; done
+  touch "$PHASE_DIR/01-12-RESEARCH.md" "$PHASE_DIR/01-13-RESEARCH.md" "$PHASE_DIR/01-15-RESEARCH.md"
+  touch "$PHASE_DIR/01-RESEARCH.md"
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" get-or-init "$PHASE_DIR" "major"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "^next_plan=16$"
+  # Must NOT find legacy research — per-plan 01-16-RESEARCH.md doesn't exist, legacy must be ignored
+  echo "$output" | grep -q "^research_path=$"
 }
 
 @test "get-or-init per-plan research takes priority over legacy" {


### PR DESCRIPTION
**Superseded by phase directory restructure (issue #234, branch `feat/phase-dir-restructure-234`).**

The restructure eliminates the legacy RESEARCH.md fallback entirely by isolating remediation artifacts into round-specific subdirectories (`remediation/P{NN}-{RR}-round/`). The bug is structurally impossible in the new layout.

---

_Original description:_

Fixes #232

The `emit_plan_metadata()` function in `uat-remediation-state.sh` unconditionally fell back to the legacy `{phase_prefix}-RESEARCH.md` file when no per-plan research file existed. During the `research` stage this is incorrect — the legacy file is stale from a prior remediation round.

**Fix**: Skip the legacy fallback when `stage = "research"`. Only per-plan research files should be reported during the research stage.