### PR TITLE
fix(archive): use Write tool for SHIPPED.md creation

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1070,7 +1070,7 @@ FAIL -> STOP with remediation suggestions. WARN -> proceed with warnings.
    ```
    Compiles final rolling context before artifacts move to milestones/. Fail-open.
    When `rolling_summary=false`: skip.
-5. Archive: `mkdir -p .vbw-planning/milestones/{SLUG}`. Move ROADMAP.md, STATE.md, and phases/ to milestones/{SLUG}/. If `.vbw-planning/CONTEXT.md` exists, move it to milestones/{SLUG}/CONTEXT.md. Write SHIPPED.md. Delete stale RESUME.md.
+5. Archive: `mkdir -p .vbw-planning/milestones/{SLUG}`. Move ROADMAP.md, STATE.md, and phases/ to milestones/{SLUG}/. If `.vbw-planning/CONTEXT.md` exists, move it to milestones/{SLUG}/CONTEXT.md. Use the **Write** tool (not Bash) to create `.vbw-planning/milestones/{SLUG}/SHIPPED.md` — this ensures PostToolUse hooks fire for artifact tracking. Delete stale RESUME.md.
 5b. **Persist project-level state:** After archiving, run:
    ```bash
    bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/persist-state-after-ship.sh \


### PR DESCRIPTION
## Linked Issue

Fixes #209

## What

Changed one line in Archive mode step 5 of `commands/vibe.md` to explicitly instruct the LLM to use the **Write** tool (not Bash) when creating `SHIPPED.md` during milestone archiving.

## Why

The previous instruction "Write SHIPPED.md" was ambiguous — the LLM sometimes interpreted it as a Bash `cat > ... << EOF` heredoc. This bypassed any PostToolUse hooks registered on the `Write` matcher in `.claude/settings.local.json`, silently breaking user workflows that depend on artifact tracking (e.g., Obsidian sync, notification systems, dashboards).

The root cause is the ambiguous verb "Write" which could mean either the English verb or the Claude Code Write tool. The fix disambiguates by explicitly naming the tool and explaining why.

## How

- **`commands/vibe.md`** (line 1073): Replaced "Write SHIPPED.md" with "Use the **Write** tool (not Bash) to create `.vbw-planning/milestones/{SLUG}/SHIPPED.md` — this ensures PostToolUse hooks fire for artifact tracking." This follows the same explicit tool-direction pattern used elsewhere in vibe.md (e.g., Scout "writes the file using its Write tool" at line 827).

## Acceptance criteria verification

1. **Archive mode step 5 explicitly instructs Write tool usage**: Satisfied — the instruction now says "Use the **Write** tool (not Bash)" with bold emphasis and parenthetical exclusion.
2. **Full target path included**: Satisfied — `.vbw-planning/milestones/{SLUG}/SHIPPED.md` is specified, matching the `{SLUG}` variable from step 1.
3. **PostToolUse hooks will fire**: Satisfied — verified that `file-guard.sh` (PreToolUse) allows writes to milestone root files (only blocks `milestones/*/phases/*`), and the Write tool's PostToolUse dispatch chain will fire correctly for SHIPPED.md.

## Testing

- [x] `bash testing/run-all.sh` — all 2381 BATS tests pass, 28/28 contract checks pass, 1/1 lint checks pass
- [x] No new tests needed — this is a Tier 3 change (LLM instruction wording). The real validation is that the LLM uses the Write tool when following these instructions in a live session.
- [x] Verified `file-guard.sh` won't block the Write tool on the SHIPPED.md path
- [x] Verified downstream SHIPPED.md consumers (`phase-detect.sh`, `rename-default-milestone.sh`, `session-start.sh`) only check file existence/content, not creation mechanism

## QA summary

- **3 rounds completed** (minimum requirement met)
- **0 total findings** across all rounds (0 critical, 0 high, 0 medium, 0 low)
- **0 false positives**
- All 3 rounds independently verified: file-guard exemption, PostToolUse hook chain, downstream consumers, scope boundary, and adjacent step consistency
