### PR TITLE
fix(tests): use _ORIG_HOME for real HOME capture after setup_temp_dir

### DIFF
--- a/tests/inject-subagent-skills.bats
+++ b/tests/inject-subagent-skills.bats
@@ -6,7 +6,7 @@ load test_helper
 
 setup() {
   setup_temp_dir
-  export ORIG_HOME="$HOME"
+  export ORIG_HOME="${_ORIG_HOME:-$HOME}"
   export ORIG_CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-}"
   export HOME="$TEST_TEMP_DIR"
   export CLAUDE_CONFIG_DIR="$TEST_TEMP_DIR/.claude-config"

--- a/tests/inject-subagent-skills.bats
+++ b/tests/inject-subagent-skills.bats
@@ -28,6 +28,10 @@ teardown() {
 
 # --- inject-subagent-skills.sh removal verification ---
 
+@test "ORIG_HOME captures real HOME, not temp dir" {
+  [ "$ORIG_HOME" != "$TEST_TEMP_DIR" ]
+}
+
 @test "inject-subagent-skills: script is deleted" {
   [ ! -f "$SCRIPTS_DIR/inject-subagent-skills.sh" ]
 }

--- a/tests/resolve-claude-dir.bats
+++ b/tests/resolve-claude-dir.bats
@@ -7,7 +7,7 @@ load test_helper
 setup() {
   setup_temp_dir
   # Save original values
-  export ORIG_HOME="$HOME"
+  export ORIG_HOME="${_ORIG_HOME:-$HOME}"
   export ORIG_CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-}"
 }
 

--- a/tests/resolve-claude-dir.bats
+++ b/tests/resolve-claude-dir.bats
@@ -21,6 +21,10 @@ teardown() {
 
 # --- resolve-claude-dir.sh tests ---
 
+@test "ORIG_HOME captures real HOME, not temp dir" {
+  [ "$ORIG_HOME" != "$TEST_TEMP_DIR" ]
+}
+
 @test "resolve-claude-dir.sh defaults to HOME/.claude when CLAUDE_CONFIG_DIR unset" {
   unset CLAUDE_CONFIG_DIR
   export HOME="$TEST_TEMP_DIR"


### PR DESCRIPTION
Fixes #407

## What

Two-line fix in `tests/resolve-claude-dir.bats` and `tests/inject-subagent-skills.bats` — changed `ORIG_HOME="$HOME"` to `ORIG_HOME="${_ORIG_HOME:-$HOME}"` so the capture reads the real pre-override HOME saved by `setup_temp_dir()` instead of the temp directory.

Added regression tests in both files asserting `ORIG_HOME != TEST_TEMP_DIR`.

## Why

After PR #409 merged (fixing #404), `setup_temp_dir()` in `test_helper.bash` now sets `HOME="$TEST_TEMP_DIR"` before the per-file `setup()` functions run. The `ORIG_HOME="$HOME"` assignments in these two files therefore captured the temp dir instead of the real HOME. While `teardown_temp_dir()` authoritatively restores HOME via `_ORIG_HOME`, the semantic intent of `ORIG_HOME` was violated — `_ORIG_HOME` already holds the correct value, so referencing it is the architecturally correct fix.

## How

- **`tests/resolve-claude-dir.bats`**: Changed line 10 from `export ORIG_HOME="$HOME"` to `export ORIG_HOME="${_ORIG_HOME:-$HOME}"`. Added regression test `"ORIG_HOME captures real HOME, not temp dir"`.
- **`tests/inject-subagent-skills.bats`**: Changed line 9 from `export ORIG_HOME="$HOME"` to `export ORIG_HOME="${_ORIG_HOME:-$HOME}"`. Added regression test `"ORIG_HOME captures real HOME, not temp dir"`.

## Acceptance criteria verification

1. **`ORIG_HOME` in both files captures the real HOME, not the temp dir**: Satisfied by `${_ORIG_HOME:-$HOME}` expansion — `_ORIG_HOME` is set by `setup_temp_dir()` at `test_helper.bash` line 19 before HOME is overridden at line 22. Regression tests in both files assert `ORIG_HOME != TEST_TEMP_DIR`.
2. **All existing tests continue to pass**: 2744/2744 BATS tests pass, 38/38 contract checks pass, lint clean.

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] BATS tests: 2744/2744 passing (2 new regression tests added)
- [x] Lint: shellcheck + bash -n clean
- [x] Contract checks: 38/38 passing
- [x] Existing commands still work

## QA summary

- **Primary QA**: 3 rounds (Claude Opus 4.6) — all clean, zero findings
- **Cross-model QA**: 3 rounds (GPT-5.4) — round 1: 1 low observation (test-coverage gap, fixed with regression test in resolve-claude-dir.bats); round 2: 1 low observation (matching gap in inject-subagent-skills.bats, fixed); round 3: 1 low finding (empty HOME edge case — false positive, HOME is always set in real environments)
- **Copilot PR review**: pending
- Total findings: 2 legitimate (both fixed — regression tests added), 1 false positive