### PR TITLE
fix(scripts): route to needs_uat_remediation when round UAT shows issues_found (#369)

### DIFF
--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -439,17 +439,34 @@ if [ -d "$PHASES_DIR" ]; then
           if [ -n "$_round_uat" ]; then
             _round_uat_status=$(extract_status_value "$_round_uat")
           fi
+          # Read layout before the routing decision — apply the same path-based
+          # default as the execute→done transition above.
+          if [ -n "$_rem_state_file" ] && [ -f "$_rem_state_file" ]; then
+            _cur_layout=$(grep '^layout=' "$_rem_state_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
+            if [ -z "$_cur_layout" ]; then
+              case "$_rem_state_file" in
+                */remediation/.uat-remediation-stage|*/.uat-remediation-stage)
+                  _cur_layout="legacy" ;;
+                *)
+                  _cur_layout="round-dir" ;;
+              esac
+            fi
+          else
+            _cur_layout="round-dir"
+          fi
           case "$_round_uat_status" in
             issues_found)
               # Re-verification already happened and found issues.
               # Auto-advance to next round's research stage.
               _next_rr=$(printf '%02d' $(( 10#${_cur_rr} + 1 )))
               if [ -n "$_rem_state_file" ] && [ -f "$_rem_state_file" ]; then
-                _cur_layout=$(grep '^layout=' "$_rem_state_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
-                _cur_layout="${_cur_layout:-round-dir}"
                 printf 'stage=research\nround=%s\nlayout=%s\n' "$_next_rr" "$_cur_layout" > "$_rem_state_file"
               fi
-              mkdir -p "${TARGET_DIR}remediation/uat/round-${_next_rr}" 2>/dev/null || true
+              if [ "$_cur_layout" = "legacy" ]; then
+                mkdir -p "${TARGET_DIR}remediation/round-${_next_rr}" 2>/dev/null || true
+              else
+                mkdir -p "${TARGET_DIR}remediation/uat/round-${_next_rr}" 2>/dev/null || true
+              fi
               NEXT_PHASE_STATE="needs_uat_remediation"
               ;;
             *)

--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -457,17 +457,27 @@ if [ -d "$PHASES_DIR" ]; then
           case "$_round_uat_status" in
             issues_found)
               # Re-verification already happened and found issues.
-              # Auto-advance to next round's research stage.
-              _next_rr=$(printf '%02d' $(( 10#${_cur_rr} + 1 )))
-              if [ -n "$_rem_state_file" ] && [ -f "$_rem_state_file" ]; then
-                printf 'stage=research\nround=%s\nlayout=%s\n' "$_next_rr" "$_cur_layout" > "$_rem_state_file"
-              fi
-              if [ "$_cur_layout" = "legacy" ]; then
-                mkdir -p "${TARGET_DIR}remediation/round-${_next_rr}" 2>/dev/null || true
-              else
-                mkdir -p "${TARGET_DIR}remediation/uat/round-${_next_rr}" 2>/dev/null || true
-              fi
-              NEXT_PHASE_STATE="needs_uat_remediation"
+              # Auto-advance to next round's research stage, but only if the
+              # current round read from state is a valid numeric value.
+              case "$_cur_rr" in
+                ''|*[!0-9]*)
+                  # Malformed/corrupt round value; avoid arithmetic expansion
+                  # and fall back to explicit re-verification routing.
+                  NEXT_PHASE_STATE="needs_reverification"
+                  ;;
+                *)
+                  _next_rr=$(printf '%02d' $(( 10#${_cur_rr} + 1 )))
+                  if [ -n "$_rem_state_file" ] && [ -f "$_rem_state_file" ]; then
+                    printf 'stage=research\nround=%s\nlayout=%s\n' "$_next_rr" "$_cur_layout" > "$_rem_state_file"
+                  fi
+                  if [ "$_cur_layout" = "legacy" ]; then
+                    mkdir -p "${TARGET_DIR}remediation/round-${_next_rr}" 2>/dev/null || true
+                  else
+                    mkdir -p "${TARGET_DIR}remediation/uat/round-${_next_rr}" 2>/dev/null || true
+                  fi
+                  NEXT_PHASE_STATE="needs_uat_remediation"
+                  ;;
+              esac
               ;;
             *)
               # No round UAT yet, or UAT passed — needs re-verification

--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -423,7 +423,41 @@ if [ -d "$PHASES_DIR" ]; then
           fi
           _rem_stage="done"
         fi
-        if [ "$_rem_stage" = "done" ] || [ "$_rem_stage" = "verify" ]; then
+        if [ "$_rem_stage" = "done" ]; then
+          # Check if re-verification already happened for this round.
+          # If a round-scoped UAT exists with issues, skip re-verification
+          # and route directly to the next remediation round.
+          _round_uat=""
+          _round_uat_status=""
+          # Round-dir layout
+          if [ -f "${TARGET_DIR}remediation/uat/round-${_cur_rr}/R${_cur_rr}-UAT.md" ]; then
+            _round_uat="${TARGET_DIR}remediation/uat/round-${_cur_rr}/R${_cur_rr}-UAT.md"
+          # Legacy layout
+          elif [ -f "${TARGET_DIR}remediation/round-${_cur_rr}/R${_cur_rr}-UAT.md" ]; then
+            _round_uat="${TARGET_DIR}remediation/round-${_cur_rr}/R${_cur_rr}-UAT.md"
+          fi
+          if [ -n "$_round_uat" ]; then
+            _round_uat_status=$(extract_status_value "$_round_uat")
+          fi
+          case "$_round_uat_status" in
+            issues_found)
+              # Re-verification already happened and found issues.
+              # Auto-advance to next round's research stage.
+              _next_rr=$(printf '%02d' $(( 10#${_cur_rr} + 1 )))
+              if [ -n "$_rem_state_file" ] && [ -f "$_rem_state_file" ]; then
+                _cur_layout=$(grep '^layout=' "$_rem_state_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
+                _cur_layout="${_cur_layout:-round-dir}"
+                printf 'stage=research\nround=%s\nlayout=%s\n' "$_next_rr" "$_cur_layout" > "$_rem_state_file"
+              fi
+              mkdir -p "${TARGET_DIR}remediation/uat/round-${_next_rr}" 2>/dev/null || true
+              NEXT_PHASE_STATE="needs_uat_remediation"
+              ;;
+            *)
+              # No round UAT yet, or UAT passed — needs re-verification
+              NEXT_PHASE_STATE="needs_reverification"
+              ;;
+          esac
+        elif [ "$_rem_stage" = "verify" ]; then
           NEXT_PHASE_STATE="needs_reverification"
         else
           NEXT_PHASE_STATE="needs_uat_remediation"

--- a/scripts/uat-utils.sh
+++ b/scripts/uat-utils.sh
@@ -35,6 +35,7 @@ normalize_uat_status() {
   local raw="${1:-}"
   case "$raw" in
     all_pass|passed|pass|all_passed|verified|no_issues) echo "complete" ;;
+    failed) echo "issues_found" ;;
     *) echo "$raw" ;;
   esac
 }
@@ -48,9 +49,9 @@ normalize_uat_status() {
 # to contain 'status:'.
 #
 # UAT files: the extracted value is passed through normalize_uat_status() to
-# map LLM synonyms (all_pass, passed, verified, etc.) to canonical values.
-# SUMMARY files are unaffected — their valid statuses (complete, partial,
-# failed) never match any normalization rule.
+# map LLM synonyms (all_pass, passed, verified, failed, etc.) to canonical
+# values. SUMMARY files use their own extraction path in summary-utils.sh
+# which never calls normalize_uat_status(), so these mappings are UAT-only.
 extract_status_value() {
   local file="$1"
   local result

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2505,3 +2505,133 @@ EOF
   echo "$output" | grep -q "first_qa_attention_slug=02-remediating"
   echo "$output" | grep -q "qa_attention_status=verify"
 }
+
+# ---------- #369: cross-session reverification routing ----------
+
+@test "phase-detect: stage=done + round UAT with issues_found routes to needs_uat_remediation" {
+  # Scenario: UAT remediation round 02 completed, re-verification found issues,
+  # but the session ended before auto-continuing to round 03. The next session
+  # should recognise the round UAT and route to remediation, not re-verify.
+  mkdir -p .vbw-planning/phases/01-feature/remediation/uat/round-01
+  mkdir -p .vbw-planning/phases/01-feature/remediation/uat/round-02
+  touch .vbw-planning/phases/01-feature/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-feature/01-01-SUMMARY.md
+  cat > .vbw-planning/phases/01-feature/01-UAT.md <<'EOF'
+---
+phase: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  # Round 01 UAT (prior round, already remediated)
+  cat > .vbw-planning/phases/01-feature/remediation/uat/round-01/R01-UAT.md <<'EOF'
+---
+phase: 01
+round: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  # Round 02 UAT — re-verification happened, still has issues
+  cat > .vbw-planning/phases/01-feature/remediation/uat/round-02/R02-UAT.md <<'EOF'
+---
+phase: 01
+round: 02
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+- **Issue:** fix did not resolve
+  - Description: test still fails
+  - Severity: major
+EOF
+  # Remediation state: round 02 done
+  printf 'stage=done\nround=02\nlayout=round-dir\n' > .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+
+  run bash "$SCRIPTS_DIR/phase-detect.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "next_phase_state=needs_uat_remediation"
+  # State file should be auto-advanced to round 03, stage=research
+  grep -q '^stage=research$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+  grep -q '^round=03$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+  # Round 03 directory should be created
+  [ -d .vbw-planning/phases/01-feature/remediation/uat/round-03 ]
+}
+
+@test "phase-detect: stage=done + no round UAT routes to needs_reverification" {
+  # Scenario: UAT remediation round 02 completed execution, but re-verification
+  # has NOT happened yet. Should route to needs_reverification so it can run.
+  mkdir -p .vbw-planning/phases/01-feature/remediation/uat/round-02
+  touch .vbw-planning/phases/01-feature/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-feature/01-01-SUMMARY.md
+  cat > .vbw-planning/phases/01-feature/01-UAT.md <<'EOF'
+---
+phase: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  touch .vbw-planning/phases/01-feature/remediation/uat/round-02/R02-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-feature/remediation/uat/round-02/R02-SUMMARY.md
+  # Remediation state: round 02 done, but NO R02-UAT.md
+  printf 'stage=done\nround=02\nlayout=round-dir\n' > .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+
+  run bash "$SCRIPTS_DIR/phase-detect.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "next_phase_state=needs_reverification"
+  # State file should NOT be modified
+  grep -q '^stage=done$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+  grep -q '^round=02$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+}
+
+@test "phase-detect: stage=done + round UAT with complete status does NOT trigger remediation" {
+  # Scenario: UAT remediation round 01 completed, re-verification passed.
+  # Phase-detect sees no active UAT issues since round UAT is complete,
+  # so it exits the remediation routing block. Must NOT start another round.
+  mkdir -p .vbw-planning/phases/01-feature/remediation/uat/round-01
+  touch .vbw-planning/phases/01-feature/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-feature/01-01-SUMMARY.md
+  cat > .vbw-planning/phases/01-feature/01-UAT.md <<'EOF'
+---
+phase: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  # Round 01 UAT — re-verification passed (all tests passed)
+  cat > .vbw-planning/phases/01-feature/remediation/uat/round-01/R01-UAT.md <<'EOF'
+---
+phase: 01
+round: 01
+status: complete
+issues: 0
+---
+## Tests
+### P01-T1: sample test
+- **Result:** pass
+EOF
+  # Remediation state: round 01 done
+  printf 'stage=done\nround=01\nlayout=round-dir\n' > .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+
+  run bash "$SCRIPTS_DIR/phase-detect.sh"
+  [ "$status" -eq 0 ]
+  # When round UAT is complete (tests passed), must NOT trigger another remediation round
+  ! echo "$output" | grep -q "next_phase_state=needs_uat_remediation"
+  # State file should NOT be modified — no round advancement
+  grep -q '^stage=done$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+  grep -q '^round=01$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+}

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2631,7 +2631,53 @@ EOF
   [ "$status" -eq 0 ]
   # When round UAT is complete (tests passed), must NOT trigger another remediation round
   ! echo "$output" | grep -q "next_phase_state=needs_uat_remediation"
+  # Phase exits remediation routing entirely — routes to standard verification
+  echo "$output" | grep -q "next_phase_state=needs_verification"
   # State file should NOT be modified — no round advancement
   grep -q '^stage=done$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
   grep -q '^round=01$' .vbw-planning/phases/01-feature/remediation/uat/.uat-remediation-stage
+}
+
+@test "phase-detect: stage=done + legacy layout routes to needs_uat_remediation with correct paths" {
+  # Scenario: Legacy brownfield project uses .uat-remediation-stage at phase root
+  # and stores round UATs under remediation/round-NN/ (no /uat/ prefix).
+  # The auto-advance must create remediation/round-02 (legacy), NOT remediation/uat/round-02.
+  mkdir -p .vbw-planning/phases/01-feature/remediation/round-01
+  touch .vbw-planning/phases/01-feature/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-feature/01-01-SUMMARY.md
+  cat > .vbw-planning/phases/01-feature/01-UAT.md <<'EOF'
+---
+phase: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  # Round 01 UAT at legacy path — re-verification found issues
+  cat > .vbw-planning/phases/01-feature/remediation/round-01/R01-UAT.md <<'EOF'
+---
+phase: 01
+round: 01
+status: issues_found
+issues: 1
+---
+## Tests
+### P01-T1: sample test
+- **Result:** issue
+EOF
+  # Legacy state file at phase root (no /uat/ prefix)
+  printf 'stage=done\nround=01\n' > .vbw-planning/phases/01-feature/.uat-remediation-stage
+
+  run bash "$SCRIPTS_DIR/phase-detect.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "next_phase_state=needs_uat_remediation"
+  # State file should advance to round 02, stage=research, layout=legacy
+  grep -q '^stage=research$' .vbw-planning/phases/01-feature/.uat-remediation-stage
+  grep -q '^round=02$' .vbw-planning/phases/01-feature/.uat-remediation-stage
+  grep -q '^layout=legacy$' .vbw-planning/phases/01-feature/.uat-remediation-stage
+  # Legacy layout: create remediation/round-02 (NOT remediation/uat/round-02)
+  [ -d .vbw-planning/phases/01-feature/remediation/round-02 ]
+  [ ! -d .vbw-planning/phases/01-feature/remediation/uat/round-02 ]
 }

--- a/tests/uat-utils.bats
+++ b/tests/uat-utils.bats
@@ -159,7 +159,11 @@ teardown() {
   [ "$(normalize_uat_status "issues_found")" = "issues_found" ]
   [ "$(normalize_uat_status "in_progress")" = "in_progress" ]
   [ "$(normalize_uat_status "pending")" = "pending" ]
-  [ "$(normalize_uat_status "failed")" = "failed" ]
+}
+
+@test "normalize_uat_status: failed maps to issues_found" {
+  result=$(normalize_uat_status "failed")
+  [ "$result" = "issues_found" ]
 }
 
 @test "normalize_uat_status: empty input returns empty" {


### PR DESCRIPTION
Fixes #369\n\n## What\n\nFix cross-session UAT remediation routing in `phase-detect.sh`. When a remediation round's re-verification UAT already exists with issues (`issues_found` or `failed`), route to `needs_uat_remediation` instead of `needs_reverification`. Also normalize `failed` → `issues_found` in `uat-utils.sh` so LLM-written status synonyms are handled consistently.\n\n**Modified files:**\n- `scripts/phase-detect.sh` — Added round-scoped UAT check in the `_rem_stage=done` block; layout-aware directory creation and path-based layout defaults\n- `scripts/uat-utils.sh` — Added `failed` → `issues_found` normalization in `normalize_uat_status()`; updated comment\n- `tests/phase-detect.bats` — 4 new tests covering the cross-session routing scenarios\n- `tests/uat-utils.bats` — Updated `failed` assertion, added new normalization test\n\n## Why\n\n`phase-detect.sh` checked only `_rem_stage` when routing from the `done` state. Two distinct scenarios collapsed into the same routing:\n- Remediation done, no re-verification yet → `needs_reverification` (correct)\n- Remediation done, re-verification done with issues → `needs_reverification` (wrong — should be `needs_uat_remediation`)\n\nThe second case occurs when a session completes re-verification (writing the round UAT with `issues_found`) but ends before advancing to the next round. The fix checks for an existing round-scoped UAT and its status before routing.\n\n## How\n\n- **`scripts/phase-detect.sh`**: The `_rem_stage=done` block now checks for `R{RR}-UAT.md` in both round-dir and legacy layout paths. If found with `issues_found`, auto-advances state to the next round's `research` stage and outputs `needs_uat_remediation`. Layout default uses the same path-based heuristic as the execute→done transition (legacy state file path → `legacy` layout, else `round-dir`). Directory creation is layout-aware.\n- **`scripts/uat-utils.sh`**: `normalize_uat_status()` now maps `failed` → `issues_found`, satisfying the \"or equivalent\" acceptance criterion. This fixes routing for both the existing upstream UAT scan and the new done→research block.\n- **`tests/phase-detect.bats`**: Test 1 (issues_found → needs_uat_remediation + auto-advance), Test 2 (no round UAT → needs_reverification), Test 3 (complete → needs_verification, negative assertion for needs_uat_remediation), Test 4 (legacy layout → correct paths).\n- **`tests/uat-utils.bats`**: `failed` moved from pass-through test to its own `failed maps to issues_found` test.\n\n## Acceptance criteria verification\n\n1. **`_rem_stage=done` + round UAT with `issues_found` → `needs_uat_remediation`**: Satisfied by `phase-detect.sh` lines 457-470, tested in `phase-detect.bats` test \"stage=done + round UAT with issues_found routes to needs_uat_remediation\"\n2. **`_rem_stage=done` + no round UAT → `needs_reverification`**: Satisfied by `phase-detect.sh` wildcard case at line 476, tested in `phase-detect.bats` test \"stage=done + no round UAT routes to needs_reverification\"\n3. **`_rem_stage=done` + round UAT with `complete` → verification path**: Satisfied — `current_uat()` returns the complete round UAT, upstream scan sees no issues, routes to `needs_verification`. Tested in `phase-detect.bats` test \"stage=done + round UAT with complete status does NOT trigger remediation\"\n4. **Auto-advance to `round=RR+1, stage=research`**: Satisfied by `phase-detect.sh` lines 462-470, tested in both test 1 (round-dir) and test 4 (legacy layout)\n5. **All existing tests pass**: 2533 BATS, 33 contracts, 1 lint — all pass\n6. **BATS test covers cross-session detection**: Test 1 directly covers this scenario\n\n## Testing\n\n- [x] Loaded plugin locally with `claude --plugin-dir .`\n- [x] `bash testing/run-all.sh` — 2533 BATS passed, 33 contracts passed, 1 lint passed, 0 failures\n- [x] 4 new BATS tests cover the #369 scenarios (round-dir + legacy layouts, positive + negative cases)\n- [x] Existing commands still work (no routing table changes)\n\n## QA summary\n\n- **Primary QA (Claude Opus 4.6):** 3 rounds\n  - Round 1: 3 findings (1 medium, 2 low) — all fixed in commit `6e283c4`\n  - Rounds 2-3: Clean (0 findings each)\n- **Cross-model QA (GPT-5.4):** 2 rounds\n  - Round 1: 1 finding (medium) — fixed in commit `27f736b` (normalize `failed` → `issues_found`)\n  - Round 2: Clean (0 findings)\n- **Total findings:** 4 (all fixed), 0 false positives