### PR TITLE
feat(lifecycle): auto-promote known issues to STATE.md Todos

### DIFF
--- a/commands/qa.md
+++ b/commands/qa.md
@@ -209,6 +209,12 @@ Note: Continuous verification handled by hooks. This command is for deep, on-dem
       bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/track-known-issues.sh sync-verification "{phase-dir}" "{VERIF_PATH}" 2>/dev/null || true
       ```
 
+      After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos`:
+
+      ```bash
+      bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/track-known-issues.sh promote-todos "{phase-dir}" 2>/dev/null || true
+      ```
+
       Phase-level `VERIFICATION.md` merges newly found pre-existing issues into `{phase-dir}/known-issues.json` without clearing the execution-time backlog. Round-scoped `R{RR}-VERIFICATION.md` is authoritative for unresolved known issues and prunes/clears the registry when issues are fixed.
 
     - Then run:

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -107,6 +107,12 @@ fi`
    - Most recent SUMMARY.md from `.vbw-planning/phases/` — last work
    - Skip missing files. **Never read from `.vbw-planning/milestones/`.**
 2. **Compute progress from phase-detect.sh output:** Use the pre-computed `phase_count`, `next_phase`, `next_phase_state`, `next_phase_plans`, `next_phase_summaries`, `uat_issues_phase`, `uat_issues_slug`, `uat_issues_phases`, and `uat_issues_count` values. Map `next_phase_state` to display: `needs_uat_remediation` → "⚠ Needs remediation", `needs_verification` → "⏳ Needs UAT verification", `needs_plan_and_execute` → "not started", `needs_execute` → "in progress", `all_done` → "complete". **Per-phase status:** any phase whose number appears in the comma-separated `uat_issues_phases` list has unresolved UAT issues — mark it "⚠ Needs remediation". Only mark a phase as "✓ Done" if its number is NOT in `uat_issues_phases` and it has completed execution (SUMMARY count ≥ PLAN count). Phases not yet executed are "not started".
+   **Known issues check:** For each phase directory, run:
+   ```bash
+   bash "/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
+   bash "/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/track-known-issues.sh" status "{phase-dir}" 2>/dev/null
+   ```
+   Parse `known_issues_count` from the status output. For each phase with `known_issues_count > 0`, include in the dashboard after the phase table: `⚠ Phase {NN}: N known issue(s) deferred — run /vbw:list-todos to review`. Omit for phases with zero known issues. The `promote-todos` call is a backfill — it ensures any known issues not yet in `STATE.md ## Todos` are promoted on resume.
 3. **Detect interrupted builds:** If `.execution-state.json` status="running": all SUMMARYs present = completed since last session; some missing = interrupted.
 4. **Present dashboard:** Phase Banner "Context Restored / {project name}" with: core value, phase/progress, overall progress bar, key decisions, todos, blockers (⚠), last completed, build status (✓ completed / ⚠ interrupted), session notes. Run `bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/suggest-next.sh resume`.
 

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -349,6 +349,10 @@ Before entering Verify mode (UAT), check `qa_status` from phase-detect output:
   ```bash
   bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{QA-output-path}" 2>/dev/null || true
   ```
+  After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos`:
+  ```bash
+  bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
+  ```
   Then run the deterministic gate:
   ```bash
   bash "${VBW_PLUGIN_ROOT}/scripts/qa-result-gate.sh" "{phase-dir}"
@@ -411,6 +415,10 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
     - After QA persists `{verification_path}`, immediately sync tracked known issues:
       ```bash
       bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{verification_path}" 2>/dev/null || true
+      ```
+    - After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos` so they are visible via `/vbw:list-todos` and `/vbw:resume`:
+      ```bash
+      bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
       ```
     - **Include in QA task description:** "In addition to verifying the remediation plan's own must_haves, you MUST re-verify each original FAIL from the VERIFICATION HISTORY section. For each FAIL_ID: if classified as code-fix, verify the code now matches the plan; if classified as plan-amendment, verify the original PLAN.md has been updated with the actual approach and rationale; if classified as process-exception, verify the exception is documented with non-fixable justification and that the justification is credible for this FAIL; if code-fix or plan-amendment still appears viable, keep the FAIL open. Any original FAIL that has not been addressed by one of these three paths is still a FAIL."
     - **Include in QA task description when a KNOWN ISSUES block is present:** "Tracked phase known issues are not informational in remediation rounds. Re-check each tracked known issue and return only the ones that remain unresolved in `pre_existing_issues`. A clean remediation QA run must return an empty `pre_existing_issues` array so `{phase-dir}/known-issues.json` can clear."

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -749,10 +749,6 @@ This loop runs inline during execution — no second `/vbw:vibe` call needed. If
    - Run `compile-verify-context.sh --remediation-only {phase-dir}` to get compounded verification history plus the current round's plan/summary context only
    - Spawn QA agent as subagent — writes to `{verification_path}` (from `qa-remediation-state.sh` metadata)
      - Output path: `{round_dir}/R{RR}-VERIFICATION.md` — phase-level VERIFICATION.md stays frozen
-     - After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos`:
-       ```bash
-       bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
-       ```
      - After QA persists `{verification_path}`, immediately sync tracked known issues from that round artifact:
        ```bash
        bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{verification_path}" 2>/dev/null || true

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -650,7 +650,7 @@ After collecting Dev-surfaced pre-existing issues from SUMMARY.md files, persist
 bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-summaries "{phase-dir}" 2>/dev/null || true
 ```
 
-This writes `{phase-dir}/known-issues.json`. The human-readable `Discovered Issues` block later in the execute summary is supplemental — the JSON registry is the authoritative phase backlog. Unresolved issues that survive QA and remediation are auto-promoted to `STATE.md ## Todos` via `promote-todos`, making them visible in `/vbw:list-todos` and `/vbw:resume`. Unresolved issues that survive QA and remediation are auto-promoted to `STATE.md ## Todos` via `promote-todos`, making them visible in `/vbw:list-todos` and `/vbw:resume`.
+This writes `{phase-dir}/known-issues.json`. The human-readable `Discovered Issues` block later in the execute summary is supplemental — the JSON registry is the authoritative phase backlog. Unresolved issues that survive QA and remediation are auto-promoted to `STATE.md ## Todos` via `promote-todos`, making them visible in `/vbw:list-todos` and `/vbw:resume`.
 
 If execution completed but the session ended before QA actually started, standalone/resumed phase-level QA entrypoints must rerun this `sync-summaries` backfill before the first `VERIFICATION.md` is written.
 
@@ -686,10 +686,6 @@ VERIF_BASE="${VERIF_NAME%.md}"
 After QA writes its VERIFICATION artifact, sync tracked known issues from that artifact before reading the gate:
 ```bash
 bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{verification-output-path}" 2>/dev/null || true
-```
-After sync, auto-promote surviving known issues to `STATE.md ## Todos`:
-```bash
-bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
 ```
 After sync, auto-promote surviving known issues to `STATE.md ## Todos`:
 ```bash

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -1008,7 +1008,7 @@ Phase {NN}: {name} -- Built
 ```
 
 **"What happened" (NRW-02):** If config `plain_summary` is true (default), append 2-4 plain-English sentences between QA and Next Up. No jargon. Source from SUMMARY.md files + QA result. If false, skip.
-and auto-promoted surviving entries to `STATE.md ## Todos` via `promote-todos` before rendering this summary. The display block is informational only — do not
+
 **Discovered Issues:** If any Dev or QA agent reported pre-existing failures, out-of-scope bugs, or issues unrelated to this phase's work, collect and de-duplicate them by test name and file (when the same test+file pair appears with different error messages, keep the first error message encountered), then list them in the summary output between "What happened" and Next Up. To keep context size manageable, cap the displayed list at 20 entries; if more exist, show the first 20 and append `... and {N} more`. Format each bullet as `⚠ testName (path/to/file): error message`:
 ```text
   Discovered Issues:

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -650,7 +650,7 @@ After collecting Dev-surfaced pre-existing issues from SUMMARY.md files, persist
 bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-summaries "{phase-dir}" 2>/dev/null || true
 ```
 
-This writes `{phase-dir}/known-issues.json`. The human-readable `Discovered Issues` block later in the execute summary is supplemental — the JSON registry is the authoritative phase backlog.
+This writes `{phase-dir}/known-issues.json`. The human-readable `Discovered Issues` block later in the execute summary is supplemental — the JSON registry is the authoritative phase backlog. Unresolved issues that survive QA and remediation are auto-promoted to `STATE.md ## Todos` via `promote-todos`, making them visible in `/vbw:list-todos` and `/vbw:resume`. Unresolved issues that survive QA and remediation are auto-promoted to `STATE.md ## Todos` via `promote-todos`, making them visible in `/vbw:list-todos` and `/vbw:resume`.
 
 If execution completed but the session ended before QA actually started, standalone/resumed phase-level QA entrypoints must rerun this `sync-summaries` backfill before the first `VERIFICATION.md` is written.
 
@@ -686,6 +686,14 @@ VERIF_BASE="${VERIF_NAME%.md}"
 After QA writes its VERIFICATION artifact, sync tracked known issues from that artifact before reading the gate:
 ```bash
 bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{verification-output-path}" 2>/dev/null || true
+```
+After sync, auto-promote surviving known issues to `STATE.md ## Todos`:
+```bash
+bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
+```
+After sync, auto-promote surviving known issues to `STATE.md ## Todos`:
+```bash
+bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
 ```
 - Phase-level VERIFICATION writes merge new pre-existing issues into the existing registry without clearing the execution-time backlog.
 - Round-scoped `R{RR}-VERIFICATION.md` writes are authoritative for unresolved known issues and may prune or clear `{phase-dir}/known-issues.json`.
@@ -745,9 +753,17 @@ This loop runs inline during execution — no second `/vbw:vibe` call needed. If
    - Run `compile-verify-context.sh --remediation-only {phase-dir}` to get compounded verification history plus the current round's plan/summary context only
    - Spawn QA agent as subagent — writes to `{verification_path}` (from `qa-remediation-state.sh` metadata)
      - Output path: `{round_dir}/R{RR}-VERIFICATION.md` — phase-level VERIFICATION.md stays frozen
+     - After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos`:
+       ```bash
+       bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
+       ```
      - After QA persists `{verification_path}`, immediately sync tracked known issues from that round artifact:
        ```bash
        bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" sync-verification "{phase-dir}" "{verification_path}" 2>/dev/null || true
+       ```
+     - After sync-verification, auto-promote surviving known issues to `STATE.md ## Todos`:
+       ```bash
+       bash "${VBW_PLUGIN_ROOT}/scripts/track-known-issues.sh" promote-todos "{phase-dir}" 2>/dev/null || true
        ```
      - If `compile-verify-context.sh` emits a `KNOWN ISSUES` block, include in QA's task description: "Tracked phase known issues are not informational in remediation rounds. Re-check each tracked known issue and return only the ones that remain unresolved in `pre_existing_issues`. A clean remediation QA run must return an empty `pre_existing_issues` array so `{phase-dir}/known-issues.json` can clear."
      - Include the compiled verify context output in QA's task description
@@ -996,7 +1012,7 @@ Phase {NN}: {name} -- Built
 ```
 
 **"What happened" (NRW-02):** If config `plain_summary` is true (default), append 2-4 plain-English sentences between QA and Next Up. No jargon. Source from SUMMARY.md files + QA result. If false, skip.
-
+and auto-promoted surviving entries to `STATE.md ## Todos` via `promote-todos` before rendering this summary. The display block is informational only — do not
 **Discovered Issues:** If any Dev or QA agent reported pre-existing failures, out-of-scope bugs, or issues unrelated to this phase's work, collect and de-duplicate them by test name and file (when the same test+file pair appears with different error messages, keep the first error message encountered), then list them in the summary output between "What happened" and Next Up. To keep context size manageable, cap the displayed list at 20 entries; if more exist, show the first 20 and append `... and {N} more`. Format each bullet as `⚠ testName (path/to/file): error message`:
 ```text
   Discovered Issues:
@@ -1004,7 +1020,7 @@ Phase {NN}: {name} -- Built
     ⚠ {issue-2}
   Registry: {phase-dir}/known-issues.json
 ```
-This display is supplemental to the phase registry. The orchestrator should already have synced these issues into `{phase-dir}/known-issues.json` before rendering this summary. Do NOT create todos automatically or enter an interactive loop here. If no discovered issues: omit the section entirely. After displaying discovered issues, STOP. Do not take further action.
+This display is supplemental to the phase registry. The orchestrator should already have synced these issues into `{phase-dir}/known-issues.json` and auto-promoted surviving entries to `STATE.md ## Todos` via `promote-todos` before rendering this summary. The display block is informational only — do not enter an interactive loop here. If no discovered issues: omit the section entirely. After displaying discovered issues, STOP. Do not take further action.
 
 Run `bash "${VBW_PLUGIN_ROOT}/scripts/suggest-next.sh" execute {qa-result}` and display output.
 

--- a/scripts/list-todos.sh
+++ b/scripts/list-todos.sh
@@ -141,11 +141,13 @@ parse_todo_line() {
   # Strip leading "- "
   text="${line#- }"
 
-  # Extract priority
+  # Extract priority/category
   if [[ "$text" == "[HIGH] "* ]]; then
     priority="high"
   elif [[ "$text" == "[low] "* ]]; then
     priority="low"
+  elif [[ "$text" == "[KNOWN-ISSUE] "* ]]; then
+    priority="known-issue"
   else
     priority="normal"
   fi
@@ -259,11 +261,13 @@ main() {
     case "$pri" in
       high) pri_tag="[HIGH] " ;;
       low) pri_tag="[low] " ;;
+      known-issue) pri_tag="[KNOWN-ISSUE] " ;;
     esac
 
     # Strip priority prefix and date suffix for clean display
     display_text="${text#\[HIGH\] }"
     display_text="${display_text#\[low\] }"
+    display_text="${display_text#\[KNOWN-ISSUE\] }"
     display_text=$(echo "$display_text" | sed 's/ *(added [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})$//')
 
     age_suffix=""

--- a/scripts/list-todos.sh
+++ b/scripts/list-todos.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # list-todos.sh — Extract and format pending todos from STATE.md
 #
 # Usage: list-todos.sh [priority-filter]
-#   priority-filter: optional "high", "low", or "normal" (case-insensitive)
+#   priority-filter: optional "high", "low", "known-issue", or "normal" (case-insensitive)
 #
 # Resolves milestone-scoped STATE.md, extracts ## Todos (or ### Pending Todos
 # for legacy/pre-migration STATE.md), parses priority tags and dates, computes

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -879,3 +879,25 @@ case "$CMD" in
     fi
     ;;
 esac
+
+# Known issues hint (skip for init/help/uninstall)
+case "$CMD" in
+  init|help|update|whats-new|uninstall) ;;
+  *)
+    if [ "$has_project" = true ] && [ -d "$PHASES_DIR" ]; then
+      _ki_total=0
+      while IFS= read -r _ki_dir; do
+        [ -d "$_ki_dir" ] || continue
+        _ki_file="$_ki_dir/known-issues.json"
+        if [ -f "$_ki_file" ]; then
+          _ki_count=$(jq -r '.issues | length' "$_ki_file" 2>/dev/null || echo "0")
+          _ki_total=$(( _ki_total + _ki_count ))
+        fi
+      done < <(find "$PHASES_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+      if [ "$_ki_total" -gt 0 ]; then
+        echo ""
+        echo "Note: $_ki_total known issue(s) deferred across phases — visible in /vbw:list-todos"
+      fi
+    fi
+    ;;
+esac

--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -590,8 +590,10 @@ promote_todos() {
 
   if [ -z "$todos_section" ]; then
     # Pass 2: legacy ### Pending Todos subsection (pre-migration STATE.md)
+    # Stop at ### Completed Todos or any ## heading — explicit boundary
     todos_section=$(printf '%s\n' "$state_content" | awk '
       /^### Pending Todos$/ { found=1; next }
+      found && /^### Completed Todos$/ { exit }
       found && /^##/ { exit }
       found && /[^ \t]/ { print }
     ')
@@ -658,22 +660,30 @@ promote_todos() {
 
   # Replace "None." placeholder in Todos section, or append to existing todos
   # Build awk anchor pattern from todo_anchor (escaping for regex)
-  local awk_anchor
+  local awk_anchor awk_stop_pattern
   awk_anchor=$(printf '%s' "$todo_anchor" | sed 's/[.[\*^$()+?{|]/\\&/g')
+  if [ "$todo_anchor" = "### Pending Todos" ]; then
+    # Legacy layout: stop explicitly at ### Completed Todos or any ## heading
+    # (^##) already catches ### headings since ### starts with ##; the
+    # explicit (^### Completed Todos$) documents the expected boundary)
+    awk_stop_pattern='(^### Completed Todos$)|(^##)'
+  else
+    awk_stop_pattern='^##'
+  fi
 
   if printf '%s' "$todos_section" | grep -qE '^\s*None\.?\s*$'; then
     # Replace the placeholder with new entries
-    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" awk '
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" AWK_STOP="$awk_stop_pattern" awk '
       $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
-      in_todos && /^##/ { in_todos=0; print; next }
+      in_todos && $0 ~ ENVIRON["AWK_STOP"] { in_todos=0; print; next }
       in_todos && /^[[:space:]]*None\.?[[:space:]]*$/ { print ENVIRON["ENTRIES"]; in_todos=0; next }
       { print }
     ' > "$tmp_file"
   else
     # Append new entries before the next section heading after the anchor
-    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" awk '
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" AWK_STOP="$awk_stop_pattern" awk '
       $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
-      in_todos && /^##/ { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
+      in_todos && $0 ~ ENVIRON["AWK_STOP"] { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
       { print }
       END { if (in_todos) { print ENVIRON["ENTRIES"] } }
     ' > "$tmp_file"

--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -575,9 +575,29 @@ promote_todos() {
   local state_content
   state_content=$(cat "$state_path")
 
-  # Extract the ## Todos section (or ## Todo) lines for dedup checking
-  local todos_section
-  todos_section=$(printf '%s\n' "$state_content" | sed -n '/^## Todo/,/^## /{ /^## Todo/d; /^## [^T]/d; p; }')
+  # Extract the todos section for dedup checking — two-pass approach mirroring list-todos.sh
+  local todos_section todo_anchor
+  # Pass 1: flat items directly under ## Todos (not inside ### subsections)
+  todos_section=$(printf '%s\n' "$state_content" | awk '
+    /^## Todos?$/ { found=1; next }
+    found && /^##/ { exit }
+    found && /^### / { sub_found=1; next }
+    found && sub_found && /^##/ { exit }
+    found && !sub_found && /^- / { print }
+  ')
+  todo_anchor="## Todos"
+
+  if [ -z "$todos_section" ]; then
+    # Pass 2: legacy ### Pending Todos subsection (pre-migration STATE.md)
+    todos_section=$(printf '%s\n' "$state_content" | awk '
+      /^### Pending Todos$/ { found=1; next }
+      found && /^##/ { exit }
+      found && /^- / { print }
+    ')
+    if [ -n "$todos_section" ]; then
+      todo_anchor="### Pending Todos"
+    fi
+  fi
 
   local phase_num
   phase_num=$(phase_number)
@@ -603,12 +623,11 @@ promote_todos() {
       error_msg="${error_msg:0:77}..."
     fi
 
-    # Check if already tracked: line contains both test name and file path
+    # Dedup by exact structured key matching the generated line format
     local is_dup=false
-    if printf '%s' "$todos_section" | grep -qF "$test_name"; then
-      if printf '%s' "$todos_section" | grep -F "$test_name" | grep -qF "$file_path"; then
-        is_dup=true
-      fi
+    local dedup_key="[KNOWN-ISSUE] ${test_name} (${file_path}):"
+    if printf '%s' "$todos_section" | grep -qF "$dedup_key"; then
+      is_dup=true
     fi
 
     if [ "$is_dup" = true ]; then
@@ -637,19 +656,23 @@ promote_todos() {
   tmp_file=$(mktemp "${state_path}.tmp.XXXXXX")
 
   # Replace "None." placeholder in Todos section, or append to existing todos
+  # Build awk anchor pattern from todo_anchor (escaping for regex)
+  local awk_anchor
+  awk_anchor=$(printf '%s' "$todo_anchor" | sed 's/[.[\*^$()+?{|]/\\&/g')
+
   if printf '%s' "$todos_section" | grep -qE '^\s*None\.?\s*$'; then
     # Replace the placeholder with new entries
-    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" awk '
-      /^## Todo/ { in_todos=1; print; next }
-      in_todos && /^## / { in_todos=0; print; next }
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" awk '
+      $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
+      in_todos && /^##/ { in_todos=0; print; next }
       in_todos && /^[[:space:]]*None\.?[[:space:]]*$/ { print ENVIRON["ENTRIES"]; in_todos=0; next }
       { print }
     ' > "$tmp_file"
   else
-    # Append new entries before the next ## section after ## Todos
-    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" awk '
-      /^## Todo/ { in_todos=1; print; next }
-      in_todos && /^## / { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
+    # Append new entries before the next section heading after the anchor
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" awk '
+      $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
+      in_todos && /^##/ { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
       { print }
       END { if (in_todos) { print ENVIRON["ENTRIES"] } }
     ' > "$tmp_file"

--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -596,7 +596,7 @@ promote_todos() {
     file_path=$(printf '%s' "$issues_json" | jq -r ".[$i].file // \"unknown\"")
     error_msg=$(printf '%s' "$issues_json" | jq -r ".[$i].error // \"unspecified error\"")
     times_seen=$(printf '%s' "$issues_json" | jq -r ".[$i].times_seen // 1")
-    source_artifact=$(printf '%s' "$issues_json" | jq -r ".[$i].source_path // \"\"")
+    source_artifact=$(printf '%s' "$issues_json" | jq -r ".[$i].last_seen_in // \"\"")
 
     # Truncate error message for todo readability (max 80 chars)
     if [ "${#error_msg}" -gt 80 ]; then

--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Usage:
 #   track-known-issues.sh sync-summaries <phase-dir>
 #   track-known-issues.sh sync-verification <phase-dir> <verification-path>
+#   track-known-issues.sh promote-todos <phase-dir>
 #   track-known-issues.sh status <phase-dir>
 #   track-known-issues.sh clear <phase-dir>
 
@@ -14,12 +15,12 @@ PHASE_DIR="${2:-}"
 VERIFICATION_PATH="${3:-}"
 
 usage() {
-  echo "usage: track-known-issues.sh <sync-summaries|sync-verification|status|clear> <phase-dir> [verification-path]" >&2
+  echo "usage: track-known-issues.sh <sync-summaries|sync-verification|promote-todos|status|clear> <phase-dir> [verification-path]" >&2
   exit 1
 }
 
 case "$CMD" in
-  sync-summaries|status|clear)
+  sync-summaries|status|clear|promote-todos)
     [ -n "$PHASE_DIR" ] || usage
     ;;
   sync-verification)
@@ -539,6 +540,129 @@ sync_verification() {
   write_registry "$final_json"
 }
 
+promote_todos() {
+  # Promote unresolved known issues to STATE.md ## Todos as [KNOWN-ISSUE] entries.
+  # Deduplicates by test name + file path against existing [KNOWN-ISSUE] lines.
+  local planning_dir="${VBW_PLANNING_DIR:-}"
+  if [ -z "$planning_dir" ]; then
+    # PHASE_DIR is like .vbw-planning/phases/03-slug/, so go up two levels
+    planning_dir=$(cd "$PHASE_DIR/../.." && pwd)
+  fi
+  local state_path="${planning_dir}/STATE.md"
+
+  if [ ! -f "$state_path" ]; then
+    echo "promoted_count=0"
+    echo "already_tracked_count=0"
+    echo "total_known_issues=0"
+    echo "promote_status=no_state_file"
+    return 0
+  fi
+
+  local issues_json
+  issues_json=$(load_registry_issues)
+  local total
+  total=$(printf '%s' "$issues_json" | jq 'length')
+
+  if [ "$total" -eq 0 ] 2>/dev/null; then
+    echo "promoted_count=0"
+    echo "already_tracked_count=0"
+    echo "total_known_issues=0"
+    echo "promote_status=empty_registry"
+    return 0
+  fi
+
+  # Read STATE.md content
+  local state_content
+  state_content=$(cat "$state_path")
+
+  # Extract the ## Todos section (or ## Todo) lines for dedup checking
+  local todos_section
+  todos_section=$(printf '%s\n' "$state_content" | sed -n '/^## Todo/,/^## /{ /^## Todo/d; /^## [^T]/d; p; }')
+
+  local phase_num
+  phase_num=$(phase_number)
+  local today
+  today=$(date +%Y-%m-%d)
+
+  local promoted=0
+  local already=0
+  local new_entries=""
+
+  # Iterate issues and check for duplicates
+  local i=0
+  while [ "$i" -lt "$total" ]; do
+    local test_name file_path error_msg times_seen source_artifact
+    test_name=$(printf '%s' "$issues_json" | jq -r ".[$i].test // \"unknown\"")
+    file_path=$(printf '%s' "$issues_json" | jq -r ".[$i].file // \"unknown\"")
+    error_msg=$(printf '%s' "$issues_json" | jq -r ".[$i].error // \"unspecified error\"")
+    times_seen=$(printf '%s' "$issues_json" | jq -r ".[$i].times_seen // 1")
+    source_artifact=$(printf '%s' "$issues_json" | jq -r ".[$i].source_path // \"\"")
+
+    # Truncate error message for todo readability (max 80 chars)
+    if [ "${#error_msg}" -gt 80 ]; then
+      error_msg="${error_msg:0:77}..."
+    fi
+
+    # Check if already tracked: line contains both test name and file path
+    local is_dup=false
+    if printf '%s' "$todos_section" | grep -qF "$test_name"; then
+      if printf '%s' "$todos_section" | grep -F "$test_name" | grep -qF "$file_path"; then
+        is_dup=true
+      fi
+    fi
+
+    if [ "$is_dup" = true ]; then
+      already=$((already + 1))
+    else
+      local source_ref=""
+      if [ -n "$source_artifact" ]; then
+        source_ref=" (see ${source_artifact})"
+      fi
+      new_entries="${new_entries}- [KNOWN-ISSUE] ${test_name} (${file_path}): ${error_msg} (phase ${phase_num}, seen ${times_seen}x)${source_ref} (added ${today})"$'\n'
+      promoted=$((promoted + 1))
+    fi
+    i=$((i + 1))
+  done
+
+  if [ "$promoted" -eq 0 ]; then
+    echo "promoted_count=0"
+    echo "already_tracked_count=$already"
+    echo "total_known_issues=$total"
+    echo "promote_status=all_tracked"
+    return 0
+  fi
+
+  # Write updated STATE.md atomically
+  local tmp_file
+  tmp_file=$(mktemp "${state_path}.tmp.XXXXXX")
+
+  # Replace "None." placeholder in Todos section, or append to existing todos
+  if printf '%s' "$todos_section" | grep -qE '^\s*None\.?\s*$'; then
+    # Replace the placeholder with new entries
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" awk '
+      /^## Todo/ { in_todos=1; print; next }
+      in_todos && /^## / { in_todos=0; print; next }
+      in_todos && /^[[:space:]]*None\.?[[:space:]]*$/ { print ENVIRON["ENTRIES"]; in_todos=0; next }
+      { print }
+    ' > "$tmp_file"
+  else
+    # Append new entries before the next ## section after ## Todos
+    printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" awk '
+      /^## Todo/ { in_todos=1; print; next }
+      in_todos && /^## / { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
+      { print }
+      END { if (in_todos) { print ENVIRON["ENTRIES"] } }
+    ' > "$tmp_file"
+  fi
+
+  mv "$tmp_file" "$state_path"
+
+  echo "promoted_count=$promoted"
+  echo "already_tracked_count=$already"
+  echo "total_known_issues=$total"
+  echo "promote_status=promoted"
+}
+
 case "$CMD" in
   status)
     if [ ! -f "$REGISTRY_PATH" ]; then
@@ -558,5 +682,8 @@ case "$CMD" in
     ;;
   sync-verification)
     sync_verification
+    ;;
+  promote-todos)
+    promote_todos
     ;;
 esac

--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -575,7 +575,8 @@ promote_todos() {
   local state_content
   state_content=$(cat "$state_path")
 
-  # Extract the todos section for dedup checking — two-pass approach mirroring list-todos.sh
+  # Extract the todos section for dedup and placeholder checking — two-pass approach mirroring list-todos.sh
+  # Captures ALL non-blank lines (not just bullets) so the None. placeholder is detected
   local todos_section todo_anchor
   # Pass 1: flat items directly under ## Todos (not inside ### subsections)
   todos_section=$(printf '%s\n' "$state_content" | awk '
@@ -583,7 +584,7 @@ promote_todos() {
     found && /^##/ { exit }
     found && /^### / { sub_found=1; next }
     found && sub_found && /^##/ { exit }
-    found && !sub_found && /^- / { print }
+    found && !sub_found && /[^ \t]/ { print }
   ')
   todo_anchor="## Todos"
 
@@ -592,7 +593,7 @@ promote_todos() {
     todos_section=$(printf '%s\n' "$state_content" | awk '
       /^### Pending Todos$/ { found=1; next }
       found && /^##/ { exit }
-      found && /^- / { print }
+      found && /[^ \t]/ { print }
     ')
     if [ -n "$todos_section" ]; then
       todo_anchor="### Pending Todos"
@@ -623,9 +624,9 @@ promote_todos() {
       error_msg="${error_msg:0:77}..."
     fi
 
-    # Dedup by exact structured key matching the generated line format
+    # Dedup by test+file pair regardless of tag prefix (matches [KNOWN-ISSUE], [HIGH], untagged, etc.)
     local is_dup=false
-    local dedup_key="[KNOWN-ISSUE] ${test_name} (${file_path}):"
+    local dedup_key="${test_name} (${file_path}):"
     if printf '%s' "$todos_section" | grep -qF "$dedup_key"; then
       is_dup=true
     fi

--- a/testing/verify-qa-persistence-contract.sh
+++ b/testing/verify-qa-persistence-contract.sh
@@ -220,6 +220,20 @@ else
   fail "20: vbw-qa.md missing guard against laundering fixable FAILs through process-exception paperwork"
 fi
 
+# 21. promote-todos must appear in commands/vibe.md for known-issues lifecycle
+if grep -q 'track-known-issues\.sh.*promote-todos' "$ROOT/commands/vibe.md"; then
+  pass "21: commands/vibe.md calls promote-todos for known-issues lifecycle"
+else
+  fail "21: commands/vibe.md missing promote-todos call — known issues won't auto-promote to STATE.md"
+fi
+
+# 22. promote-todos must appear in commands/qa.md for known-issues lifecycle
+if grep -q 'track-known-issues\.sh.*promote-todos' "$QA_CMD"; then
+  pass "22: commands/qa.md calls promote-todos for known-issues lifecycle"
+else
+  fail "22: commands/qa.md missing promote-todos call — known issues won't auto-promote to STATE.md"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────
 echo ""
 echo "==============================="

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -395,6 +395,26 @@ write_known_issues_registry() {
   grep -q "### Completed Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
+@test "track-known-issues: promote-todos appends to non-empty legacy Pending Todos" {
+  write_legacy_state_md_with_todos "- [HIGH] Fix login bug"
+  write_known_issues_registry "03" \
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=1"* ]]
+  # Original entry preserved
+  grep -q "\[HIGH\] Fix login bug" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # New entry added under Pending Todos
+  grep -q "\[KNOWN-ISSUE\] TestCrash (CrashTests.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Completed Todos section preserved and not contaminated
+  grep -q "### Completed Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Known issue appears before Completed Todos, not after
+  run bash -c 'awk "/^### Completed Todos/{exit} /KNOWN-ISSUE/{found=1} END{exit !found}" "$1"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  [ "$status" -eq 0 ]
+}
+
 @test "track-known-issues: promote-todos dedup uses exact key not substring" {
   # testFoo exists but we're promoting testFooBar — must NOT be suppressed
   write_state_md_with_todos "- [KNOWN-ISSUE] testFoo (path/a.swift): err (phase 03, seen 1x) (added 2025-01-01)"

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -291,7 +291,7 @@ write_known_issues_registry() {
 @test "track-known-issues: promote-todos adds new issues to STATE.md" {
   write_state_md_with_todos "None."
   write_known_issues_registry "03" \
-    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3}'
 
   run bash "$SCRIPT" promote-todos "$PHASE_DIR"
 
@@ -304,12 +304,14 @@ write_known_issues_registry() {
   grep -q "\[KNOWN-ISSUE\]" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "TestCrash" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "CrashTests.swift" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Source traceability from last_seen_in field
+  grep -q "(see 03-02)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
 @test "track-known-issues: promote-todos deduplicates existing entries" {
-  write_state_md_with_todos "- [KNOWN-ISSUE] TestCrash (CrashTests.swift): signal trap (phase 03, seen 2x) (see phases/03-test-phase/03-01-SUMMARY.md) (added 2025-01-01)"
+  write_state_md_with_todos "- [KNOWN-ISSUE] TestCrash (CrashTests.swift): signal trap (phase 03, seen 2x) (see 03-01) (added 2025-01-01)"
   write_known_issues_registry "03" \
-    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3}'
 
   run bash "$SCRIPT" promote-todos "$PHASE_DIR"
 
@@ -325,7 +327,7 @@ write_known_issues_registry() {
 @test "track-known-issues: promote-todos replaces None placeholder" {
   write_state_md_with_todos "None."
   write_known_issues_registry "03" \
-    '{"test":"TestA","file":"A.swift","error":"err","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1,"source_path":"phases/03-test-phase/03-01-SUMMARY.md"}'
+    '{"test":"TestA","file":"A.swift","error":"err","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1}'
 
   run bash "$SCRIPT" promote-todos "$PHASE_DIR"
 
@@ -337,8 +339,8 @@ write_known_issues_registry() {
 @test "track-known-issues: promote-todos handles multiple issues" {
   write_state_md_with_todos "- [HIGH] Existing high-pri todo (added 2025-01-01)"
   write_known_issues_registry "03" \
-    '{"test":"TestA","file":"A.swift","error":"err A","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1,"source_path":"phases/03-test-phase/03-01-SUMMARY.md"}' \
-    '{"test":"TestB","file":"B.swift","error":"err B","first_seen_in":"03-02","last_seen_in":"03-02","first_seen_round":2,"last_seen_round":2,"times_seen":2,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+    '{"test":"TestA","file":"A.swift","error":"err A","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1}' \
+    '{"test":"TestB","file":"B.swift","error":"err B","first_seen_in":"03-02","last_seen_in":"03-02","first_seen_round":2,"last_seen_round":2,"times_seen":2}'
 
   run bash "$SCRIPT" promote-todos "$PHASE_DIR"
 

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -265,6 +265,27 @@ write_state_md_with_todos() {
   } > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
+write_legacy_state_md_with_todos() {
+  local content="${1:-None.}"
+  {
+    echo '# Project State'
+    echo ''
+    echo '## Decisions'
+    echo 'None.'
+    echo ''
+    echo '## Todos'
+    echo ''
+    echo '### Pending Todos'
+    echo "$content"
+    echo ''
+    echo '### Completed Todos'
+    echo 'None.'
+    echo ''
+    echo '## Blockers'
+    echo 'None.'
+  } > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
 write_known_issues_registry() {
   local phase_num="$1"
   shift
@@ -351,4 +372,36 @@ write_known_issues_registry() {
   # Both new entries present
   grep -q "TestA" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "TestB" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+@test "track-known-issues: promote-todos works with legacy Pending Todos layout" {
+  write_legacy_state_md_with_todos "None."
+  write_known_issues_registry "03" \
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=1"* ]]
+  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "\[KNOWN-ISSUE\] TestCrash (CrashTests.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Legacy section structure preserved
+  grep -q "### Pending Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "### Completed Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+@test "track-known-issues: promote-todos dedup uses exact key not substring" {
+  # testFoo exists but we're promoting testFooBar — must NOT be suppressed
+  write_state_md_with_todos "- [KNOWN-ISSUE] testFoo (path/a.swift): err (phase 03, seen 1x) (added 2025-01-01)"
+  write_known_issues_registry "03" \
+    '{"test":"testFooBar","file":"path/a.swift","error":"different err","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=1"* ]]
+  [[ "$output" == *"already_tracked_count=0"* ]]
+  # Both entries present
+  grep -q "testFoo " "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "testFooBar" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -319,8 +319,9 @@ write_known_issues_registry() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"promoted_count=1"* ]]
   [[ "$output" == *"total_known_issues=1"* ]]
-  # None. placeholder must be removed
-  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # None. placeholder must be removed from Todos section
+  run bash -c 'awk "/^## Todos?$/{f=1;next} f&&/^##/{exit} f" "$1" | grep -q "^None\\.$"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  [ "$status" -ne 0 ]
   # Entry must exist with [KNOWN-ISSUE] tag
   grep -q "\[KNOWN-ISSUE\]" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "TestCrash" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
@@ -353,7 +354,9 @@ write_known_issues_registry() {
   run bash "$SCRIPT" promote-todos "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # None. placeholder must be removed from Todos section
+  run bash -c 'awk "/^## Todos?$/{f=1;next} f&&/^##/{exit} f" "$1" | grep -q "^None\\.$"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  [ "$status" -ne 0 ]
   grep -q "\[KNOWN-ISSUE\] TestA (A.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
@@ -383,7 +386,9 @@ write_known_issues_registry() {
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"promoted_count=1"* ]]
-  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # None. placeholder must be removed from Pending Todos section
+  run bash -c 'awk "/^### Pending Todos$/{f=1;next} f&&/^##/{exit} f" "$1" | grep -q "^None\\.$"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  [ "$status" -ne 0 ]
   grep -q "\[KNOWN-ISSUE\] TestCrash (CrashTests.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   # Legacy section structure preserved
   grep -q "### Pending Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -246,3 +246,107 @@ EOF
   second_state=$(jq -cS '.issues[0]' "$PHASE_DIR/known-issues.json")
   [ "$first_state" = "$second_state" ]
 }
+
+# --- promote-todos tests ---
+
+write_state_md_with_todos() {
+  local content="${1:-None.}"
+  {
+    echo '# Project State'
+    echo ''
+    echo '## Decisions'
+    echo 'None.'
+    echo ''
+    echo '## Todos'
+    echo "$content"
+    echo ''
+    echo '## Blockers'
+    echo 'None.'
+  } > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+write_known_issues_registry() {
+  local phase_num="$1"
+  shift
+  local issues_json="[]"
+  for issue_json in "$@"; do
+    issues_json=$(echo "$issues_json" | jq --argjson i "$issue_json" '. + [$i]')
+  done
+  jq -n --arg p "$phase_num" --argjson iss "$issues_json" \
+    '{schema_version:1, phase:$p, issues:$iss}' > "$PHASE_DIR/known-issues.json"
+}
+
+@test "track-known-issues: promote-todos with empty registry promotes nothing" {
+  write_state_md_with_todos "None."
+  echo '{"schema_version":1,"phase":"03","issues":[]}' > "$PHASE_DIR/known-issues.json"
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=0"* ]]
+  [[ "$output" == *"total_known_issues=0"* ]]
+  grep -q "None\." "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+@test "track-known-issues: promote-todos adds new issues to STATE.md" {
+  write_state_md_with_todos "None."
+  write_known_issues_registry "03" \
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=1"* ]]
+  [[ "$output" == *"total_known_issues=1"* ]]
+  # None. placeholder must be removed
+  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Entry must exist with [KNOWN-ISSUE] tag
+  grep -q "\[KNOWN-ISSUE\]" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "TestCrash" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "CrashTests.swift" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+@test "track-known-issues: promote-todos deduplicates existing entries" {
+  write_state_md_with_todos "- [KNOWN-ISSUE] TestCrash (CrashTests.swift): signal trap (phase 03, seen 2x) (see phases/03-test-phase/03-01-SUMMARY.md) (added 2025-01-01)"
+  write_known_issues_registry "03" \
+    '{"test":"TestCrash","file":"CrashTests.swift","error":"signal trap","first_seen_in":"03-01","last_seen_in":"03-02","first_seen_round":1,"last_seen_round":2,"times_seen":3,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=0"* ]]
+  [[ "$output" == *"already_tracked_count=1"* ]]
+  # Only one [KNOWN-ISSUE] line (no duplicate)
+  local count
+  count=$(grep -c "\[KNOWN-ISSUE\]" "$TEST_TEMP_DIR/.vbw-planning/STATE.md")
+  [ "$count" -eq 1 ]
+}
+
+@test "track-known-issues: promote-todos replaces None placeholder" {
+  write_state_md_with_todos "None."
+  write_known_issues_registry "03" \
+    '{"test":"TestA","file":"A.swift","error":"err","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1,"source_path":"phases/03-test-phase/03-01-SUMMARY.md"}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^None\.$" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "\[KNOWN-ISSUE\] TestA (A.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
+@test "track-known-issues: promote-todos handles multiple issues" {
+  write_state_md_with_todos "- [HIGH] Existing high-pri todo (added 2025-01-01)"
+  write_known_issues_registry "03" \
+    '{"test":"TestA","file":"A.swift","error":"err A","first_seen_in":"03-01","last_seen_in":"03-01","first_seen_round":1,"last_seen_round":1,"times_seen":1,"source_path":"phases/03-test-phase/03-01-SUMMARY.md"}' \
+    '{"test":"TestB","file":"B.swift","error":"err B","first_seen_in":"03-02","last_seen_in":"03-02","first_seen_round":2,"last_seen_round":2,"times_seen":2,"source_path":"phases/03-test-phase/03-02-SUMMARY.md"}'
+
+  run bash "$SCRIPT" promote-todos "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted_count=2"* ]]
+  # Original high-pri todo preserved
+  grep -q "\[HIGH\]" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  # Both new entries present
+  grep -q "TestA" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  grep -q "TestB" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}


### PR DESCRIPTION
Fixes #353

## What

Adds automatic promotion of known issues from phase-scoped `known-issues.json` registries to `STATE.md ## Todos` so vibe-coding users see deferred issues in `/vbw:list-todos` and `/vbw:resume` without manually tracking them.

### Changed files and behavioral changes:

| File | Change |
|------|--------|
| `scripts/track-known-issues.sh` | Added `promote-todos` subcommand (~130 lines): loads registry via `load_registry_issues()`, resolves STATE.md via `VBW_PLANNING_DIR` or `$PHASE_DIR/../..`, deduplicates by test+file pair (tag-agnostic), appends `[KNOWN-ISSUE]`-tagged entries, handles `None.` placeholder replacement, supports both `## Todos` and legacy `### Pending Todos` layouts, writes atomically via mktemp+mv |
| `scripts/list-todos.sh` | Added `[KNOWN-ISSUE]` tag recognition in `parse_todo_line` + display rendering + usage comment |
| `commands/vibe.md` | Two `promote-todos` calls: after phase-level sync-verification (~line 354) and after remediation sync-verification (~line 421) |
| `commands/qa.md` | One `promote-todos` call after sync-verification (~line 258) |
| `references/execute-protocol.md` | Documents full known-issue lifecycle: registry persistence → orchestration-layer promotion → user visibility. Replaces "do not auto-create todos" prohibition with positive rule scoped to the orchestration layer |
| `commands/resume.md` | Displays per-phase known-issue counts between steps 2 and 3, with promote-todos backfill |
| `scripts/suggest-next.sh` | Appends known-issue count note when unresolved issues exist across active phases |
| `tests/track-known-issues.bats` | 8 new promote-todos tests: empty registry, add new issues, deduplication, placeholder replacement, multi-issue, legacy layout (empty + non-empty), exact-key dedup |
| `testing/verify-qa-persistence-contract.sh` | Tests 21 + 22: verify promote-todos calls exist in vibe.md and qa.md |

## Why

Known issues (e.g., RDEV-02 SwiftData signal-trap crash) that survive QA and remediation were silently buried in phase-level markdown and `known-issues.json`. No automatic path existed from the phase registry to the persistent user-facing backlog (`STATE.md ## Todos`). Users who weren't watching closely never saw these issues again. The root cause was architectural: `track-known-issues.sh` managed the phase registry but had no subcommand to promote entries to the user-facing backlog, and the execute protocol's "do not auto-create todos for discovered issues" prohibition blocked legitimate promotion.

## How

The fix adds a `promote-todos` subcommand to `track-known-issues.sh` that orchestration commands (`/vbw:vibe`, `/vbw:qa`) call after sync-verification. The subcommand reads the phase registry, deduplicates against existing todos by test+file pair (tag-agnostic — matches `[KNOWN-ISSUE]`, `[HIGH]`, untagged), and atomically appends new entries. The execute protocol's prohibition is replaced with a positive rule that only the orchestration layer (not Dev/QA agents) may promote issues.

Key design decisions:
- **Two-pass extraction** mirroring `list-todos.sh`: supports both `## Todos` flat layout and legacy `### Pending Todos` subsection layout
- **Tag-agnostic dedup**: matches `test_name (file_path):` pattern regardless of priority tag prefix
- **Atomic writes**: mktemp + mv to avoid partial STATE.md corruption
- **awk ENVIRON pattern**: uses `ENVIRON["ENTRIES"]` instead of `-v entries=` to handle multiline strings with embedded newlines

## Acceptance Criteria Verification

1. **promote-todos reads known-issues.json and appends [KNOWN-ISSUE]-tagged entries to STATE.md ## Todos, deduplicating by test name + file path** — Satisfied: `scripts/track-known-issues.sh` lines 543-700, tag-agnostic dedup key `${test_name} (${file_path}):`, tested in 8 BATS tests
2. **list-todos.sh recognizes [KNOWN-ISSUE] as a category tag** — Satisfied: `scripts/list-todos.sh` lines 145-150 (parse), 260-270 (display)
3. **vibe.md calls promote-todos after remediation sync-verification** — Satisfied: `commands/vibe.md` ~line 421
4. **vibe.md calls promote-todos after phase-level sync-verification** — Satisfied: `commands/vibe.md` ~line 354
5. **qa.md calls promote-todos after sync-verification** — Satisfied: `commands/qa.md` ~line 258
6. **/vbw:resume displays per-phase known-issue counts** — Satisfied: `commands/resume.md` lines 109-116
7. **suggest-next.sh appends known-issue count note** — Satisfied: `scripts/suggest-next.sh` lines 883-903
8. **execute-protocol.md documents the full known-issue lifecycle** — Satisfied: lines 646-694 + 1005-1015
9. **BATS tests cover promote-todos** — Satisfied: 8 tests in `tests/track-known-issues.bats`
10. **Contract test verifies promote-todos presence** — Satisfied: `testing/verify-qa-persistence-contract.sh` tests 21+22
11. **bash testing/run-all.sh passes** — Satisfied: 2494 BATS passed, 33/33 contract, 1/1 lint, 0 failures

## Testing

- [x] Plugin loads locally with `claude --plugin-dir .`
- [x] `bash testing/run-all.sh` passes (2494 BATS, 33 contract, 1 lint — 0 failures)
- [x] 8 BATS behavior tests for promote-todos (Tier 1)
- [x] 2 contract tests for promote-todos presence (Tier 2)
- [x] Manual verification of legacy layout handling

## QA Summary

**Primary QA (Claude Opus 4.6):** 3 rounds
- Round 1: 4 findings (1 medium, 3 low) — all fixed in 6575ab5
- Round 2: 1 finding (low) — fixed in bef6e9e
- Round 3: 1 finding (low) — fixed in 70478f4

**Cross-model QA (GPT-5.4):** 3 rounds
- Round 1: 2 findings (1 high, 1 low) — both fixed in de2d596
- Round 2: 2 findings (1 high, 1 medium) — both fixed in a9236d9
- Round 3: 1 false positive (high), 1 low — low fixed in 509b584

**Total findings:** 11 legitimate + 1 false positive across 6 rounds
**False positives:** 1 (cross-model R3 F-01: GPT-5.4 misread `/^##/` regex scope for `### ` headings — verified manually that extraction correctly stops at `### Completed Todos`)