### PR TITLE
feat(testing): add AskUserQuestion maxItems contract test

### DIFF
--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -45,4 +45,5 @@ printf '%s\t%s\n' \
   qa-persistence-contract      testing/verify-qa-persistence-contract.sh \
   discussion-engine-contract   testing/verify-discussion-engine-contract.sh \
   debug-session-contract       testing/verify-debug-session-contract.sh \
+  askuserquestion-contract     testing/verify-askuserquestion-contract.sh \
   verify-vibe                  scripts/verify-vibe.sh

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-askuserquestion-contract.sh — Contract checks for AskUserQuestion maxItems:4
+#
+# The Claude Code AskUserQuestion tool has a maxItems:4 constraint on its
+# `options` array. Commands that need more than 4 choices must use a
+# numbered-list-in-question-text workaround with explicit guard language.
+#
+# Checks:
+# 1. No pipe-delimited option lists with >4 items in AskUserQuestion context
+# 2. Numbered-list AskUserQuestion workarounds include guard language
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMMANDS_DIR="$ROOT/commands"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+# Extract body after YAML frontmatter (everything after second ---)
+extract_body() {
+  local file="$1"
+  awk '
+    BEGIN { delim=0 }
+    /^---$/ { delim++; next }
+    delim >= 2 { print }
+  ' "$file"
+}
+
+echo "=== AskUserQuestion maxItems Contract Verification ==="
+
+# --------------------------------------------------------------------------
+# Check 1: No pipe-delimited option lists exceeding 4 items
+#
+# Scans for lines matching: "something" | "something" | ... (quoted strings
+# separated by pipes). If a single line has >4 pipe-separated quoted items,
+# it violates the maxItems:4 constraint.
+#
+# Exclusions: fenced code blocks, markdown table rows (lines starting with |)
+# --------------------------------------------------------------------------
+
+echo ""
+echo "--- Check 1: No >4 pipe-delimited option lists ---"
+
+for file in "$COMMANDS_DIR"/*.md; do
+  [ -f "$file" ] || continue
+  base="$(basename "$file" .md)"
+
+  # Count lines with >4 pipe-delimited quoted options (outside code fences)
+  violations=$(extract_body "$file" | awk '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    /^\|/ { next }  # skip markdown table rows
+
+    {
+      # Count pipe-separated quoted segments: "..." | "..."
+      # Split on | and count segments that contain a quoted string
+      n = split($0, parts, /\|/)
+      quoted_count = 0
+      for (i = 1; i <= n; i++) {
+        if (parts[i] ~ /"[^"]*"/) {
+          quoted_count++
+        }
+      }
+      if (quoted_count > 4) {
+        print NR ": " $0
+      }
+    }
+  ')
+
+  if [ -n "$violations" ]; then
+    while IFS= read -r violation; do
+      fail "$base: >4 pipe-delimited options (line $violation)"
+    done <<<"$violations"
+  else
+    pass "$base: no >4 pipe-delimited option lists"
+  fi
+done
+
+# --------------------------------------------------------------------------
+# Check 2: Numbered-list AskUserQuestion workarounds include guard language
+#
+# When a command instructs the LLM to "present ... as a numbered list in the
+# AskUserQuestion text", it should also include guard language like:
+# "do NOT use `options` array" or "no `options` array"
+#
+# This prevents future editors from removing the guard while keeping the
+# numbered-list pattern, which could lead to the LLM using an options array
+# with >4 items.
+# --------------------------------------------------------------------------
+
+echo ""
+echo "--- Check 2: Numbered-list workarounds include guard language ---"
+
+for file in "$COMMANDS_DIR"/*.md; do
+  [ -f "$file" ] || continue
+  base="$(basename "$file" .md)"
+
+  body=$(extract_body "$file")
+
+  # Check if the command uses the numbered-list AskUserQuestion workaround pattern
+  has_numbered_list_pattern=false
+  if printf '%s\n' "$body" | grep -qi 'numbered list.*AskUserQuestion\|AskUserQuestion.*numbered list'; then
+    # Only trigger on lines that say to present choices as a numbered list
+    # in the AskUserQuestion text (the workaround pattern)
+    if printf '%s\n' "$body" | grep -Eqi 'present.*(as a |as )numbered list.*(in|for).*AskUserQuestion|numbered list in the (AskUserQuestion|question) text'; then
+      has_numbered_list_pattern=true
+    fi
+  fi
+
+  if [ "$has_numbered_list_pattern" = true ]; then
+    # Verify guard language exists somewhere in the body
+    if printf '%s\n' "$body" | grep -qi 'do NOT use.*options.*array\|no.*options.*array'; then
+      pass "$base: numbered-list workaround has guard language"
+    else
+      fail "$base: uses numbered-list AskUserQuestion workaround but missing guard language (e.g., 'do NOT use \`options\` array')"
+    fi
+  fi
+done
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All AskUserQuestion contract checks passed."
+exit 0

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # numbered-list-in-question-text workaround with explicit guard language.
 #
 # Checks:
-# 1. No pipe-delimited option lists with >4 items in AskUserQuestion context
+# 1. No option lists with >4 items in AskUserQuestion context (pipe-delimited
+#    or JSON array format)
 # 2. Numbered-list AskUserQuestion workarounds include guard language
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -50,21 +51,22 @@ echo "=== AskUserQuestion maxItems Contract Verification ==="
 # --------------------------------------------------------------------------
 
 echo ""
-echo "--- Check 1: No >4 pipe-delimited option lists ---"
+echo "--- Check 1: No >4 option lists ---"
 
 for file in "$COMMANDS_DIR"/*.md; do
   [ -f "$file" ] || continue
   base="$(basename "$file" .md)"
 
-  # Count lines with >4 pipe-delimited quoted options (outside code fences)
+  # Count lines with >4 options in either format (outside code fences):
+  # - Pipe-delimited: "a" | "b" | "c" | "d" | "e"
+  # - JSON array:     Options: ["a", "b", "c", "d", "e"]
   violations=$(extract_body "$file" | awk '
     /^```/ { in_fence = !in_fence; next }
     in_fence { next }
     /^\|/ { next }  # skip markdown table rows
 
     {
-      # Count pipe-separated quoted segments: "..." | "..."
-      # Split on | and count segments that contain a quoted string
+      # Check 1a: pipe-separated quoted segments: "..." | "..."
       n = split($0, parts, /\|/)
       quoted_count = 0
       for (i = 1; i <= n; i++) {
@@ -74,16 +76,36 @@ for file in "$COMMANDS_DIR"/*.md; do
       }
       if (quoted_count > 4) {
         print NR ": " $0
+        next
+      }
+
+      # Check 1b: JSON array options: Options: ["...", "...", ...]
+      if ($0 ~ /Options:[[:space:]]*\[/) {
+        # Extract content between [ and ]
+        arr = $0
+        sub(/.*Options:[[:space:]]*\[/, "", arr)
+        sub(/\].*/, "", arr)
+        # Count comma-separated quoted items
+        m = split(arr, items, /,/)
+        arr_count = 0
+        for (j = 1; j <= m; j++) {
+          if (items[j] ~ /"[^"]*"/) {
+            arr_count++
+          }
+        }
+        if (arr_count > 4) {
+          print NR ": " $0
+        }
       }
     }
   ')
 
   if [ -n "$violations" ]; then
     while IFS= read -r violation; do
-      fail "$base: >4 pipe-delimited options (line $violation)"
+      fail "$base: >4 options (line $violation)"
     done <<<"$violations"
   else
-    pass "$base: no >4 pipe-delimited option lists"
+    pass "$base: no >4 option lists"
   fi
 done
 

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -53,7 +53,7 @@ echo "=== AskUserQuestion maxItems Contract Verification ==="
 echo ""
 echo "--- Check 1: No >4 option lists ---"
 
-for file in "$COMMANDS_DIR"/*.md; do
+for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
   [ -f "$file" ] || continue
   base="$(basename "$file" .md)"
 
@@ -124,7 +124,7 @@ done
 echo ""
 echo "--- Check 2: Numbered-list workarounds include guard language ---"
 
-for file in "$COMMANDS_DIR"/*.md; do
+for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
   [ -f "$file" ] || continue
   base="$(basename "$file" .md)"
 
@@ -132,7 +132,7 @@ for file in "$COMMANDS_DIR"/*.md; do
 
   # Check if the command uses the numbered-list AskUserQuestion workaround pattern
   has_numbered_list_pattern=false
-  if printf '%s\n' "$body" | grep -qi 'numbered list.*AskUserQuestion\|AskUserQuestion.*numbered list'; then
+  if printf '%s\n' "$body" | grep -Eqi 'numbered list.*AskUserQuestion|AskUserQuestion.*numbered list'; then
     # Only trigger on lines that say to present choices as a numbered list
     # in the AskUserQuestion text (the workaround pattern)
     if printf '%s\n' "$body" | grep -Eqi 'present.*(as a |as )numbered list.*(in|for).*AskUserQuestion|numbered list in the (AskUserQuestion|question) text'; then
@@ -142,7 +142,7 @@ for file in "$COMMANDS_DIR"/*.md; do
 
   if [ "$has_numbered_list_pattern" = true ]; then
     # Verify guard language exists somewhere in the body
-    if printf '%s\n' "$body" | grep -qi 'do NOT use.*options.*array\|no.*options.*array'; then
+    if printf '%s\n' "$body" | grep -Eqi 'do NOT use.*options.*array|no.*options.*array'; then
       pass "$base: numbered-list workaround has guard language"
     else
       fail "$base: uses numbered-list AskUserQuestion workaround but missing guard language (e.g., 'do NOT use \`options\` array')"

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -33,7 +33,7 @@ extract_body() {
   local file="$1"
   awk '
     BEGIN { delim=0 }
-    /^---$/ { delim++; next }
+    /^---$/ && delim < 2 { delim++; next }
     delim >= 2 { print }
   ' "$file"
 }


### PR DESCRIPTION
Fixes #382

## What

Adds a Tier 2 contract test (`testing/verify-askuserquestion-contract.sh`) that validates the AskUserQuestion `maxItems:4` constraint across command markdown. Registered in `testing/list-contract-tests.sh` for auto-discovery by `run-all.sh` and CI.

## Why

The AskUserQuestion tool has a `maxItems:4` constraint on its `options` array. Without a contract test, future edits could reintroduce violations (e.g., adding a 5th option to an AskUserQuestion block in `config.md` or `skills.md`) without a failing test. Identified during cross-model QA review of #378.

## How

### `testing/verify-askuserquestion-contract.sh` (NEW)

Two checks:

- **Check 1 — No >4 option lists**: Scans all `commands/*.md` bodies (excluding fenced code blocks and markdown table rows) for two option formats:
  - **Pipe-delimited**: `"a" | "b" | "c" | "d" | "e"` — counts pipe-separated quoted segments
  - **JSON array**: `Options: ["a", "b", "c", "d", "e"]` — counts comma-separated quoted items within `[...]` brackets
  - Fails if either format has >4 items

- **Check 2 — Guard language on numbered-list workarounds**: When a command explicitly instructs the LLM to "present as a numbered list in the AskUserQuestion text" (the documented workaround for >4 choices), verifies the command also contains guard language like `do NOT use \`options\` array` to prevent the LLM from reverting to an options array.

### `testing/list-contract-tests.sh`

Added `askuserquestion-contract` entry. This is the only registration needed — `run-all.sh` and CI both discover tests from this registry.

## Acceptance Criteria Verification

1. **A new contract script exists that catches >4 option arrays in command markdown**: Satisfied by `testing/verify-askuserquestion-contract.sh` Check 1, which detects both pipe-delimited and JSON array formats.
2. **`testing/run-all.sh` includes the new check**: Satisfied by adding the entry to `testing/list-contract-tests.sh`, which `run-all.sh` reads dynamically.
3. **The check passes on the current branch state**: Verified — 26 PASS, 0 FAIL. All 24 command files pass Check 1 (no >4 option lists), and the 2 commands using numbered-list workarounds (`config.md`, `skills.md`) pass Check 2 (both have guard language).

## Testing

- [x] `bash testing/verify-askuserquestion-contract.sh` — 26 PASS, 0 FAIL
- [x] `shellcheck -S warning testing/verify-askuserquestion-contract.sh` — clean
- [x] `bash testing/run-all.sh` — 35/35 contracts pass, 2670/2670 BATS pass
- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] Existing commands still work — no behavior changes

## QA Summary

- **Primary QA (Claude)**: 3 rounds. Round 1: 1 high finding (F-01: missing JSON array format detection) — fixed in `fix(testing): address QA round 1`. Rounds 2-3: clean (observations only, all pre-existing).
- **Cross-model QA (GPT-5.4)**: 1 round. 2 findings classified as false positives — both requested prose-described dynamic option detection, which is Tier 3 (smoke testing) scope, not Tier 2 contract testing.
- Total findings: 1 fixed (JSON array detection), 2 false positives (prose patterns outside contract test scope)