### PR TITLE
fix(vibe): add explicit AskUserQuestion tool-call directives at confirmation gates

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -423,7 +423,7 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
 
 ### Confirmation Gate
 
-Every mode triggers confirmation before executing. **Call AskUserQuestion** with the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`), providing the recommended option and alternatives from the table below.
+Every mode triggers confirmation before executing. **Call AskUserQuestion** with the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`), providing the recommended option and alternatives from the table below where listed. For simple yes/no confirmations without a table entry, offer the affirmative action as recommended and a "Skip" or "Not now" alternative.
 - **Exception:** `--yolo` skips all confirmation gates. Error guards (missing roadmap, uninitialized project) still halt.
 - **Exception:** Flags skip confirmation (explicit intent).
 


### PR DESCRIPTION
## Linked Issue

Fixes #324
Also filed #325 (pre-existing Milestone UAT Recovery two-step pattern, discovered during QA)

## What

Adds explicit `→ AskUserQuestion:` tool-call directives to the `/vbw:vibe` command's routing table and strengthens the Confirmation Gate section to ensure the model calls the `AskUserQuestion` tool instead of rendering options as plain text.

**Modified file:** `commands/vibe.md` (only file changed)

## Why

The model was rendering confirmation options as plain text numbered lists instead of calling the `AskUserQuestion` tool. Root cause: the AskUserQuestion tool name appeared once in the Confirmation Gate preamble (line 426), far from the routing table (lines 293-313) where the model makes routing decisions. Per Anthropic prompt engineering best practices, tool directives placed far from the action point decay into plain text in long prompts.

## How

- **`commands/vibe.md` — Routing table (lines 294-304):** Added `→ AskUserQuestion:` prefix to all 10 confirmation-bearing rows in the Confirmation column. This co-locates the tool-call directive with each routing decision. Rows without confirmation (Init redirect, Verify) were left unchanged.

- **`commands/vibe.md` — Confirmation Gate preamble (line 426):** Changed from passive "Every mode triggers confirmation via AskUserQuestion" to imperative "**Call AskUserQuestion** with the question from the routing table's Confirmation column." Added fallback guidance for states without explicit alternatives-table entries.

- **`commands/vibe.md` — AskUserQuestion parameter note (line 438):** Added guidance to set `isRecommended` flag on the recommended option and add 3-4 blank lines before the call (dialog obscures trailing text).

- **`commands/vibe.md` — Path 2 natural language (line 268):** Changed from "ALWAYS confirm interpreted intent via AskUserQuestion" to "ALWAYS call AskUserQuestion to confirm interpreted intent" — action directive instead of intent description.

## Acceptance criteria verification

1. ✅ Routing table Confirmation column contains explicit `→ AskUserQuestion:` directives for every row requiring user confirmation — rows 2, 3 (auto_uat=false), 3.5 (auto_uat=false), 4 (auto_uat=false), 5, 6, 8, 9, 10, 11
2. ✅ Confirmation Gate preamble says "Call AskUserQuestion" — line 426
3. ✅ Confirmation Gate includes AskUserQuestion parameter guidance — line 438 (isRecommended flag, spacing)
4. ✅ Path 2 says "call AskUserQuestion to confirm" — line 268
5. ✅ `bash testing/verify-commands-contract.sh` passes (29/29 contract checks)
6. ✅ `bash testing/run-all.sh` passes (lint 1/1, contract 29/29, BATS 2428/0)

## Testing

- [x] Load plugin locally with `claude --plugin-dir .`
- [x] `bash testing/verify-commands-contract.sh` — 29/29 passed
- [x] `bash testing/run-all.sh` — lint 1/1, contract 29/29, BATS 2428 passed / 0 failed
- [ ] Smoke test: run `/vbw:vibe` on a `needs_discussion` state and verify AskUserQuestion tool is called (Tier 3 — requires live session)

## QA Summary

- **Rounds:** 4 (3 minimum required)
- **Model:** Claude Opus 4.6
- **Findings:**
  - Round 1: 0 findings
  - Round 2: 0 findings
  - Round 3: 2 low observations
    - QA-R3-1 (low/observation): Milestone UAT Recovery two-step AskUserQuestion pattern — pre-existing, filed as #325
    - QA-R3-2 (low/observation): Alternatives table only covers 3 of 10 states — fixed in commit `6eb6450` by adding fallback guidance
  - Round 4: 0 findings (clean exit)
- **Fixed:** 1 finding (QA-R3-2, commit `6eb6450`)
- **Filed as separate issue:** 1 finding (QA-R3-1 → #325)
- **False positives:** 0