### PR TITLE
fix(routing): discussion-aware confirmation alternatives and continuation mode

### DIFF
--- a/commands/discuss.md
+++ b/commands/discuss.md
@@ -36,7 +36,8 @@ Phase state:
 
 1. If `$ARGUMENTS` contains a number N, target phase N.
 2. If the target phase has a `*-CONTEXT.md` file with `pre_seeded: true` in its YAML frontmatter (remediation phase): WARN the user that this phase has pre-seeded UAT context and ask whether they want to re-discuss (which overwrites the pre-seeded content) or skip discussion and proceed to planning.
-3. Otherwise auto-detect: find the first phase directory without a `*-CONTEXT.md` file. If all phases already have context: STOP "All phases discussed."
+3. If the target phase has a `*-CONTEXT.md` file WITHOUT `pre_seeded: true` (organic discussion already happened): This is a **continuation discussion**. Display: "Phase {NN} already has discussion context. Continuing to explore additional topics." The Discussion Engine's Step 1.5 will handle loading existing decisions as baseline.
+4. Otherwise auto-detect: find the first phase directory without a `*-CONTEXT.md` file. If all phases already have context: STOP "All phases discussed. Specify a phase number to deepen an existing discussion."
 
 ## Execute
 

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -154,6 +154,14 @@ Every mode triggers confirmation via AskUserQuestion before executing, with cont
 - **Exception:** `--yolo` skips all confirmation gates. Error guards (missing roadmap, uninitialized project) still halt.
 - **Exception:** Flags skip confirmation (explicit intent).
 
+**Discussion-aware alternatives (NON-NEGOTIABLE):** Alternatives must reflect whether discussion has already happened for the target phase. Never offer "discuss this phase" when a `{NN}-CONTEXT.md` exists — discussion is already complete.
+
+| Routing state | Recommended | Alternatives |
+|---|---|---|
+| `needs_discussion` | "Discuss phase {NN}" | "Skip discussion and plan directly", "View phase goal first" |
+| `needs_plan_and_execute` | "Plan and execute phase {NN}" | "Plan only (review before executing)", "Deepen discussion (explore additional topics beyond what's already captured)" |
+| `needs_execute` | "Execute phase {NN}" | "Review plans first", "Deepen discussion (revisit scope with existing insights as baseline)" |
+
 ## Modes
 
 ### Mode: Init Redirect
@@ -261,6 +269,8 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
 
 **Guard:** Initialized, phase exists in roadmap.
 **Phase auto-detection:** First phase without `*-CONTEXT.md`. All discussed: STOP "All phases discussed. Specify: `/vbw:vibe --discuss N`"
+
+**Continuation mode:** When the target phase already has a `{NN}-CONTEXT.md`, this is a **continuation discussion** — not a fresh one. Display: "Phase {NN} already has discussion context. Continuing to explore additional topics." The Discussion Engine will load existing decisions as baseline and focus on uncovered gray areas.
 
 **Steps:**
 1. Determine target phase from $ARGUMENTS or auto-detection.

--- a/references/discussion-engine.md
+++ b/references/discussion-engine.md
@@ -40,6 +40,13 @@ Same gray area, two modes:
 - "Block submission, show connectivity state (pessimistic)"
 - "Let me explain..."
 
+## Step 1.5: Detect Continuation
+
+Before orienting, check if `{NN}-CONTEXT.md` already exists for the target phase.
+
+- **If no CONTEXT.md exists:** Fresh discussion — proceed to Step 2 normally.
+- **If CONTEXT.md exists:** This is a **continuation discussion**. Read the existing file to understand what was already covered (Decisions sections, Deferred Ideas, Phase Boundary). Proceed to Step 2 with this context loaded.
+
 ## Step 2: Orient
 
 Read the phase goal from ROADMAP.md and **think** about what gray areas exist. No keyword matching. No predefined templates. Pure analysis.
@@ -47,6 +54,16 @@ Read the phase goal from ROADMAP.md and **think** about what gray areas exist. N
 The engine asks itself:
 
 > "What decisions about this phase could go multiple ways and would change what gets built?"
+
+**Continuation mode:** When existing CONTEXT.md was loaded in Step 1.5, the question becomes:
+
+> "What decisions about this phase are NOT already captured in the existing discussion context? What new angles, edge cases, or deeper implications haven't been explored yet?"
+
+Exclude gray areas already covered by existing `## Decisions` subsections. Focus on:
+- Topics the user didn't select in the original discussion
+- Deeper implications of decisions already made (second-order effects)
+- Edge cases or integration concerns that surface after the first discussion
+- Deferred ideas that the user may want to revisit
 
 Generate phase-specific gray areas. These must be concrete, not categorical.
 
@@ -63,8 +80,9 @@ Profile depth controls gray area count:
 | default | 3-5 |
 | production | 4-6 |
 
-Present gray areas as a multi-select using AskUserQuestion: "Which areas should we discuss?"
-No "skip all" option — if the user ran discuss, give them real choices.
+Present gray areas as a multi-select using AskUserQuestion.
+- **Fresh discussion:** "Which areas should we discuss?" No "skip all" option — if the user ran discuss, give them real choices.
+- **Continuation:** "These topics weren't covered in the previous discussion. Which would you like to explore?" Include a "None — discussion is complete" option since the user may have only wanted to check.
 
 > **AskUserQuestion spacing**: output 3–4 blank lines before the tool call (the dialog obscures trailing text).
 
@@ -94,7 +112,14 @@ Resolve the CONTEXT filename:
 ```bash
 CONTEXT_NAME=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/resolve-artifact-path.sh context "{phase-dir}")
 ```
-Write `${CONTEXT_NAME}` to the phase directory:
+
+**Continuation mode (CONTEXT.md already exists):** Do NOT overwrite. Merge new insights into the existing file:
+- Add new `### [Gray Area]` subsections under `## Decisions` (after existing subsections)
+- Append new entries to `## Deferred Ideas` if any surfaced
+- Update the `Gathered:` date to today's date
+- Do NOT remove, rewrite, or reorder existing content — the original discussion decisions are still valid
+
+**Fresh discussion:** Write `${CONTEXT_NAME}` to the phase directory:
 
 ```markdown
 # Phase N: Name — Context


### PR DESCRIPTION
## What

After phase discussion completes and `/vbw:vibe` re-detects state as `needs_plan_and_execute`, the confirmation gate alternatives included "discuss this phase" as if discussion never happened.

## Why

The Confirmation Gate instruction said "contextual options (recommended action + alternatives)" but never specified what alternatives to show per routing state. The LLM generated generic alternatives including "discuss this phase" even when `{NN}-CONTEXT.md` exists (discussion already complete).

## How

**1. Explicit alternatives table** (`commands/vibe.md`): Added a discussion-aware alternatives specification below the Confirmation Gate section. Each routing state now has explicit recommended + alternative options:
- `needs_discussion`: Discuss (recommended), Skip discussion, View phase goal
- `needs_plan_and_execute`: Plan + Execute (recommended), Plan only, Deepen discussion
- `needs_execute`: Execute (recommended), Review plans, Deepen discussion

**2. Discussion Engine continuation mode** (`references/discussion-engine.md`):
- Added Step 1.5 (Detect Continuation) to check for existing CONTEXT.md
- Updated Step 2 (Orient) to exclude already-covered gray areas in continuation mode
- Updated Step 4 (Capture) to merge new insights instead of overwriting

**3. Standalone discuss.md**: Updated Phase Resolution to detect and handle organic continuation discussions with appropriate messaging.

## Testing

- [x] `bash testing/run-all.sh` passes (96 files, 0 failures)
- [x] Markdown-only changes — behavioral testing is Tier 3 (smoke test in sandbox)
- [x] All changes are additive (new sections/guidance), no existing behavior removed

Fixes #293