### PR TITLE
fix(config): sync config.md settings table with defaults.json

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -380,6 +380,7 @@ Note: `auto_commit` controls source-task commits during Execute mode. Planning a
 | skill_suggestions | boolean | true/false | true |
 | auto_install_skills | boolean | true/false | false |
 | discovery_questions | boolean | true/false | true |
+| discussion_mode | string | questions/assumptions/auto | questions |
 | visual_format | string | unicode/ascii | unicode |
 | max_tasks_per_plan | number | 1-7 | 5 |
 | prefer_teams | string | always/auto/never | auto |
@@ -390,6 +391,7 @@ Note: `auto_commit` controls source-task commits during Execute mode. Planning a
 | model_profile | string | quality/balanced/budget | quality |
 | model_overrides | object | agent-to-model map | {} |
 | agent_max_turns | object | per-agent turns (number), 0/false = unlimited | scout=15, qa=25, architect=30, debugger=80, lead=50, dev=75 |
+| qa_skip_agents | array | array of agent role names | ["docs"] |
 | context_compiler | boolean | true/false | true |
 | token_budgets | boolean | true/false | true |
 | two_phase_completion | boolean | true/false | true |
@@ -397,15 +399,15 @@ Note: `auto_commit` controls source-task commits during Execute mode. Planning a
 | smart_routing | boolean | true/false | true |
 | validation_gates | boolean | true/false | true |
 | snapshot_resume | boolean | true/false | true |
-| lease_locks | boolean | true/false | false |
-| event_recovery | boolean | true/false | false |
+| lease_locks | boolean | true/false | true |
+| event_recovery | boolean | true/false | true |
+| worktree_isolation | string | off/on | off |
 | monorepo_routing | boolean | true/false | true |
 | require_phase_discussion | boolean | true/false | false |
 | auto_uat | boolean | true/false | false |
 | max_uat_remediation_rounds | boolean/number | false, 0, or positive integer | false |
 | rolling_summary | boolean | true/false | false |
 | debug_logging | boolean | true/false | false |
-| subagent_skill_xml_mode | string | off/names_only/full | names_only |
 | statusline_hide_limits | boolean | true/false | false |
 | statusline_hide_limits_for_api_key | boolean | true/false | false |
 | statusline_hide_agent_in_tmux | boolean | true/false | false |

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -46,4 +46,5 @@ printf '%s\t%s\n' \
   discussion-engine-contract   testing/verify-discussion-engine-contract.sh \
   debug-session-contract       testing/verify-debug-session-contract.sh \
   askuserquestion-contract     testing/verify-askuserquestion-contract.sh \
+  config-defaults-sync         testing/verify-config-defaults-sync.sh \
   verify-vibe                  scripts/verify-vibe.sh

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Checks:
 # 1. Every key in defaults.json has a row in the config.md table
 # 2. Every setting name in the config.md table exists in defaults.json
-# 3. For boolean/string settings with simple defaults, the default value matches
+# 3. Default values match (scalars compared directly, arrays/objects via compact JSON; shorthand-only keys skipped)
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CONFIG_MD="$ROOT/commands/config.md"

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -61,17 +61,19 @@ for setting in $md_settings; do
 done
 
 # --- Check 3: Default values match for simple types ---
-# Skip object/array types where table uses shorthand representations.
+# For object/array types, use compact JSON for comparison where the table
+# uses JSON-like notation, or skip where the table uses shorthand.
 echo ""
-echo "--- Check: default values match for simple types ---"
+echo "--- Check: default values match ---"
 
-COMPLEX_KEYS="custom_profiles model_overrides agent_max_turns qa_skip_agents"
+# Settings whose table representation uses non-JSON shorthand
+SHORTHAND_KEYS="agent_max_turns"
 
 for key in $json_keys; do
-  # Skip complex types
+  # Skip shorthand keys (table format differs fundamentally from JSON)
   skip=false
-  for ck in $COMPLEX_KEYS; do
-    if [ "$key" = "$ck" ]; then
+  for sk in $SHORTHAND_KEYS; do
+    if [ "$key" = "$sk" ]; then
       skip=true
       break
     fi
@@ -79,8 +81,6 @@ for key in $json_keys; do
   if $skip; then
     continue
   fi
-
-  json_val=$(jq -r --arg k "$key" '.[$k]' "$DEFAULTS_JSON")
 
   # Extract the default column (4th field) from the matching config.md row
   md_row=$(grep -E "^\| ${key} \|" "$CONFIG_MD" || true)
@@ -90,6 +90,14 @@ for key in $json_keys; do
   fi
 
   md_default=$(echo "$md_row" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $5); print $5}')
+
+  # Use compact JSON for object/array types, raw output for scalars
+  json_type=$(jq -r --arg k "$key" '.[$k] | type' "$DEFAULTS_JSON")
+  if [ "$json_type" = "object" ] || [ "$json_type" = "array" ]; then
+    json_val=$(jq -c --arg k "$key" '.[$k]' "$DEFAULTS_JSON")
+  else
+    json_val=$(jq -r --arg k "$key" '.[$k]' "$DEFAULTS_JSON")
+  fi
 
   if [ "$json_val" = "$md_default" ]; then
     pass "'$key' default matches: $json_val"

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-config-defaults-sync.sh — Contract test for issue #373
+#
+# Validates that the settings reference table in commands/config.md stays
+# in sync with config/defaults.json (the source of truth for all settings).
+#
+# Checks:
+# 1. Every key in defaults.json has a row in the config.md table
+# 2. Every setting name in the config.md table exists in defaults.json
+# 3. For boolean/string settings with simple defaults, the default value matches
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_MD="$ROOT/commands/config.md"
+DEFAULTS_JSON="$ROOT/config/defaults.json"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== Config Defaults Sync Contract (Issue #373) ==="
+
+# Extract setting names from the markdown table.
+# Table rows look like: | setting_name | type | values | default |
+# Skip the header row (Setting) and separator row (------).
+md_settings=$(grep -E '^\| [a-z_]+ \|' "$CONFIG_MD" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2}')
+
+# Extract keys from defaults.json
+json_keys=$(jq -r 'keys[]' "$DEFAULTS_JSON")
+
+# --- Check 1: Every key in defaults.json has a row in config.md ---
+echo ""
+echo "--- Check: defaults.json keys present in config.md table ---"
+for key in $json_keys; do
+  if echo "$md_settings" | grep -qx "$key"; then
+    pass "defaults.json key '$key' found in config.md table"
+  else
+    fail "defaults.json key '$key' MISSING from config.md table"
+  fi
+done
+
+# --- Check 2: Every setting in config.md exists in defaults.json ---
+echo ""
+echo "--- Check: config.md table settings exist in defaults.json ---"
+for setting in $md_settings; do
+  if echo "$json_keys" | grep -qx "$setting"; then
+    pass "config.md setting '$setting' found in defaults.json"
+  else
+    fail "config.md setting '$setting' NOT in defaults.json (stale/graduated?)"
+  fi
+done
+
+# --- Check 3: Default values match for simple types ---
+# Skip object/array types where table uses shorthand representations.
+echo ""
+echo "--- Check: default values match for simple types ---"
+
+COMPLEX_KEYS="custom_profiles model_overrides agent_max_turns qa_skip_agents"
+
+for key in $json_keys; do
+  # Skip complex types
+  skip=false
+  for ck in $COMPLEX_KEYS; do
+    if [ "$key" = "$ck" ]; then
+      skip=true
+      break
+    fi
+  done
+  if $skip; then
+    continue
+  fi
+
+  json_val=$(jq -r --arg k "$key" '.[$k]' "$DEFAULTS_JSON")
+
+  # Extract the default column (4th field) from the matching config.md row
+  md_row=$(grep -E "^\| ${key} \|" "$CONFIG_MD" || true)
+  if [ -z "$md_row" ]; then
+    # Already caught by Check 1, skip value comparison
+    continue
+  fi
+
+  md_default=$(echo "$md_row" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $5); print $5}')
+
+  if [ "$json_val" = "$md_default" ]; then
+    pass "'$key' default matches: $json_val"
+  else
+    fail "'$key' default mismatch: defaults.json='$json_val' config.md='$md_default'"
+  fi
+done
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -66,9 +66,10 @@ for setting in $md_settings; do
   fi
 done
 
-# --- Check 3: Default values match for simple types ---
-# For object/array types, use compact JSON for comparison where the table
-# uses JSON-like notation, or skip where the table uses shorthand.
+# --- Check 3: Default values match across supported table representations ---
+# Compare scalar defaults directly and array/object defaults via compact JSON
+# when the table uses JSON-like notation; skip only keys whose table values
+# use non-JSON shorthand representations.
 echo ""
 echo "--- Check: default values match ---"
 
@@ -88,7 +89,8 @@ for key in $json_keys; do
     continue
   fi
 
-  # Extract the default column (4th field) from the matching config.md row
+  # Extract the default column from the matching config.md row.
+  # With awk -F'|', the leading pipe is field 1, so the 4th visible table column is $5.
   md_row=$(grep -E "^\| ${key} \|" "$CONFIG_MD" || true)
   if [ -z "$md_row" ]; then
     # Already caught by Check 1, skip value comparison

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -33,7 +33,7 @@ echo "=== Config Defaults Sync Contract (Issue #373) ==="
 # Extract setting names from the markdown table.
 # Table rows look like: | setting_name | type | values | default |
 # Skip the header row (Setting) and separator row (------).
-md_settings=$(grep -E '^\| [a-z_]+ \|' "$CONFIG_MD" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2}')
+md_settings=$(grep -E '^\| [a-z0-9_]+ \|' "$CONFIG_MD" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2}')
 
 # Extract keys from defaults.json
 json_keys=$(jq -r 'keys[]' "$DEFAULTS_JSON")

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -39,7 +39,10 @@ if [ -z "$md_settings" ]; then
 fi
 
 # Extract keys from defaults.json
-json_keys=$(jq -r 'keys[]' "$DEFAULTS_JSON")
+if ! json_keys=$(jq -r 'keys[]' "$DEFAULTS_JSON"); then
+  fail "Could not extract keys from defaults.json; file is missing, unreadable, or invalid JSON"
+  json_keys=""
+fi
 if [ -z "$json_keys" ]; then
   fail "No keys could be extracted from defaults.json"
 fi

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -33,10 +33,16 @@ echo "=== Config Defaults Sync Contract (Issue #373) ==="
 # Extract setting names from the markdown table.
 # Table rows look like: | setting_name | type | values | default |
 # Skip the header row (Setting) and separator row (------).
-md_settings=$(grep -E '^\| [a-z0-9_]+ \|' "$CONFIG_MD" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2}')
+md_settings=$(grep -E '^\| [a-z0-9_]+ \|' "$CONFIG_MD" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2}' || true)
+if [ -z "$md_settings" ]; then
+  fail "No settings rows could be extracted from config.md table; expected rows like '| setting_name | type | values | default |'"
+fi
 
 # Extract keys from defaults.json
 json_keys=$(jq -r 'keys[]' "$DEFAULTS_JSON")
+if [ -z "$json_keys" ]; then
+  fail "No keys could be extracted from defaults.json"
+fi
 
 # --- Check 1: Every key in defaults.json has a row in config.md ---
 echo ""


### PR DESCRIPTION
Fixes #373

## What

Synchronizes the settings reference table in `commands/config.md` with the source of truth in `config/defaults.json`. Six discrepancies were identified and fixed:

- **`commands/config.md`**: Fixed `lease_locks` default (`false` → `true`), fixed `event_recovery` default (`false` → `true`), removed graduated `subagent_skill_xml_mode` row, added missing `discussion_mode`, `qa_skip_agents`, and `worktree_isolation` rows.
- **`testing/verify-config-defaults-sync.sh`**: New contract test that validates key-set parity and default-value agreement between config.md and defaults.json.
- **`testing/list-contract-tests.sh`**: Registered the new contract test.

## Why

The settings reference table is an LLM-consumed artifact that guides `/vbw:config` behavior. When defaults drift from the source of truth, the LLM presents incorrect information to users. The root cause is that there was no automated check enforcing table ↔ JSON agreement — each change to `defaults.json` relied on the author remembering to update the markdown table. The new contract test prevents this class of drift permanently.

## How

- **`commands/config.md`**: Updated the markdown table — corrected two boolean defaults, deleted the graduated `subagent_skill_xml_mode` row, and inserted three new rows (`discussion_mode`, `qa_skip_agents`, `worktree_isolation`) in thematically appropriate positions.
- **`testing/verify-config-defaults-sync.sh`**: Three-check contract test: (1) every `defaults.json` key has a row in config.md, (2) every config.md setting exists in `defaults.json`, (3) default values match — using `jq -c` compact JSON for array/object types, with a shorthand exception only for `agent_max_turns` (whose table representation is non-JSON).
- **`testing/list-contract-tests.sh`**: Added `config-defaults-sync` entry to the shared registry.

## Acceptance criteria verification

1. **`config.md` `lease_locks` default matches `defaults.json` value (`true`)** — satisfied: `commands/config.md` line 402 shows `true`, verified by contract test Check 3.
2. **`config.md` `event_recovery` default matches `defaults.json` value (`true`)** — satisfied: `commands/config.md` line 403 shows `true`, verified by contract test Check 3.
3. **`subagent_skill_xml_mode` is removed from config.md** — satisfied: `grep -c subagent_skill_xml_mode commands/config.md` returns 0. Already graduated per `migrate-config.sh` line 148 and BATS test `tests/config-migration.bats` line 194.
4. **A contract test in `testing/` asserts that config.md defaults match defaults.json** — satisfied: `testing/verify-config-defaults-sync.sh` runs 122 checks (41 key-presence + 41 reverse + 40 value comparisons), registered in `list-contract-tests.sh`, wired into `run-all.sh` and CI via shared discovery.

## Testing

- [x] `bash testing/verify-config-defaults-sync.sh` — 122 PASS, 0 FAIL
- [x] `bash testing/run-all.sh` — Lint 1/1, Contract 35/35, BATS 2670/0

## QA summary

| Phase | Model | Rounds | Findings |
|-------|-------|--------|----------|
| Primary QA (Phase 3) | Claude Opus | 3 | R1: clean, R2: clean, R3: 1 low fixed (regex `[a-z_]+` → `[a-z0-9_]+`) |
| Cross-model QA (Phase 3.5) | GPT-5.4 | 2 | M1: 1 medium fixed (narrowed SHORTHAND_KEYS, added `jq -c` for complex defaults), M2: clean |

- Total findings: 2 (1 low + 1 medium), both fixed
- False positives: 0