### PR TITLE
feat(vibe): add skill evaluation to remediation recovery spawn sites

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -429,6 +429,8 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
   - After writing the plan, advance state: `bash {plugin-root}/scripts/qa-remediation-state.sh advance {phase-dir}`
 
 - **stage=execute:** Spawn a Dev subagent per `R{RR}-PLAN.md`:
+  - Before composing the Dev task description, evaluate installed skills visible in your system context — read each skill's description and determine if it is relevant to this specific task. The Dev prompt MUST begin with exactly one explicit skill outcome block: use `<skill_activation>{For each relevant skill: "Call Skill({skill-name})"}</skill_activation>` when one or more installed skills apply, or `<skill_no_activation>Evaluated installed skills for this task. No installed skills apply. Reason: {brief task-specific reason}.</skill_no_activation>` when none apply. Silent omission of both blocks is invalid. After evaluating, state the skill outcome in your response (e.g., "Skills: activating {skill-name}" or "Skills: none apply — {reason}") so the user has visibility before the agent is spawned. Only include skills whose description matches the task at hand.
+  - Also evaluate available MCP tools in your system context. If any MCP servers provide build, test, or domain-specific capabilities relevant to the remediation tasks, note them in the Dev's task context.
   - Always subagent — NO team creation for QA remediation (NON-NEGOTIABLE)
   - Dev fixes code, commits, writes `R{RR}-SUMMARY.md` in `{round_dir}` using `templates/REMEDIATION-SUMMARY.md` (NOT `templates/SUMMARY.md`)
     - The remediation summary frontmatter MUST include aggregated `commit_hashes`, `files_modified`, and `deviations`
@@ -438,6 +440,8 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
 
 - **stage=verify:** Re-run QA:
   - Run `compile-verify-context.sh --remediation-only {phase-dir}` to get compounded verification history plus the current round's plan/summary context only
+  - Before composing the QA task description, evaluate installed skills visible in your system context — read each skill's description and determine if it is relevant to verifying this remediation round's work. The QA prompt MUST begin with exactly one explicit skill outcome block: use `<skill_activation>{For each relevant skill: "Call Skill({skill-name})"}</skill_activation>` when one or more installed skills apply, or `<skill_no_activation>Evaluated installed skills for this task. No installed skills apply. Reason: {brief task-specific reason}.</skill_no_activation>` when none apply. Silent omission of both blocks is invalid. After evaluating, state the skill outcome in your response (e.g., "Skills: activating {skill-name}" or "Skills: none apply — {reason}") so the user has visibility before the agent is spawned. Only include skills whose description matches the verification task.
+  - Also evaluate available MCP tools in your system context. If any MCP servers provide build, test, documentation, or domain-specific capabilities relevant to verification, note them in the QA task context.
   - Spawn QA agent as subagent — writes to `{verification_path}` (from `qa-remediation-state.sh get` metadata)
     - The output path is `{round_dir}/R{RR}-VERIFICATION.md` — NOT the phase-level file
     - Phase-level VERIFICATION.md stays frozen as the original QA FAIL result

--- a/testing/verify-skill-activation.sh
+++ b/testing/verify-skill-activation.sh
@@ -48,7 +48,7 @@ fail() {
 
 expected_skill_contract_sites() {
   case "$(basename "$1")" in
-    vibe.md) echo 8 ;;
+    vibe.md) echo 10 ;;
     debug.md) echo 2 ;;
     research.md|fix.md|qa.md|execute-protocol.md) echo 1 ;;
     map.md) echo 2 ;;


### PR DESCRIPTION
Fixes #381

## What

Adds skill evaluation instruction blocks to the two QA Remediation cross-session recovery spawn paths in `commands/vibe.md`:

- **`commands/vibe.md`**: Added Dev skill evaluation block before `stage=execute` spawn (~line 432) and QA skill evaluation block before `stage=verify` spawn (~line 443). Each block includes the standard `evaluate installed skills visible in your system context` pattern with `<skill_activation>` / `<skill_no_activation>` XML blocks, explicit one-of-two outcome contract, visible reporting instruction, and MCP tool evaluation bullet.
- **`testing/verify-skill-activation.sh`**: Updated `expected_skill_contract_sites()` return value for `vibe.md` from 8 to 10.

## Why

The QA Remediation cross-session recovery path was the only spawn path in the codebase that lacked skill evaluation instructions. Issue #379 addressed the 16 primary spawn paths but explicitly scoped out the recovery paths. This created an inconsistency where skill decisions were invisible and unlogged when resuming remediation from a previous session. The root cause is that the recovery path was added before the skill evaluation contract was established, and #379's scope boundary left it unaddressed.

## How

- **`commands/vibe.md`**: Inserted the standard skill evaluation preamble (2 bullets each — skill eval + MCP tool eval) at the two recovery spawn sites. The Dev block uses "remediation tasks" scoping language; the QA block uses "this remediation round's work" / "verification task" scoping language. Both are structurally identical to the 8 existing blocks.
- **`testing/verify-skill-activation.sh`**: Changed the hard-coded expected count from 8 to 10 in the `expected_skill_contract_sites()` case statement.

## Acceptance Criteria Verification

1. **`stage=execute` Dev spawn includes skill evaluation** — satisfied by `commands/vibe.md` ~line 432, full pattern with activation/no-activation/visible-reporting
2. **`stage=verify` QA spawn includes skill evaluation** — satisfied by `commands/vibe.md` ~line 443, same pattern adapted for QA verification context
3. **Expected count updated from 8 to 10** — satisfied by `testing/verify-skill-activation.sh` line 52
4. **All tests pass** — `bash testing/run-all.sh`: 1/1 lint, 34/34 contract, 2670/0 BATS
5. **New blocks pass all 5 per-site contract checks** — verified by `bash testing/verify-skill-activation.sh`: 268 PASS, 0 FAIL

## Testing

- [x] `bash testing/verify-skill-activation.sh` — 268 PASS, 0 FAIL (includes 10 per-site checks for vibe.md)
- [x] `bash testing/run-all.sh` — 1/1 lint, 34/34 contract, 2670 BATS passed, 0 failed
- [x] `grep -c 'evaluate installed skills visible' commands/vibe.md` returns 10

## QA Summary

- **Primary QA (Phase 3)**: 3 rounds with Claude Opus 4.6 — 0 findings across all rounds
- **Cross-model QA (Phase 3.5)**: 1 round with GPT-5.4 — 0 findings
- **Copilot PR review (Phase 4.5)**: pending
- **Total findings**: 0 (0 fixed, 0 false positives)