### PR TITLE
fix(commands): disambiguate step 4 task list from TaskCreate delegation

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -287,7 +287,16 @@ fi
 Display: "⚠ Renamed misnamed plan files to `{NN}-PLAN.md` convention."
 Then re-run phase-detect.sh and use updated output for routing below.
 
-**State-driven routing prohibition (NON-NEGOTIABLE):** When state detection routes to a mode, call its confirmation gate (AskUserQuestion — see Confirmation Gate section below) in the same turn, then execute the mode inline after the user responds. Do NOT use TaskCreate, TaskUpdate, or any task management tool for state-driven routing — these add overhead and delay execution. State routing is deterministic: the pre-computed data in the Context section above provides all routing information. Do not spawn tasks or read protocol files for routing decisions. After confirmation (when required by the routing table), execute the mode inline.
+**State-driven routing prohibition (NON-NEGOTIABLE):** When state detection routes to a mode, call its confirmation gate (AskUserQuestion — see Confirmation Gate section below) in the same turn, then execute the mode inline after the user responds. Do NOT use TaskCreate, TaskUpdate, or any task management tool for state-driven routing — these add overhead and delay execution. State routing is deterministic: the pre-computed data in the Context section above provides all routing information. Do not spawn tasks or read protocol files for routing decisions. After confirmation (when required by the routing table), execute the mode inline. Modes that spawn agents (Scout, Lead, Dev) do so within their step-by-step flow — this is delegation of work units within a stage, not delegation of the stage pipeline itself.
+
+<examples>
+<example type="anti-pattern" label="WRONG — delegating the stage pipeline via TaskCreate">
+State detects needs_uat_remediation → TaskCreate("Research"), TaskCreate("Plan"), TaskCreate("Execute") with blocking dependencies → stages run as separate delegated tasks, breaking state management and losing orchestrator control between stages
+</example>
+<example type="correct" label="RIGHT — inline orchestration with agent spawning per stage">
+State detects needs_uat_remediation → enters mode inline → step 4 creates TodoWrite progress list (Research, Plan, Execute) → step 6 spawns Scout for research stage via Task tool → advances state → spawns Lead for plan stage → advances → spawns Dev for execute stage → chains into re-verification
+</example>
+</examples>
 
 | Priority | Condition | Mode | Confirmation |
 | --- | --- | --- | --- |
@@ -367,6 +376,8 @@ Before entering Verify mode (UAT), check `qa_status` from phase-detect output:
 
 **QA Remediation mode (needs_qa_remediation) — cross-session recovery:**
 When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persisted stage. This is the cross-session recovery path — the inline execution path is in execute-protocol.md Step 4. This state also covers completed phases with no UAT yet when phase-level QA already wrote a PASS artifact but unresolved tracked known issues still force remediation before UAT can begin.
+
+**Execution model:** This mode runs inline — the orchestrator manages stage transitions and spawns agents for the actual work within each stage. Do not decompose the stages into TaskCreate items — they are sequential steps of this conversation, not delegated tasks.
 
 1. Read current state: `bash {plugin-root}/scripts/qa-remediation-state.sh get-or-init {phase-dir}`
   Parse output: `stage`, `round`, `round_dir`, `source_verification_path`, `source_fail_count`, `known_issues_path`, `known_issues_count`, `input_mode`, `verification_path`
@@ -648,6 +659,8 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
 
 **Guard:** Initialized, target phase has `*-UAT.md` with `status: issues_found`.
 
+**Execution model:** This mode runs inline — the orchestrator manages stage transitions (steps 1-5) and spawns agents for the actual work within each stage (step 6). The three stages (research, plan, execute) are sequential steps of this conversation, not delegated tasks — do not decompose them into TaskCreate items.
+
 **Chain state tracking:** This mode uses `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh` to persist the current stage of the remediation chain on disk. This ensures correct resumption after compaction or session restart — the chain does NOT rely on prompt memory alone.
 
 **Steps:**
@@ -674,10 +687,10 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
    - If a stage was already persisted (resume after compaction/restart), the script returns the stage word + plan metadata with no side effects.
    - If no stage existed (first entry into remediation), the script initializes the stage file, creates `remediation/uat/round-01/` directory, pre-seeds the phase `{NN}-CONTEXT.md`, and returns the stage word + plan metadata + `---CONTEXT---` separator with the full pre-seeded context content — **use this directly as your remediation context. Do NOT separately read UAT.md or `{NN}-CONTEXT.md` files.**
    - If the returned stage is `done`: UAT remediation already completed for this phase. Display "Remediation already completed. Run `/vbw:vibe` to re-verify." STOP.
-   **Task list (NON-NEGOTIABLE ordering and state):** Immediately after resolving the stage, create a task list with items in **exactly this order** for the major path: (1) Research, (2) Plan, (3) Execute. For the minor path: (1) Fix. **Item numbering must match stage order** — Research is always #1, Plan #2, Execute #3. Never reorder items.
+   **TodoWrite progress list (NON-NEGOTIABLE ordering and state):** Immediately after resolving the stage, create a TodoWrite progress list with items in **exactly this order** for the major path: (1) Research, (2) Plan, (3) Execute. For the minor path: (1) Fix. **Item numbering must match stage order** — Research is always #1, Plan #2, Execute #3. Never reorder items. This is a progress display for the user — agent spawning for each stage is handled in step 6 below.
    - **Initial creation:** If the resolved stage is `research`, mark Research as in-progress, Plan and Execute as not-started. If the resolved stage is `plan` (resume case), mark Research as completed, Plan as in-progress, Execute as not-started. If `execute`, mark Research and Plan as completed, Execute as in-progress.
-   - **Same-session progression:** When a stage completes and you advance to the next stage within the same session (e.g., research completes → advance → start plan), immediately update the task list: mark the completed stage as completed and the new stage as in-progress. Do NOT defer task list updates or recreate the list from scratch.
-   - **Final stage:** When the last stage completes, mark ALL tasks as completed before presenting the summary.
+   - **Same-session progression:** When a stage completes and you advance to the next stage within the same session (e.g., research completes → advance → start plan), immediately update the TodoWrite progress list: mark the completed stage as completed and the new stage as in-progress. Do NOT defer updates or recreate the list from scratch.
+   - **Final stage:** When the last stage completes, mark ALL TodoWrite items as completed before presenting the summary.
 5. **Recurrence analysis and priority ranking:**
   Use `round=RR` from step 4 as the **current remediation round** for stage management.
 

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -702,7 +702,7 @@ If `planning_dir_exists=false`: display "Run /vbw:init first to set up your proj
 
   **Post-route enrichment:** When inspecting earlier archived UAT artifacts for recurrence, read only the archived artifacts for this phase (flat `*-UAT-round-*.md` or round-dir `remediation/uat/round-*/R*-UAT.md`) and **exclude the active step-2 UAT artifact itself from the scan**. Build `FAILED_IN_ROUNDS` from the matching archived rounds plus `active_uat_round`. If no earlier matches exist, default each current issue to `FAILED_IN_ROUNDS={active_uat_round}` — **never** default to `RR` when the active artifact is a previous-round UAT.
 
-  **Phase-level escalation:** When `RR >= 3`, force ALL issues through `research → plan → execute` regardless of severity. If the persisted stage from step 4 is `fix`, replace the quick-fix task list with the major-path task list (`Research`, `Plan`, `Execute`) before continuing.
+  **Phase-level escalation:** When `RR >= 3`, force ALL issues through `research → plan → execute` regardless of severity. If the persisted stage from step 4 is `fix`, replace the quick-fix TodoWrite progress list with the major-path TodoWrite progress list (`Research`, `Plan`, `Execute`) before continuing.
 
   **Per-test priority ranking:** Rank issues by `failure_count` descending — tests that failed the most recorded UAT rounds get investigated and fixed FIRST. When presenting issues to Scout (research stage) and Lead (plan stage), reorder by `failure_count` descending and annotate:
   - `⚠ RECURRING (failed in N recorded rounds): ID|SEVERITY|DESCRIPTION` for tests with `failure_count >= 2`

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -717,11 +717,12 @@ done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "$COMMANDS_DI
 echo ""
 echo "--- UAT Remediation TodoWrite disambiguation ---"
 # Scope the check to the UAT Remediation section (between its header and the next ### Mode:)
+# Match step 4's heading specifically — not just any "TodoWrite progress list" in the section
 uat_section="$(sed -n '/^### Mode: UAT Remediation/,/^### Mode:/p' "$COMMANDS_DIR/vibe.md")"
-if printf '%s' "$uat_section" | grep -q "TodoWrite progress list"; then
+if printf '%s' "$uat_section" | grep -q '\*\*TodoWrite progress list (NON-NEGOTIABLE'; then
   pass "UAT Remediation step 4 explicitly references TodoWrite"
 else
-  fail "UAT Remediation step 4 missing 'TodoWrite progress list' — risk of TaskCreate conflation (see issue #367)"
+  fail "UAT Remediation step 4 missing 'TodoWrite progress list' heading — risk of TaskCreate conflation (see issue #367)"
 fi
 
 echo ""

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -713,6 +713,15 @@ while IFS= read -r ref; do
   fi
 done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md 2>/dev/null | sort -u)
 
+# ── UAT Remediation step 4 must use TodoWrite (not generic "task list") ──
+echo ""
+echo "--- UAT Remediation TodoWrite disambiguation ---"
+if grep -q "TodoWrite progress list" "$COMMANDS_DIR/vibe.md"; then
+  pass "UAT Remediation step 4 explicitly references TodoWrite"
+else
+  fail "UAT Remediation step 4 missing 'TodoWrite progress list' — risk of TaskCreate conflation (see issue #367)"
+fi
+
 echo ""
 echo "==============================="
 echo "TOTAL: $PASS PASS, $FAIL FAIL"

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -716,9 +716,15 @@ done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "$COMMANDS_DI
 # ── UAT Remediation step 4 must use TodoWrite (not generic "task list") ──
 echo ""
 echo "--- UAT Remediation TodoWrite disambiguation ---"
-# Scope the check to the UAT Remediation section (between its header and the next ### Mode:)
+# Extract the UAT Remediation section body (between its header and the next ### Mode:)
 # Match step 4's heading specifically — not just any "TodoWrite progress list" in the section
-uat_section="$(sed -n '/^### Mode: UAT Remediation/,/^### Mode:/p' "$COMMANDS_DIR/vibe.md")"
+uat_section="$(
+  awk '
+    /^### Mode: UAT Remediation$/ { in_section=1; next }
+    in_section && /^### Mode:/ { exit }
+    in_section { print }
+  ' "$COMMANDS_DIR/vibe.md"
+)"
 if printf '%s' "$uat_section" | grep -q '\*\*TodoWrite progress list (NON-NEGOTIABLE'; then
   pass "UAT Remediation step 4 explicitly references TodoWrite"
 else

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -716,7 +716,9 @@ done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "$COMMANDS_DI
 # ── UAT Remediation step 4 must use TodoWrite (not generic "task list") ──
 echo ""
 echo "--- UAT Remediation TodoWrite disambiguation ---"
-if grep -q "TodoWrite progress list" "$COMMANDS_DIR/vibe.md"; then
+# Scope the check to the UAT Remediation section (between its header and the next ### Mode:)
+uat_section="$(sed -n '/^### Mode: UAT Remediation/,/^### Mode:/p' "$COMMANDS_DIR/vibe.md")"
+if printf '%s' "$uat_section" | grep -q "TodoWrite progress list"; then
   pass "UAT Remediation step 4 explicitly references TodoWrite"
 else
   fail "UAT Remediation step 4 missing 'TodoWrite progress list' — risk of TaskCreate conflation (see issue #367)"


### PR DESCRIPTION
## Linked Issue

Fixes #367

## What

Disambiguates step 4's "task list" instruction in UAT/QA Remediation modes to prevent the model from reaching for `TaskCreate` (subagent delegation) when it should use `TodoWrite` (progress tracking). Changes span `commands/vibe.md` (5 locations) and `testing/verify-commands-contract.sh` (1 new contract test).

## Why

Step 4 said "create a task list with items: Research, Plan, Execute" without specifying which tool. The model interpreted "task list" as TaskCreate items, delegating the entire stage pipeline as separate subagent tasks with blocking dependencies — breaking state management and losing orchestrator control between stages. The root cause was ambiguous terminology at step 4 with no forward pointer to step 6 (where agent delegation is actually specified).

Session evidence: `f7755e4f-1176-418f-a981-044529975bc4` (2026-03-17) — three `TaskCreate` calls for Research/Plan/Execute with `TaskUpdate` blocking dependencies.

## How

| File | Change | Reason |
|------|--------|--------|
| `commands/vibe.md` ~L290 | Added clarifying sentence to routing prohibition + `<examples>` block with anti-pattern/correct-pattern pair | Distinguishes orchestration delegation (wrong) from agent delegation within stages (right) |
| `commands/vibe.md` ~L380 | Added `**Execution model:**` note to QA Remediation header | Explicitly states mode runs inline, agents spawn within stages |
| `commands/vibe.md` ~L662 | Added `**Execution model:**` note to UAT Remediation header | Same — with step references (1-5 for stage management, 6 for agent spawning) |
| `commands/vibe.md` ~L690 | Changed step 4 heading from "task list" to "TodoWrite progress list", added forward pointer to step 6 | Directly addresses root cause — names the tool, connects to agent delegation step |
| `commands/vibe.md` ~L710 | Changed step 5 escalation "task list" → "TodoWrite progress list" (QA round 1 finding) | Consistency — step 5 references step 4's list |
| `testing/verify-commands-contract.sh` ~L720 | New contract test: extracts UAT Remediation section, verifies step 4 heading contains `**TodoWrite progress list (NON-NEGOTIABLE` | Regression guard scoped to step 4 specifically |

## Acceptance Criteria Verification

1. **Step 4 references TodoWrite** — satisfied by `commands/vibe.md` L690: `**TodoWrite progress list (NON-NEGOTIABLE ordering and state):**`
2. **Forward pointer to step 6** — satisfied by L690: `This is a progress display for the user — agent spawning for each stage is handled in step 6 below.`
3. **UAT header execution model** — satisfied by L662: `**Execution model:** This mode runs inline — the orchestrator manages stage transitions (steps 1-5) and spawns agents for the actual work within each stage (step 6).`
4. **QA header execution model** — satisfied by L380: equivalent note without step-number references (QA Remediation has different structure)
5. **Routing prohibition clarification** — satisfied by L290: `Modes that spawn agents (Scout, Lead, Dev) do so within their step-by-step flow — this is delegation of work units within a stage, not delegation of the stage pipeline itself.`
6. **Anti-pattern/correct example pair** — satisfied by L292-298: XML `<examples>` block showing TaskCreate pipeline (wrong) vs inline orchestration + TodoWrite + agent spawning (right)
7. **Contract test for TodoWrite** — satisfied by `verify-commands-contract.sh` L720: `sed`-scoped extraction of UAT Remediation section + `grep` for step 4 heading specifically
8. **All tests pass** — lint 1/1, contracts 33/33, BATS 2528/0

## Testing

- [x] Plugin loads locally with `claude --plugin-dir .`
- [x] Full test suite passes: `bash testing/run-all.sh` (lint 1/1, contracts 33/33, BATS 2528/0)
- [x] New contract test verifies step 4 heading contains `TodoWrite progress list (NON-NEGOTIABLE`
- [x] Contract test is scoped to UAT Remediation section (not whole file)
- [x] Contract test handles `pipefail` + SIGPIPE correctly (captures sed output before grep)
- [x] Remaining "task list" references in plan frontmatter context (L739, L759) are correct and unchanged

## QA Summary

**Primary QA (Claude Opus 4.6) — 3 rounds:**
- Round 1: 2 findings (1 medium, 1 low) — both fixed in `99e56de`
  - F-01 (medium): Step 5 escalation still used generic "task list" → changed to "TodoWrite progress list"
  - F-02 (low): Contract test not scoped to UAT Remediation section → scoped via sed + fixed SIGPIPE/pipefail issue
- Round 2: 0 findings (clean) — `12c43ad`
- Round 3: 0 findings (clean) — `2442c0d`

**Cross-Model QA (GPT-5.4) — 2 rounds:**
- Round 1: 1 finding (medium) — fixed in `bbcdd1e`
  - F-01 (medium): Contract test matched "TodoWrite progress list" anywhere in section, not step 4 specifically → tightened to match step 4 heading `**TodoWrite progress list (NON-NEGOTIABLE`
- Round 2: 1 finding (medium) — false positive (AC8 "all tests pass" unverifiable by read-only reviewer; tests demonstrably pass) — `85590e6`