### PR TITLE
fix(security-filter): anchor directory patterns as path components

### DIFF
--- a/scripts/security-filter.sh
+++ b/scripts/security-filter.sh
@@ -20,7 +20,9 @@ if [ -z "$FILE_PATH" ]; then
 fi
 
 # Sensitive file patterns
-if echo "$FILE_PATH" | grep -qE '\.env$|\.env\.|\.pem$|\.key$|\.cert$|\.p12$|\.pfx$|credentials\.json$|secrets\.json$|service-account.*\.json$|node_modules/|\.git/|dist/|build/'; then
+# Directory patterns use (^|/) anchoring so they match only as path components,
+# not as substrings of unrelated directory names (e.g. "corvex-build/" != "build/").
+if echo "$FILE_PATH" | grep -qE '\.env$|\.env\.|\.pem$|\.key$|\.cert$|\.p12$|\.pfx$|credentials\.json$|secrets\.json$|service-account.*\.json$|(^|/)node_modules/|(^|/)\.git/|(^|/)dist/|(^|/)build/'; then
   echo "Blocked: sensitive file ($FILE_PATH)" >&2
   exit 2
 fi

--- a/tests/hooks-isolation-lifecycle.bats
+++ b/tests/hooks-isolation-lifecycle.bats
@@ -127,13 +127,13 @@ load test_helper
 }
 
 @test "security-filter allows file when parent dir contains dist substring" {
-  INPUT='{"tool_input":{"file_path":"/home/user/redistribution/src/main.js"}}'
+  INPUT='{"tool_input":{"file_path":"/home/user/my-dist/bundle.js"}}'
   run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
   [ "$status" -eq 0 ]
 }
 
 @test "security-filter allows file when parent dir contains node_modules substring" {
-  INPUT='{"tool_input":{"file_path":"/home/user/my-node_modules-archive/readme.md"}}'
+  INPUT='{"tool_input":{"file_path":"/home/user/old-node_modules/lodash/index.js"}}'
   run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
   [ "$status" -eq 0 ]
 }

--- a/tests/hooks-isolation-lifecycle.bats
+++ b/tests/hooks-isolation-lifecycle.bats
@@ -138,6 +138,12 @@ load test_helper
   [ "$status" -eq 0 ]
 }
 
+@test "security-filter allows file when parent dir contains .git substring" {
+  INPUT='{"tool_input":{"file_path":"/home/user/repo.git/HEAD"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
 # --- Task 3: Session config cache ---
 
 @test "session config cache file is written at session start" {

--- a/tests/hooks-isolation-lifecycle.bats
+++ b/tests/hooks-isolation-lifecycle.bats
@@ -82,6 +82,62 @@ load test_helper
   echo "$output" | grep -q "sensitive file"
 }
 
+# --- Directory pattern path-component anchoring (issue #402) ---
+
+@test "security-filter blocks build/ as path component (relative)" {
+  INPUT='{"tool_input":{"file_path":"build/output.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter blocks build/ as path component (absolute)" {
+  INPUT='{"tool_input":{"file_path":"/home/user/project/build/output.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter blocks dist/ as path component" {
+  INPUT='{"tool_input":{"file_path":"dist/bundle.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter blocks node_modules/ as path component" {
+  INPUT='{"tool_input":{"file_path":"node_modules/lodash/index.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter blocks .git/ as path component" {
+  INPUT='{"tool_input":{"file_path":".git/config"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+}
+
+@test "security-filter allows file when parent dir contains build substring" {
+  INPUT='{"tool_input":{"file_path":"/home/user/corvex-build/src/app.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "security-filter allows file named build-something" {
+  INPUT='{"tool_input":{"file_path":"build-orbstack.sh"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "security-filter allows file when parent dir contains dist substring" {
+  INPUT='{"tool_input":{"file_path":"/home/user/redistribution/src/main.js"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "security-filter allows file when parent dir contains node_modules substring" {
+  INPUT='{"tool_input":{"file_path":"/home/user/my-node_modules-archive/readme.md"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+}
+
 # --- Task 3: Session config cache ---
 
 @test "session config cache file is written at session start" {


### PR DESCRIPTION
Fixes #402

## What

Anchored the four directory-based sensitive file patterns (`build/`, `dist/`, `node_modules/`, `.git/`) in `scripts/security-filter.sh` as path components instead of substrings. Added 10 new BATS tests covering both blocking and allowing cases for all four patterns.

**Files modified:**
- `scripts/security-filter.sh` — regex fix (line 25)
- `tests/hooks-isolation-lifecycle.bats` — 10 new test cases

## Why

The grep regex used unanchored `build/`, `dist/`, `node_modules/`, `.git/` patterns for substring matching. This caused false positives when a parent directory name contained these substrings — e.g., `corvex-build/src/app.js` matched `build/` and was blocked. The root cause is that `grep -qE 'build/'` matches `build/` anywhere in the path, including inside directory names like `corvex-build/`.

The correct fix is to anchor each pattern as a path component using `(^|/)` prefix, which matches only at the start of the path or after a `/` separator.

## How

- **`scripts/security-filter.sh`**: Changed `node_modules/|\.git/|dist/|build/` to `(^|/)node_modules/|(^|/)\.git/|(^|/)dist/|(^|/)build/`. The `(^|/)` prefix ensures each directory name is matched as a path component, not a substring. File-based patterns (`.env$`, `.pem$`, etc.) were already correctly anchored and are unchanged.

- **`tests/hooks-isolation-lifecycle.bats`**: Added 10 new tests in a dedicated "Directory pattern path-component anchoring (issue #402)" section:
  - 5 blocking tests (true positives): `build/` relative, `build/` absolute, `dist/`, `node_modules/`, `.git/`
  - 5 allowing tests (false-positive regression): `corvex-build/`, `build-orbstack.sh`, `my-dist/`, `old-node_modules/`, `repo.git/` — each uses a path that would have been falsely blocked by the old unanchored regex.

## Acceptance criteria verification

1. **Regex anchors all four patterns with `(^|/)` prefix** — satisfied by `scripts/security-filter.sh` line 25
2. **Files in `corvex-build/`, `redistribution/`, etc. are NOT blocked** — tested by 5 allowing BATS tests (exit 0)
3. **Files inside `build/`, `dist/`, `node_modules/`, `.git/` ARE still blocked** — tested by 5 blocking BATS tests (exit 2)
4. **Existing tests continue to pass** — 2754 BATS tests pass, 38 contract checks pass, lint clean
5. **New BATS tests cover all four patterns in both directions** — 10 new tests cover blocking and allowing for `build/`, `dist/`, `node_modules/`, `.git/`

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] Tested affected commands — security filter blocks real sensitive dirs, allows false-positive paths
- [x] No load errors
- [x] Existing commands still work
- [x] `bash testing/run-all.sh` — 2754 BATS tests pass, 38 contract checks pass, lint clean

## QA summary

- **Primary QA**: 3 rounds (Claude Opus 4.6). Round 1: 1 low finding (missing `.git/` allowing test) — fixed. Round 2: 1 medium finding (vacuous false-positive test paths for `dist/` and `node_modules/`) — fixed. Round 3: 0 findings.
- **Cross-model QA**: 1 round (GPT-5.4). 0 findings.
- **Copilot PR review**: pending