### PR TITLE
feat(research): backfill all frontmatter fields during migrate

### DIFF
--- a/scripts/research-session-state.sh
+++ b/scripts/research-session-state.sh
@@ -359,7 +359,8 @@ ENDSESSION
       if stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH" > /dev/null 2>&1; then
         created_ts=$(stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH")  # macOS/BSD
       elif stat -c '%Y' "$NEW_PATH" > /dev/null 2>&1; then
-        created_ts=$(date -d "@$(stat -c '%Y' "$NEW_PATH")" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')  # GNU/Linux
+        _epoch=$(stat -c '%Y' "$NEW_PATH")
+        created_ts=$(date -d "@$_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -r "$_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')  # GNU/Linux / mixed coreutils
       else
         created_ts=$(date '+%Y-%m-%d %H:%M:%S')  # fallback
       fi
@@ -419,8 +420,8 @@ ENDSESSION
         # Guard update_field with || inject_field fallback: if the field key
         # exists but update_field fails (e.g. malformed frontmatter without
         # closing ---), fall back to inject_field which is more tolerant.
-        _defaults="status:complete base_commit:unknown type:standalone-research confidence:medium linked_sessions:[]"
-        for _pair in $_defaults; do
+        _defaults=("status:complete" "base_commit:unknown" "type:standalone-research" "confidence:medium" "linked_sessions:[]")
+        for _pair in "${_defaults[@]}"; do
           _field="${_pair%%:*}"
           _val=$(read_field "$NEW_PATH" "$_field")
           if [ -z "$_val" ]; then

--- a/scripts/research-session-state.sh
+++ b/scripts/research-session-state.sh
@@ -387,7 +387,8 @@ ENDSESSION
           cat "$NEW_PATH"
         } > "$NEW_PATH.tmp" && mv "$NEW_PATH.tmp" "$NEW_PATH"
       else
-        # File has frontmatter — backfill all missing template fields
+        # File has frontmatter — backfill all missing template fields.
+        # inject_field only adds absent keys; it won't overwrite existing values.
         inject_field "$NEW_PATH" "status" "complete"
         inject_field "$NEW_PATH" "base_commit" "unknown"
         inject_field "$NEW_PATH" "type" "standalone-research"
@@ -396,11 +397,38 @@ ENDSESSION
         inject_field "$NEW_PATH" "updated" "$created_ts"
         inject_field "$NEW_PATH" "linked_sessions" "[]"
 
-        # Now update status to complete (in case it existed with a different value)
+        # Capture the correct 'updated' value BEFORE any update_field calls.
+        # update_field cascades a wall-clock write to 'updated' on every
+        # non-'updated' field change, which would clobber the original or
+        # just-injected value.
+        correct_updated=$(read_field "$NEW_PATH" "updated")
+        correct_updated="${correct_updated:-$created_ts}"
+
+        # Fill blank-but-present fields with defaults (inject_field skips
+        # fields that exist even if their value is empty)
+        _defaults="status:complete base_commit:unknown type:standalone-research confidence:medium linked_sessions:[]"
+        for _pair in $_defaults; do
+          _field="${_pair%%:*}"
+          _val=$(read_field "$NEW_PATH" "$_field")
+          if [ -z "$_val" ]; then
+            update_field "$NEW_PATH" "$_field" "${_pair#*:}"
+          fi
+        done
+        # Handle created separately (default is mtime, not a static string)
+        if [ -z "$(read_field "$NEW_PATH" "created")" ]; then
+          update_field "$NEW_PATH" "created" "$created_ts"
+        fi
+
+        # Ensure status is complete (update_field used instead of inject_field
+        # to handle the case where status exists with a non-complete value)
         existing_status=$(read_field "$NEW_PATH" "status")
         if [ "$existing_status" != "complete" ]; then
           update_field "$NEW_PATH" "status" "complete"
         fi
+
+        # Restore 'updated' to its pre-mutation value. update_field does not
+        # cascade when the target field IS 'updated', so this is safe.
+        update_field "$NEW_PATH" "updated" "$correct_updated"
       fi
 
       MIGRATED=$((MIGRATED + 1))

--- a/scripts/research-session-state.sh
+++ b/scripts/research-session-state.sh
@@ -364,8 +364,18 @@ ENDSESSION
         created_ts=$(date '+%Y-%m-%d %H:%M:%S')  # fallback
       fi
 
-      # Inject frontmatter if the file doesn't already have it
-      if ! head -1 "$NEW_PATH" | grep -q '^---$'; then
+      # Determine whether the file has well-formed frontmatter (opening AND
+      # closing ---). If only the opening delimiter exists, treat as no
+      # frontmatter and prepend a full block.
+      has_frontmatter=false
+      if head -1 "$NEW_PATH" | grep -q '^---$'; then
+        # Count --- delimiters; well-formed needs at least 2
+        if awk '/^---$/ { c++ } c >= 2 { exit 0 } END { exit (c < 2) }' "$NEW_PATH" 2>/dev/null; then
+          has_frontmatter=true
+        fi
+      fi
+
+      if [ "$has_frontmatter" = "false" ]; then
         # Extract title from first heading, fallback to slug
         extracted_title=$(grep -m 1 '^#' "$NEW_PATH" | sed -E 's/^#+[[:space:]]*//' || true)
         [ -z "$extracted_title" ] && extracted_title="$slug"

--- a/scripts/research-session-state.sh
+++ b/scripts/research-session-state.sh
@@ -405,30 +405,33 @@ ENDSESSION
         correct_updated="${correct_updated:-$created_ts}"
 
         # Fill blank-but-present fields with defaults (inject_field skips
-        # fields that exist even if their value is empty)
+        # fields that exist even if their value is empty).
+        # Guard update_field with || inject_field fallback: if the field key
+        # exists but update_field fails (e.g. malformed frontmatter without
+        # closing ---), fall back to inject_field which is more tolerant.
         _defaults="status:complete base_commit:unknown type:standalone-research confidence:medium linked_sessions:[]"
         for _pair in $_defaults; do
           _field="${_pair%%:*}"
           _val=$(read_field "$NEW_PATH" "$_field")
           if [ -z "$_val" ]; then
-            update_field "$NEW_PATH" "$_field" "${_pair#*:}"
+            update_field "$NEW_PATH" "$_field" "${_pair#*:}" || inject_field "$NEW_PATH" "$_field" "${_pair#*:}"
           fi
         done
         # Handle created separately (default is mtime, not a static string)
         if [ -z "$(read_field "$NEW_PATH" "created")" ]; then
-          update_field "$NEW_PATH" "created" "$created_ts"
+          update_field "$NEW_PATH" "created" "$created_ts" || inject_field "$NEW_PATH" "created" "$created_ts"
         fi
 
         # Ensure status is complete (update_field used instead of inject_field
         # to handle the case where status exists with a non-complete value)
         existing_status=$(read_field "$NEW_PATH" "status")
         if [ "$existing_status" != "complete" ]; then
-          update_field "$NEW_PATH" "status" "complete"
+          update_field "$NEW_PATH" "status" "complete" || true
         fi
 
         # Restore 'updated' to its pre-mutation value. update_field does not
         # cascade when the target field IS 'updated', so this is safe.
-        update_field "$NEW_PATH" "updated" "$correct_updated"
+        update_field "$NEW_PATH" "updated" "$correct_updated" || true
       fi
 
       MIGRATED=$((MIGRATED + 1))

--- a/scripts/research-session-state.sh
+++ b/scripts/research-session-state.sh
@@ -355,20 +355,20 @@ ENDSESSION
 
       mv "$f" "$NEW_PATH"
 
+      # Compute file mtime for created/updated timestamps (used by both branches)
+      if stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH" > /dev/null 2>&1; then
+        created_ts=$(stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH")  # macOS/BSD
+      elif stat -c '%Y' "$NEW_PATH" > /dev/null 2>&1; then
+        created_ts=$(date -d "@$(stat -c '%Y' "$NEW_PATH")" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')  # GNU/Linux
+      else
+        created_ts=$(date '+%Y-%m-%d %H:%M:%S')  # fallback
+      fi
+
       # Inject frontmatter if the file doesn't already have it
       if ! head -1 "$NEW_PATH" | grep -q '^---$'; then
         # Extract title from first heading, fallback to slug
         extracted_title=$(grep -m 1 '^#' "$NEW_PATH" | sed -E 's/^#+[[:space:]]*//' || true)
         [ -z "$extracted_title" ] && extracted_title="$slug"
-
-        # Use file mtime for created/updated timestamps
-        if stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH" > /dev/null 2>&1; then
-          created_ts=$(stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$NEW_PATH")  # macOS/BSD
-        elif stat -c '%Y' "$NEW_PATH" > /dev/null 2>&1; then
-          created_ts=$(date -d "@$(stat -c '%Y' "$NEW_PATH")" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')  # GNU/Linux
-        else
-          created_ts=$(date '+%Y-%m-%d %H:%M:%S')  # fallback
-        fi
 
         # YAML-safe title: quote to protect special chars (#, :, etc.)
         safe_title=$(printf '%s' "$extracted_title" | sed 's/\\/\\\\/g; s/"/\\"/g')
@@ -387,10 +387,14 @@ ENDSESSION
           cat "$NEW_PATH"
         } > "$NEW_PATH.tmp" && mv "$NEW_PATH.tmp" "$NEW_PATH"
       else
-        # File has frontmatter — backfill missing required fields and ensure status=complete
+        # File has frontmatter — backfill all missing template fields
         inject_field "$NEW_PATH" "status" "complete"
         inject_field "$NEW_PATH" "base_commit" "unknown"
         inject_field "$NEW_PATH" "type" "standalone-research"
+        inject_field "$NEW_PATH" "confidence" "medium"
+        inject_field "$NEW_PATH" "created" "$created_ts"
+        inject_field "$NEW_PATH" "updated" "$created_ts"
+        inject_field "$NEW_PATH" "linked_sessions" "[]"
 
         # Now update status to complete (in case it existed with a different value)
         existing_status=$(read_field "$NEW_PATH" "status")

--- a/tests/research-session-state.bats
+++ b/tests/research-session-state.bats
@@ -325,6 +325,58 @@ EOF
   [[ "$output" != *"research_updated=''"* ]]
 }
 
+@test "migrate preserves existing updated timestamp when status changes" {
+  cat > "$VBW_PLANNING_DIR/RESEARCH-upd-preserve.md" << 'EOF'
+---
+title: Updated Preserve
+status: active
+updated: 2023-06-15 10:30:00
+---
+
+# Updated Preserve
+Legacy file with explicit updated timestamp.
+EOF
+
+  run bash "$SCRIPTS_DIR/research-session-state.sh" migrate "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"migrated=1"* ]]
+
+  local migrated_file
+  migrated_file=$(find "$VBW_PLANNING_DIR/research" -name "*upd-preserve*" | head -1)
+  # Status should be updated to complete
+  grep -q '^status: complete$' "$migrated_file"
+  # Updated should preserve the original value, not wall-clock time
+  grep -q '^updated: 2023-06-15 10:30:00$' "$migrated_file"
+}
+
+@test "migrate fills blank-but-present frontmatter values with defaults" {
+  cat > "$VBW_PLANNING_DIR/RESEARCH-blank-vals.md" << 'EOF'
+---
+title: Blank Values
+confidence:
+base_commit:
+---
+
+# Blank Values
+File with blank frontmatter values.
+EOF
+
+  run bash "$SCRIPTS_DIR/research-session-state.sh" migrate "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"migrated=1"* ]]
+
+  local migrated_file
+  migrated_file=$(find "$VBW_PLANNING_DIR/research" -name "*blank-vals*" | head -1)
+  # Blank values should be filled with defaults
+  local fm_confidence fm_base
+  fm_confidence=$(awk '/^---$/ { if (!s) { s=1; next } if (s) exit } s && /^confidence:/ { sub(/^confidence:[[:space:]]*/, ""); print }' "$migrated_file")
+  fm_base=$(awk '/^---$/ { if (!s) { s=1; next } if (s) exit } s && /^base_commit:/ { sub(/^base_commit:[[:space:]]*/, ""); print }' "$migrated_file")
+  [ "$fm_confidence" = "medium" ]
+  [ "$fm_base" = "unknown" ]
+  # Title should be preserved
+  grep -q '^title: Blank Values$' "$migrated_file"
+}
+
 @test "migrate backfills missing fields even when body contains matching tokens" {
   cat > "$VBW_PLANNING_DIR/RESEARCH-bodytoken.md" << 'EOF'
 ---

--- a/tests/research-session-state.bats
+++ b/tests/research-session-state.bats
@@ -286,6 +286,45 @@ EOF
   grep -q '^confidence: high$' "$migrated_file"
 }
 
+@test "migrate backfills all template fields in partial frontmatter" {
+  cat > "$VBW_PLANNING_DIR/RESEARCH-allfields.md" << 'EOF'
+---
+title: Only Title
+---
+
+# Only Title
+Content with only title in frontmatter.
+EOF
+
+  run bash "$SCRIPTS_DIR/research-session-state.sh" migrate "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"migrated=1"* ]]
+
+  local migrated_file
+  migrated_file=$(find "$VBW_PLANNING_DIR/research" -name "*allfields*" | head -1)
+  # All 7 template fields should be present
+  grep -q '^status: complete$' "$migrated_file"
+  grep -q '^base_commit: unknown$' "$migrated_file"
+  grep -q '^type: standalone-research$' "$migrated_file"
+  grep -q '^confidence: medium$' "$migrated_file"
+  grep -q '^created: ' "$migrated_file"
+  grep -q '^updated: ' "$migrated_file"
+  grep -q '^linked_sessions: \[\]$' "$migrated_file"
+  # Original title preserved
+  grep -q '^title: Only Title$' "$migrated_file"
+
+  # Verify get returns non-blank values for all fields
+  local session_id="${migrated_file##*/}"
+  session_id="${session_id%.md}"
+  run bash "$SCRIPTS_DIR/research-session-state.sh" get "$VBW_PLANNING_DIR" "$session_id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"research_status=complete"* ]]
+  [[ "$output" == *"research_confidence=medium"* ]]
+  # created and updated should not be empty
+  [[ "$output" != *"research_created=''"* ]]
+  [[ "$output" != *"research_updated=''"* ]]
+}
+
 @test "migrate backfills missing fields even when body contains matching tokens" {
   cat > "$VBW_PLANNING_DIR/RESEARCH-bodytoken.md" << 'EOF'
 ---


### PR DESCRIPTION
Fixes #396

## What

Extends `research-session-state.sh migrate`'s existing-frontmatter branch to backfill all 7 template fields (was only 3: `status`, `base_commit`, `type`). Now also backfills `confidence`, `created`, `updated`, and `linked_sessions` when missing. Adds blank-value detection and `updated` timestamp preservation.

## Why

Legacy `RESEARCH-*.md` files migrated with partial frontmatter would have blank metadata for `confidence`, `created`, `updated`, and `linked_sessions`, causing `get` to return empty values. The root cause was that the migrate path's existing-frontmatter branch only injected the 3 fields required for staleness tracking, leaving optional fields unfilled. Additionally, `update_field`'s cascade behavior would overwrite `updated` with wall-clock time during status normalization, and blank-but-present keys (e.g., `confidence:` with no value) bypassed `inject_field`.

## How

- **`scripts/research-session-state.sh`**: Hoisted `created_ts` (file mtime) computation above the frontmatter if/else so both branches share it. Added 4 `inject_field` calls for `confidence`, `created`, `updated`, `linked_sessions`. Added blank-value fill pass that uses `update_field` for keys that exist but have empty values. Added `updated` preservation: captures the correct value before any `update_field` mutations and restores it as the terminal operation. 
- **`tests/research-session-state.bats`**: Added 3 new tests: full-field backfill verification (including `get` output), `updated` timestamp preservation when status changes, blank-value filling for empty frontmatter keys.

## Acceptance Criteria Verification

1. **`migrate` backfills all 7 template fields when missing** — Satisfied by 7 `inject_field` calls at `scripts/research-session-state.sh` lines 390-398, plus blank-value fill pass at lines 404-419. Tested in `tests/research-session-state.bats` test "migrate backfills all template fields in partial frontmatter".
2. **`get` returns non-blank values for all fields on migrated files** — Satisfied by the same backfill logic. The BATS test calls `get` on the migrated file and asserts `research_status`, `research_confidence`, `research_created`, `research_updated` are non-blank.
3. **Existing valid field values are never overwritten by defaults** — `inject_field` skips existing keys. Blank-value fill only updates when `read_field` returns empty. `updated` is preserved via capture/restore pattern. Tested in "migrate preserves existing updated timestamp when status changes" and "migrate backfills missing status and base_commit in existing frontmatter" (verifies `confidence: high` preserved).
4. **BATS test covers the full-field backfill case** — Test "migrate backfills all template fields in partial frontmatter" covers all 7 fields.

## Testing

- [x] `bash testing/run-all.sh` — 2728 BATS tests passed, 37/37 contract checks, lint clean
- [x] 3 new BATS tests added for the specific behaviors
- [x] `testing/verify-research-storage-contract.sh` — passes (validates template field structure)

## QA Summary

- **Primary QA (Claude Opus 4.6)**: 3 rounds. Round 1: 3 low observations (test gap coverage — implicit coverage sufficient, not fixed). Rounds 2-3: zero findings.
- **Cross-model QA (GPT-5.4)**: 2 rounds. Round 1: 2 medium contract findings — F-01: `update_field` cascade overwrites `updated` (fixed in `5999d07`); F-02: blank-but-present keys bypass `inject_field` (fixed in `5999d07`). Round 2: zero findings.
- **Total**: 5 findings across all rounds. 2 fixed (both medium contract). 3 not fixed (all low observations — implicit coverage sufficient).