### PR TITLE
feat(debug): make /debug a self-contained lifecycle — absorb QA and UAT inline

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -259,7 +259,11 @@ fi
    QA_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" qa)
    ```
 
-2. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo: set session status to `uat_pending` via `debug-session-state.sh set-status .vbw-planning uat_pending`, then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps (do not increment QA round).
+2. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo:
+   ```bash
+   bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh set-status .vbw-planning uat_pending
+   ```
+   Then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps (do not increment QA round).
 
 3. Increment QA round:
    ```bash

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -358,6 +358,8 @@ options:
   - label: "No"
     description: "Skip — I'll resume later with /vbw:debug --resume"
 ```
+**AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, YAML, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the prompt will not be presented to the user and the session will end prematurely. **STOP HERE.** Wait for the AskUserQuestion response before processing the answer.
+
 If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to UAT verification`.
 If the user selects "Yes": proceed.
 If the user provides freeform input: proceed only when the response is clearly affirmative (e.g., "yes", "y", "sure", "go ahead"). If the response is negative or deferring (e.g., "no", "not now", "later", "skip"): treat as "No" and STOP. If ambiguous: ask a brief follow-up to confirm before proceeding.
@@ -406,7 +408,7 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
        description: "Cannot test right now — skip this checkpoint"
    ```
 
-   **STOP and wait for the user to respond.** Process one checkpoint at a time.
+   **AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, YAML, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the checkpoint will not be presented to the user and the session will end prematurely. **STOP HERE and wait for the user to respond.** Process one checkpoint at a time.
 
 5. Response mapping (same rules as /vbw:verify; AskUserQuestion automatically provides a freeform "Other" option):
    - "Pass" → record as passed

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -306,7 +306,17 @@ fi
    - Parse the verdict (PASS/FAIL/PARTIAL) from the QA agent's response.
    - Write the QA round to the session file:
      ```bash
-     QA_RESULT_JSON='{"mode":"qa","round":{qa_round},"result":"{PASS|FAIL|PARTIAL}","checks":[{"id":"{check-id}","description":"{check description}","status":"{PASS|FAIL}","evidence":"{evidence}"}]}'
+     QA_RESULT_JSON=$(cat <<'ENDJSON'
+     {
+       "mode": "qa",
+       "round": {qa_round},
+       "result": "{PASS|FAIL|PARTIAL}",
+       "checks": [
+         {"id": "{check-id}", "description": "{check description}", "status": "{PASS|FAIL}", "evidence": "{evidence}"}
+       ]
+     }
+     ENDJSON
+     )
      echo "$QA_RESULT_JSON" | bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-debug-session.sh "$session_file"
      ```
    - Update session status based on result:
@@ -417,7 +427,20 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 
 6. After all checkpoints, persist the UAT round:
    ```bash
-   UAT_RESULT_JSON='{"mode":"uat","round":{uat_round},"result":"{pass|issues_found}","checkpoints":[{"id":"{id}","description":"{desc}","result":"pass|skip|issue","user_response":"{verbatim}"}],"issues":[{"id":"{id}","description":"{desc}","severity":"{level}"}]}'
+   UAT_RESULT_JSON=$(cat <<'ENDJSON'
+   {
+     "mode": "uat",
+     "round": {uat_round},
+     "result": "{pass|issues_found}",
+     "checkpoints": [
+       {"id": "{id}", "description": "{desc}", "result": "pass|skip|issue", "user_response": "{verbatim}"}
+     ],
+     "issues": [
+       {"id": "{id}", "description": "{desc}", "severity": "{level}"}
+     ]
+   }
+   ENDJSON
+   )
    echo "$UAT_RESULT_JSON" | bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-debug-session.sh "$session_file"
    ```
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -35,24 +35,22 @@ Store the plugin root path output above as `VBW_PLUGIN_ROOT` for use in script i
 <debug_session_routing>
 Resolve or create the debug session before any investigation. Order of precedence:
 
-1. **Explicit `--session <id>`:** Extract `SESSION_ID` — the token immediately following `--session` in $ARGUMENTS. If `--session` is present but no id follows it, STOP: `"--session requires a session id."` Parse `--yolo` if present: `YOLO_MODE=false; if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi`. Resume the named session:
+1. **Explicit `--session <id>`:** Extract `SESSION_ID` — the token immediately following `--session` in $ARGUMENTS. If `--session` is present but no id follows it, STOP: `"--session requires a session id."` Resume the named session:
    ```bash
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh resume .vbw-planning "$SESSION_ID")"
    ```
    If the session file is missing, STOP with error.
 
-2. **`--resume` flag (no explicit session):** Resume the active session or latest unresolved. Parse `--yolo` if present: `YOLO_MODE=false; if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi`.
+2. **`--resume` flag (no explicit session):** Resume the active session or latest unresolved.
    ```bash
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh get-or-latest .vbw-planning)"
    ```
    - If `active_session=none`: STOP "No active debug session to resume. Start one with: /vbw:debug \"bug description\""
    - If `active_session=fallback`: inform user which session was auto-selected (no `.active-session` pointer was set, so the latest unresolved session was chosen automatically).
 
-3. **New session (no --resume, no --session):** Create a fresh session from $ARGUMENTS. Strip known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) and any `(ref:HASH)` suffix from $ARGUMENTS before computing the slug — these are routing/ref metadata, not part of the bug description. If `--yolo` is present, store `YOLO_MODE=true`; otherwise `YOLO_MODE=false`.
+3. **New session (no --resume, no --session):** Create a fresh session from $ARGUMENTS. Strip known flags (`--competing`, `--parallel`, `--serial`) and any `(ref:HASH)` suffix from $ARGUMENTS before computing the slug — these are routing/ref metadata, not part of the bug description.
    ```bash
-   YOLO_MODE=false
-   if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi
-   BUG_DESC=$(printf '%s' "$ARGUMENTS" | sed -E 's/[[:space:]]*\(ref:[^)]+\)//g' | sed -E 's/(^|[[:space:]])--(competing|parallel|serial|yolo)([[:space:]]|$)/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -s '[:space:]' ' ')
+   BUG_DESC=$(printf '%s' "$ARGUMENTS" | sed -E 's/[[:space:]]*\(ref:[^)]+\)//g' | sed -E 's/(^|[[:space:]])--(competing|parallel|serial)([[:space:]]|$)/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -s '[:space:]' ' ')
    SLUG=$(printf '%s' "$BUG_DESC" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | head -c 50)
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh start .vbw-planning "$SLUG")"
    ```
@@ -75,7 +73,7 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
 </debug_session_routing>
 
 ## Steps
-1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) from $ARGUMENTS and store them separately for Step 2 routing. If `--yolo` was present (set during routing for `--session <id>`, `--resume`, or new-session parse), `YOLO_MODE` is already `true`. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
+1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`) from $ARGUMENTS and store them separately for Step 2 routing. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
     ```bash
     bash "`!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/todo-details.sh" get <hash>
     ```
@@ -254,22 +252,6 @@ if [ -z "${EFFORT_PROFILE:-}" ]; then
 fi
 ```
 
-**Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
-```yaml
-question: "Fix committed. Run QA verification now?"
-header: "Debug Session"
-multiSelect: false
-options:
-  - label: "Yes"
-    description: "Run QA verification inline"
-  - label: "No"
-    description: "Skip — I'll resume later with /vbw:debug --resume"
-```
-If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to QA verification`.
-If the user selects "Yes" or provides freeform acceptance: proceed.
-
-If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
-
 **QA orchestration (absorbed from /vbw:qa debug-session mode):**
 
 1. Compile QA context:
@@ -361,7 +343,7 @@ if [ -z "${AUTO_UAT:-}" ]; then
 fi
 ```
 
-**Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
+**Prompt gate:** If `AUTO_UAT` is not `"true"`, call AskUserQuestion:
 ```yaml
 question: "QA passed. Run UAT verification now?"
 header: "Debug Session"
@@ -375,7 +357,7 @@ options:
 If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to UAT verification`.
 If the user selects "Yes" or provides freeform acceptance: proceed.
 
-If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
+If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 
 **UAT orchestration (absorbed from /vbw:verify debug-session mode):**
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -41,7 +41,7 @@ Resolve or create the debug session before any investigation. Order of precedenc
    ```
    If the session file is missing, STOP with error.
 
-2. **`--resume` flag (no explicit session):** Resume the active session or latest unresolved.
+2. **`--resume` flag (no explicit session):** Resume the active session or latest unresolved. Parse `--yolo` if present: `YOLO_MODE=false; if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi`.
    ```bash
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh get-or-latest .vbw-planning)"
    ```
@@ -247,6 +247,13 @@ Read the `auto_uat` config:
 AUTO_UAT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/read-config.sh .vbw-planning/config.json auto_uat 2>/dev/null || echo "false")
 ```
 
+Resolve effort profile if not already set (needed for tier resolution and max-turns):
+```bash
+if [ -z "${EFFORT_PROFILE:-}" ]; then
+  EFFORT_PROFILE=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/read-config.sh .vbw-planning/config.json effort_profile 2>/dev/null || echo "balanced")
+fi
+```
+
 **Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
 ```yaml
 question: "Fix committed. Run QA verification now?"
@@ -258,7 +265,7 @@ options:
   - label: "No"
     description: "I'll run /vbw:qa --session later"
 ```
-If the user selects "No": STOP with `➜ Next: /vbw:qa --session -- Verify the debug fix`.
+If the user selects "No": STOP with `➞ Next: /vbw:debug --resume -- Continue to QA verification`.
 If the user selects "Yes" or provides freeform acceptance: proceed.
 
 If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
@@ -270,12 +277,12 @@ If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed 
    QA_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" qa)
    ```
 
-2. Increment QA round:
+2. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo: set session status to `uat_pending` via `debug-session-state.sh set-status .vbw-planning uat_pending`, then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps (do not increment QA round).
+
+3. Increment QA round:
    ```bash
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh increment-qa .vbw-planning)"
    ```
-
-3. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo: set session status to `uat_pending` via `debug-session-state.sh set-status .vbw-planning uat_pending`, then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps.
 
 4. Resolve QA model and max turns:
    ```bash
@@ -358,7 +365,7 @@ options:
   - label: "No"
     description: "I'll run /vbw:verify --session later"
 ```
-If the user selects "No": STOP with `➜ Next: /vbw:verify --session -- Run UAT on the debug fix`.
+If the user selects "No": STOP with `➞ Next: /vbw:debug --resume -- Continue to UAT verification`.
 If the user selects "Yes" or provides freeform acceptance: proceed.
 
 If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -275,13 +275,13 @@ If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed 
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh increment-qa .vbw-planning)"
    ```
 
-3. Resolve tier from effort profile: turbo=skip (exit "QA skipped in turbo mode — proceeding to UAT"), fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`.
+3. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo: set session status to `uat_pending` via `debug-session-state.sh set-status .vbw-planning uat_pending`, then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps.
 
 4. Resolve QA model and max turns:
    ```bash
    QA_MODEL=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/resolve-agent-model.sh qa .vbw-planning/config.json `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/config/model-profiles.json)
    if [ $? -ne 0 ]; then echo "$QA_MODEL" >&2; exit 1; fi
-   QA_MAX_TURNS=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/resolve-agent-max-turns.sh qa .vbw-planning/config.json "$QA_EFFORT_PROFILE")
+   QA_MAX_TURNS=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/resolve-agent-max-turns.sh qa .vbw-planning/config.json "$EFFORT_PROFILE")
    if [ $? -ne 0 ]; then echo "$QA_MAX_TURNS" >&2; exit 1; fi
    ```
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -4,7 +4,7 @@ category: supporting
 disable-model-invocation: true
 description: Investigate a bug using the Debugger agent's scientific method protocol.
 argument-hint: "<bug description or error message>"
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, Agent, TeamCreate, TaskCreate, SendMessage, TeamDelete, Skill, LSP
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, Agent, TeamCreate, TaskCreate, SendMessage, TeamDelete, Skill, LSP, AskUserQuestion
 ---
 
 # VBW Debug: $ARGUMENTS
@@ -48,22 +48,24 @@ Resolve or create the debug session before any investigation. Order of precedenc
    - If `active_session=none`: STOP "No active debug session to resume. Start one with: /vbw:debug \"bug description\""
    - If `active_session=fallback`: inform user which session was auto-selected (no `.active-session` pointer was set, so the latest unresolved session was chosen automatically).
 
-3. **New session (no --resume, no --session):** Create a fresh session from $ARGUMENTS. Strip known flags (`--competing`, `--parallel`, `--serial`) and any `(ref:HASH)` suffix from $ARGUMENTS before computing the slug — these are routing/ref metadata, not part of the bug description.
+3. **New session (no --resume, no --session):** Create a fresh session from $ARGUMENTS. Strip known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) and any `(ref:HASH)` suffix from $ARGUMENTS before computing the slug — these are routing/ref metadata, not part of the bug description. If `--yolo` is present, store `YOLO_MODE=true`; otherwise `YOLO_MODE=false`.
    ```bash
-   BUG_DESC=$(printf '%s' "$ARGUMENTS" | sed -E 's/[[:space:]]*\(ref:[^)]+\)//g' | sed -E 's/(^|[[:space:]])--(competing|parallel|serial)([[:space:]]|$)/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -s '[:space:]' ' ')
+   YOLO_MODE=false
+   if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi
+   BUG_DESC=$(printf '%s' "$ARGUMENTS" | sed -E 's/[[:space:]]*\(ref:[^)]+\)//g' | sed -E 's/(^|[[:space:]])--(competing|parallel|serial|yolo)([[:space:]]|$)/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -s '[:space:]' ' ')
    SLUG=$(printf '%s' "$BUG_DESC" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | head -c 50)
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh start .vbw-planning "$SLUG")"
    ```
 
 Store the resolved `session_id` and `session_file` for use in Steps below.
 
-If resuming a session with `status=qa_pending`: skip investigation, display current session state, and suggest `/vbw:qa --session` instead.
+If resuming a session with `status=qa_pending` or `status=fix_applied`: skip investigation, jump directly to `<debug_inline_qa>` below to run QA inline.
 If resuming a session with `status=qa_failed`: load failure context:
   ```bash
   FAILURE_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" qa 2>/dev/null || echo "")
   ```
   Update status to `investigating` via `write-debug-session.sh` (mode=status), then continue investigation from Step 3. When composing the debugger task prompt in Step 4, prepend the compiled `FAILURE_CONTEXT` to the bug report so the debugger has the specific failed QA checks and findings. Use this format in the task prompt: `Previous QA failed. Failure context:\n{FAILURE_CONTEXT}\n\nOriginal bug report: {description}`.
-If resuming a session with `status=uat_pending`: skip investigation, display current session state, and suggest `/vbw:verify --session` instead.
+If resuming a session with `status=uat_pending`: skip investigation, jump directly to `<debug_inline_uat>` below to run UAT inline.
 If resuming a session with `status=uat_failed`: load failure context:
   ```bash
   FAILURE_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" uat 2>/dev/null || echo "")
@@ -73,7 +75,7 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
 </debug_session_routing>
 
 ## Steps
-1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`) from $ARGUMENTS and store them separately for Step 2 routing. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
+1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) from $ARGUMENTS and store them separately for Step 2 routing. If `--yolo` was present in the new-session parse, `YOLO_MODE=true`. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
     ```bash
     bash "`!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/todo-details.sh" get <hash>
     ```
@@ -233,11 +235,222 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
 ```
 This is **display-only**. Do NOT edit STATE.md, do NOT add todos, do NOT invoke /vbw:todo, and do NOT enter an interactive loop. The user decides whether to track these. If no discovered issues: omit the section entirely. After displaying discovered issues, STOP. Do not take further action.
 
-<debug_session_next_step>
-Session-aware next step (based on what happened during investigation):
+If no fix was committed (session status is still `investigating`): STOP with `➜ Next: /vbw:debug --resume -- Continue investigation and apply fix`. Do not enter inline QA.
 
-- If a fix was committed and session status is `qa_pending`:
-  `➜ Next: /vbw:qa --session -- Verify the debug fix`
+If a fix was committed and session status is `qa_pending`: proceed to `<debug_inline_qa>` below.
+
+<debug_inline_qa>
+**Inline QA — runs automatically after a fix is committed.**
+
+Read the `auto_uat` config:
+```bash
+AUTO_UAT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/read-config.sh .vbw-planning/config.json auto_uat 2>/dev/null || echo "false")
+```
+
+**Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
+```yaml
+question: "Fix committed. Run QA verification now?"
+header: "Debug Session"
+multiSelect: false
+options:
+  - label: "Yes"
+    description: "Run QA verification inline"
+  - label: "No"
+    description: "I'll run /vbw:qa --session later"
+```
+If the user selects "No": STOP with `➜ Next: /vbw:qa --session -- Verify the debug fix`.
+If the user selects "Yes" or provides freeform acceptance: proceed.
+
+If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
+
+**QA orchestration (absorbed from /vbw:qa debug-session mode):**
+
+1. Compile QA context:
+   ```bash
+   QA_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" qa)
+   ```
+
+2. Increment QA round:
+   ```bash
+   eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh increment-qa .vbw-planning)"
+   ```
+
+3. Resolve tier from effort profile: turbo=skip (exit "QA skipped in turbo mode — proceeding to UAT"), fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`.
+
+4. Resolve QA model and max turns:
+   ```bash
+   QA_MODEL=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/resolve-agent-model.sh qa .vbw-planning/config.json `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/config/model-profiles.json)
+   if [ $? -ne 0 ]; then echo "$QA_MODEL" >&2; exit 1; fi
+   QA_MAX_TURNS=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/resolve-agent-max-turns.sh qa .vbw-planning/config.json "$QA_EFFORT_PROFILE")
+   if [ $? -ne 0 ]; then echo "$QA_MAX_TURNS" >&2; exit 1; fi
+   ```
+
+5. Spawn vbw-qa as subagent via Task tool for debug-session verification. **Set `subagent_type: "vbw:vbw-qa"` and `model: "${QA_MODEL}"` in the Task tool invocation. If `QA_MAX_TURNS` is non-empty, also pass `maxTurns: ${QA_MAX_TURNS}`.**
+
+   Task description for debug-session QA:
+   ```text
+   Debug session verification. Tier: {ACTIVE_TIER}. Round: {qa_round}.
+
+   This is a debug-session QA round, NOT a phase-scoped verification. You are verifying
+   a standalone debug fix — there are no phase PLAN.md or SUMMARY.md files.
+
+   Session context (issue, investigation, plan, implementation, prior QA rounds):
+   {QA_CONTEXT}
+
+   Verification targets:
+   - The root cause identified in the investigation is correct
+   - The fix addresses the root cause (not just the symptom)
+   - Changed files are correct and complete
+   - No regressions introduced in modified files
+   - Related tests pass
+
+   Output your verdict as PASS, FAIL, or PARTIAL with a checks table.
+   Do NOT use write-verification.sh — return your verdict inline as structured text.
+   Format each check as: ID | Description | Status (PASS/FAIL) | Evidence
+   ```
+
+6. Process the QA result:
+   - Parse the verdict (PASS/FAIL/PARTIAL) from the QA agent's response.
+   - Write the QA round to the session file:
+     ```bash
+     QA_RESULT_JSON='{"mode":"qa","round":{qa_round},"result":"{PASS|FAIL|PARTIAL}","checks":[{"id":"{check-id}","description":"{check description}","status":"{PASS|FAIL}","evidence":"{evidence}"}]}'
+     echo "$QA_RESULT_JSON" | bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-debug-session.sh "$session_file"
+     ```
+   - Update session status based on result:
+     - PASS → `bash .../debug-session-state.sh set-status .vbw-planning uat_pending`
+     - FAIL or PARTIAL → `bash .../debug-session-state.sh set-status .vbw-planning qa_failed`
+
+7. Present debug-session QA result:
+   Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
+   ```text
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   Debug QA: Round {qa_round}
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+     Session:  {session_id}
+     Tier:     {quick|standard|deep}
+     Result:   {✓ PASS | ✗ FAIL | ◆ PARTIAL}
+     Checks:   {passed}/{total}
+     Failed:   {list or "None"}
+
+   ```
+
+**QA failure handling:** If FAIL or PARTIAL:
+- Display: `QA found issues. Re-investigating...`
+- Load failure context: `FAILURE_CONTEXT=$(bash .../compile-debug-session-context.sh "$session_file" qa 2>/dev/null || echo "")`
+- Update status to `investigating` via `write-debug-session.sh` (mode=status)
+- Re-enter investigation from Step 3 with the failure context prepended to the bug report (same pattern as `--resume` from `qa_failed`). After the next fix commit, inline QA fires again automatically.
+
+**QA pass:** If PASS, proceed to `<debug_inline_uat>` below.
+</debug_inline_qa>
+
+<debug_inline_uat>
+**Inline UAT — runs automatically after QA passes.**
+
+**Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
+```yaml
+question: "QA passed. Run UAT verification now?"
+header: "Debug Session"
+multiSelect: false
+options:
+  - label: "Yes"
+    description: "Run UAT checkpoints inline"
+  - label: "No"
+    description: "I'll run /vbw:verify --session later"
+```
+If the user selects "No": STOP with `➜ Next: /vbw:verify --session -- Run UAT on the debug fix`.
+If the user selects "Yes" or provides freeform acceptance: proceed.
+
+If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
+
+**UAT orchestration (absorbed from /vbw:verify debug-session mode):**
+
+1. Compile UAT context:
+   ```bash
+   UAT_CONTEXT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/compile-debug-session-context.sh "$session_file" uat)
+   ```
+
+2. Increment UAT round:
+   ```bash
+   eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh increment-uat .vbw-planning)"
+   ```
+
+3. Generate 1-3 UAT checkpoints from the session context. These must require HUMAN judgment:
+   - Reproduce the original bug — is it fixed?
+   - Check related workflows — any regressions visible?
+   - Verify the fix from the user's perspective
+
+   **Guardrails:** Never ask the user to run automated checks (tests, lint, build commands) — those belong in QA. If the fix is purely internal (test-infra, script-only, non-user-facing), fall back to a single lightweight checkpoint: "Does the app still work as expected from your perspective?" rather than generating inapplicable user-facing scenarios.
+
+4. Present checkpoints one at a time using CHECKPOINT + AskUserQuestion:
+
+   Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
+   ```text
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+     CHECKPOINT {NN}/{total} — Debug Fix Verification
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+   {scenario description}
+   ```
+
+   Then call AskUserQuestion:
+   ```yaml
+   question: "Expected: {expected result}"
+   header: "UAT"
+   multiSelect: false
+   options:
+     - label: "Pass"
+       description: "Behavior matches expected result"
+     - label: "Skip"
+       description: "Cannot test right now — skip this checkpoint"
+   ```
+
+   **STOP and wait for the user to respond.** Process one checkpoint at a time.
+
+5. Response mapping (same rules as /vbw:verify):
+   - "Pass" → record as passed
+   - "Skip" → record as skipped
+   - Freeform text via "Other" → treat as issue description, infer severity from keywords (crash/broken/error=critical, wrong/missing/bug=major, minor/cosmetic=minor, default=major)
+
+6. After all checkpoints, persist the UAT round:
+   ```bash
+   UAT_RESULT_JSON='{"mode":"uat","round":{uat_round},"result":"{pass|issues_found}","checkpoints":[{"id":"{id}","description":"{desc}","result":"pass|skip|issue","user_response":"{verbatim}"}],"issues":[{"id":"{id}","description":"{desc}","severity":"{level}"}]}'
+   echo "$UAT_RESULT_JSON" | bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-debug-session.sh "$session_file"
+   ```
+
+7. Update session status:
+   - All checkpoints pass (no issues) → `bash .../debug-session-state.sh set-status .vbw-planning complete`
+   - Any issues found → `bash .../debug-session-state.sh set-status .vbw-planning uat_failed`
+
+8. Present debug-session UAT result:
+   Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
+   ```text
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   Debug UAT: Round {uat_round}
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+     Session:  {session_id}
+     Result:   {✓ COMPLETE | ✗ ISSUES FOUND}
+     Passed:   {N}
+     Issues:   {N}
+
+   ```
+
+**UAT failure handling:** If issues found:
+- Display: `UAT found issues. Re-investigating...`
+- Load failure context: `FAILURE_CONTEXT=$(bash .../compile-debug-session-context.sh "$session_file" uat 2>/dev/null || echo "")`
+- Update status to `investigating` via `write-debug-session.sh` (mode=status)
+- Re-enter investigation from Step 3 with the failure context prepended (same pattern as `--resume` from `uat_failed`). After the next fix commit, the inline QA → UAT chain fires again automatically.
+
+**UAT pass:** If all checkpoints pass:
+- Move session to completed: the `complete` status set above handles this.
+- Display: `➜ Debug session complete. The fix is verified.`
+- STOP.
+</debug_inline_uat>
+
+<debug_session_next_step>
+Session-aware next step (only shown when the inline flow did not run):
+
 - If investigation completed but no fix was applied (session status is `investigating`):
   `➜ Next: /vbw:debug --resume -- Continue investigation and apply fix`
 - If session was not created (error or guard stopped execution):

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -75,7 +75,7 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
 </debug_session_routing>
 
 ## Steps
-1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) from $ARGUMENTS and store them separately for Step 2 routing. If `--yolo` was present in the new-session parse, `YOLO_MODE=true`. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
+1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`, `--yolo`) from $ARGUMENTS and store them separately for Step 2 routing. If `--yolo` was present (set during routing for `--session <id>`, `--resume`, or new-session parse), `YOLO_MODE` is already `true`. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
     ```bash
     bash "`!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/todo-details.sh" get <hash>
     ```

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -244,13 +244,13 @@ If a fix was committed and session status is `qa_pending`: proceed to `<debug_in
 
 Read the `auto_uat` config:
 ```bash
-AUTO_UAT=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/read-config.sh .vbw-planning/config.json auto_uat 2>/dev/null || echo "false")
+AUTO_UAT=$(jq -r '.auto_uat // "false"' .vbw-planning/config.json 2>/dev/null || echo "false")
 ```
 
 Resolve effort profile if not already set (needed for tier resolution and max-turns):
 ```bash
 if [ -z "${EFFORT_PROFILE:-}" ]; then
-  EFFORT_PROFILE=$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/read-config.sh .vbw-planning/config.json effort_profile 2>/dev/null || echo "balanced")
+  EFFORT_PROFILE=$(jq -r '.effort // "balanced"' .vbw-planning/config.json 2>/dev/null || echo "balanced")
 fi
 ```
 
@@ -263,9 +263,9 @@ options:
   - label: "Yes"
     description: "Run QA verification inline"
   - label: "No"
-    description: "I'll run /vbw:qa --session later"
+    description: "Skip — I'll resume later with /vbw:debug --resume"
 ```
-If the user selects "No": STOP with `➞ Next: /vbw:debug --resume -- Continue to QA verification`.
+If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to QA verification`.
 If the user selects "Yes" or provides freeform acceptance: proceed.
 
 If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.
@@ -354,6 +354,13 @@ If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed 
 <debug_inline_uat>
 **Inline UAT — runs automatically after QA passes.**
 
+Resolve `AUTO_UAT` if not already set (needed when entering via `--resume` from `uat_pending`):
+```bash
+if [ -z "${AUTO_UAT:-}" ]; then
+  AUTO_UAT=$(jq -r '.auto_uat // "false"' .vbw-planning/config.json 2>/dev/null || echo "false")
+fi
+```
+
 **Prompt gate:** If `AUTO_UAT` is not `"true"` AND `YOLO_MODE` is not `true`, call AskUserQuestion:
 ```yaml
 question: "QA passed. Run UAT verification now?"
@@ -363,9 +370,9 @@ options:
   - label: "Yes"
     description: "Run UAT checkpoints inline"
   - label: "No"
-    description: "I'll run /vbw:verify --session later"
+    description: "Skip — I'll resume later with /vbw:debug --resume"
 ```
-If the user selects "No": STOP with `➞ Next: /vbw:debug --resume -- Continue to UAT verification`.
+If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to UAT verification`.
 If the user selects "Yes" or provides freeform acceptance: proceed.
 
 If `AUTO_UAT` is `"true"` OR `YOLO_MODE` is `true`: skip the prompt and proceed directly.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -348,7 +348,7 @@ fi
 </debug_inline_qa>
 
 <debug_inline_uat>
-**Inline UAT — runs automatically after QA passes.**
+**Inline UAT — prompt-gated by default (`auto_uat`); runs automatically when `auto_uat=true`.**
 
 Resolve `AUTO_UAT` if not already set (needed when entering via `--resume` from `uat_pending`):
 ```bash

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -403,7 +403,7 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 
    **STOP and wait for the user to respond.** Process one checkpoint at a time.
 
-5. Response mapping (same rules as /vbw:verify):
+5. Response mapping (same rules as /vbw:verify; AskUserQuestion automatically provides a freeform "Other" option):
    - "Pass" → record as passed
    - "Skip" → record as skipped
    - Freeform text via "Other" → treat as issue description, infer severity from keywords (crash/broken/error=critical, wrong/missing/bug=major, minor/cosmetic=minor, default=major)

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -231,11 +231,11 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
     ⚠ testName (path/to/file): error message
   Suggest: /vbw:todo <description> to track
 ```
-This is **display-only**. Do NOT edit STATE.md, do NOT add todos, do NOT invoke /vbw:todo, and do NOT enter an interactive loop. The user decides whether to track these. If no discovered issues: omit the section entirely. After displaying discovered issues, STOP. Do not take further action.
+This is **display-only**. Do NOT edit STATE.md, do NOT add todos, do NOT invoke /vbw:todo, and do NOT enter an interactive loop. The user decides whether to track these. If no discovered issues: omit the section entirely.
 
 If no fix was committed (session status is still `investigating`): STOP with `➜ Next: /vbw:debug --resume -- Continue investigation and apply fix`. Do not enter inline QA.
 
-If a fix was committed and session status is `qa_pending`: proceed to `<debug_inline_qa>` below.
+If a fix was committed and session status is `qa_pending`: proceed to `<debug_inline_qa>` below (even if discovered issues were displayed above — they are informational only and do not gate the QA lifecycle).
 
 <debug_inline_qa>
 **Inline QA — runs automatically after a fix is committed.**
@@ -359,7 +359,8 @@ options:
     description: "Skip — I'll resume later with /vbw:debug --resume"
 ```
 If the user selects "No": STOP with `➜ Next: /vbw:debug --resume -- Continue to UAT verification`.
-If the user selects "Yes" or provides freeform acceptance: proceed.
+If the user selects "Yes": proceed.
+If the user provides freeform input: proceed only when the response is clearly affirmative (e.g., "yes", "y", "sure", "go ahead"). If the response is negative or deferring (e.g., "no", "not now", "later", "skip"): treat as "No" and STOP. If ambiguous: ask a brief follow-up to confirm before proceeding.
 
 If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -35,7 +35,7 @@ Store the plugin root path output above as `VBW_PLUGIN_ROOT` for use in script i
 <debug_session_routing>
 Resolve or create the debug session before any investigation. Order of precedence:
 
-1. **Explicit `--session <id>`:** Extract `SESSION_ID` — the token immediately following `--session` in $ARGUMENTS. If `--session` is present but no id follows it, STOP: `"--session requires a session id."` Resume the named session:
+1. **Explicit `--session <id>`:** Extract `SESSION_ID` — the token immediately following `--session` in $ARGUMENTS. If `--session` is present but no id follows it, STOP: `"--session requires a session id."` Parse `--yolo` if present: `YOLO_MODE=false; if printf '%s' "$ARGUMENTS" | grep -qE '(^|[[:space:]])--yolo([[:space:]]|$)'; then YOLO_MODE=true; fi`. Resume the named session:
    ```bash
    eval "$(bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/debug-session-state.sh resume .vbw-planning "$SESSION_ID")"
    ```

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -593,7 +593,7 @@ case "$CMD" in
             qa_pending|uat_pending|fix_applied)
               case "$effective_result" in
                 pass)
-                  suggest "/vbw:verify -- Run UAT on the debug fix"
+                  suggest "/vbw:debug --resume -- Continue to UAT verification"
                   _qa_debug_handled=true
                   ;;
                 fail|partial)
@@ -604,11 +604,11 @@ case "$CMD" in
                   # No result passed — suggest based on session status
                   case "$_qa_ds_status" in
                     qa_pending|fix_applied)
-                      suggest "/vbw:qa -- Run QA on the debug fix"
+                      suggest "/vbw:debug --resume -- Continue to QA verification"
                       _qa_debug_handled=true
                       ;;
                     uat_pending)
-                      suggest "/vbw:verify -- Run UAT on the debug fix"
+                      suggest "/vbw:debug --resume -- Continue to UAT verification"
                       _qa_debug_handled=true
                       ;;
                   esac
@@ -782,21 +782,13 @@ case "$CMD" in
     fi
     case "$_ds_status" in
       qa_pending|fix_applied)
-        if [ "${phase_count:-0}" -gt 0 ]; then
-          suggest "/vbw:qa --session -- Verify the debug fix"
-        else
-          suggest "/vbw:qa -- Verify the debug fix"
-        fi
+        suggest "/vbw:debug --resume -- Continue to QA verification"
         ;;
       qa_failed)
         suggest "/vbw:debug --resume -- Address QA failures"
         ;;
       uat_pending)
-        if [ "${phase_count:-0}" -gt 0 ]; then
-          suggest "/vbw:verify --session -- Run UAT on the debug fix"
-        else
-          suggest "/vbw:verify -- Run UAT on the debug fix"
-        fi
+        suggest "/vbw:debug --resume -- Continue to UAT verification"
         ;;
       uat_failed)
         suggest "/vbw:debug --resume -- Address UAT issues"

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -593,8 +593,16 @@ case "$CMD" in
             qa_pending|uat_pending|fix_applied)
               case "$effective_result" in
                 pass)
-                  suggest "/vbw:debug --resume -- Continue to UAT verification"
-                  _qa_debug_handled=true
+                  case "$_qa_ds_status" in
+                    qa_pending|fix_applied)
+                      suggest "/vbw:debug --resume -- Continue to QA verification"
+                      _qa_debug_handled=true
+                      ;;
+                    uat_pending)
+                      suggest "/vbw:debug --resume -- Continue to UAT verification"
+                      _qa_debug_handled=true
+                      ;;
+                  esac
                   ;;
                 fail|partial)
                   suggest "/vbw:debug --resume -- Address QA failures"

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -51,7 +51,7 @@ fi
 echo ""
 echo "--- Check: defaults.json keys present in config.md table ---"
 for key in $json_keys; do
-  if echo "$md_settings" | grep -qx "$key"; then
+  if grep -qx "$key" <<< "$md_settings"; then
     pass "defaults.json key '$key' found in config.md table"
   else
     fail "defaults.json key '$key' MISSING from config.md table"
@@ -62,7 +62,7 @@ done
 echo ""
 echo "--- Check: config.md table settings exist in defaults.json ---"
 for setting in $md_settings; do
-  if echo "$json_keys" | grep -qx "$setting"; then
+  if grep -qx "$setting" <<< "$json_keys"; then
     pass "config.md setting '$setting' found in defaults.json"
   else
     fail "config.md setting '$setting' NOT in defaults.json (stale/graduated?)"

--- a/testing/verify-config-defaults-sync.sh
+++ b/testing/verify-config-defaults-sync.sh
@@ -51,7 +51,7 @@ fi
 echo ""
 echo "--- Check: defaults.json keys present in config.md table ---"
 for key in $json_keys; do
-  if grep -qx "$key" <<< "$md_settings"; then
+  if grep -Fxq "$key" <<< "$md_settings"; then
     pass "defaults.json key '$key' found in config.md table"
   else
     fail "defaults.json key '$key' MISSING from config.md table"
@@ -62,7 +62,7 @@ done
 echo ""
 echo "--- Check: config.md table settings exist in defaults.json ---"
 for setting in $md_settings; do
-  if grep -qx "$setting" <<< "$json_keys"; then
+  if grep -Fxq "$setting" <<< "$json_keys"; then
     pass "config.md setting '$setting' found in defaults.json"
   else
     fail "config.md setting '$setting' NOT in defaults.json (stale/graduated?)"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -318,7 +318,7 @@ else
   fail "debug.md missing inline UAT section (debug_inline_uat)"
 fi
 
-if grep -q 'AskUserQuestion' "$ROOT/commands/debug.md" 2>/dev/null; then
+if sed -n '1,/^---$/p' "$ROOT/commands/debug.md" 2>/dev/null | grep -q 'AskUserQuestion'; then
   pass "debug.md frontmatter includes AskUserQuestion tool"
 else
   fail "debug.md frontmatter missing AskUserQuestion tool"
@@ -336,7 +336,7 @@ else
   fail "debug.md resume routing for qa_pending/fix_applied missing inline QA entry"
 fi
 
-if grep -q 'uat_pending.*debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
+if sed -n '/status=uat_pending/,/debug_inline_uat/p' "$ROOT/commands/debug.md" 2>/dev/null | grep -q 'debug_inline_uat'; then
   pass "debug.md resume routing for uat_pending enters inline UAT"
 else
   fail "debug.md resume routing for uat_pending missing inline UAT entry"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -336,7 +336,7 @@ else
   fail "debug.md resume routing for qa_pending/fix_applied missing inline QA entry"
 fi
 
-if sed -n '/status=uat_pending/,/debug_inline_uat/p' "$ROOT/commands/debug.md" 2>/dev/null | grep -q 'debug_inline_uat'; then
+if grep -q 'status=uat_pending.*debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
   pass "debug.md resume routing for uat_pending enters inline UAT"
 else
   fail "debug.md resume routing for uat_pending missing inline UAT entry"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -262,12 +262,12 @@ else
   fail "verify.md guard missing --session flag"
 fi
 
-# — suggest-next.sh appends --session when phases exist (CM3-01) —
+# — suggest-next.sh routes debug sessions to /vbw:debug --resume (CM3-01) —
 
-if grep -q '\-\-session' "$ROOT/scripts/suggest-next.sh" 2>/dev/null; then
-  pass "suggest-next.sh has --session flag logic"
+if grep -q 'vbw:debug --resume' "$ROOT/scripts/suggest-next.sh" 2>/dev/null; then
+  pass "suggest-next.sh routes debug sessions to /vbw:debug --resume"
 else
-  fail "suggest-next.sh missing --session flag logic"
+  fail "suggest-next.sh missing /vbw:debug --resume routing for debug sessions"
 fi
 
 # — suggest-next.sh qa/verify debug handlers guard on phase_count=0 (CM7-01) —
@@ -304,12 +304,24 @@ else
   fail "write-debug-session.sh missing awk-based frontmatter scoping"
 fi
 
-# — Command next-step text includes --session (CM4-01, CM4-02) —
+# — Command inline QA/UAT lifecycle (CM4-01, CM4-02) —
 
-if grep -q '\-\-session.*Verify the debug fix' "$ROOT/commands/debug.md" 2>/dev/null; then
-  pass "debug.md next-step for qa_pending includes --session"
+if grep -q 'debug_inline_qa' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md has inline QA section (debug_inline_qa)"
 else
-  fail "debug.md next-step for qa_pending missing --session flag"
+  fail "debug.md missing inline QA section (debug_inline_qa)"
+fi
+
+if grep -q 'debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md has inline UAT section (debug_inline_uat)"
+else
+  fail "debug.md missing inline UAT section (debug_inline_uat)"
+fi
+
+if grep -q 'AskUserQuestion' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md frontmatter includes AskUserQuestion tool"
+else
+  fail "debug.md frontmatter missing AskUserQuestion tool"
 fi
 
 if grep -q '\-\-session.*Run UAT on the debug fix' "$ROOT/commands/qa.md" 2>/dev/null; then
@@ -318,11 +330,10 @@ else
   fail "qa.md next-step for PASS missing --session flag"
 fi
 
-if grep -q 'uat_pending.*\-\-session' "$ROOT/commands/debug.md" 2>/dev/null || \
-   grep -q '\-\-session.*uat_pending' "$ROOT/commands/debug.md" 2>/dev/null; then
-  pass "debug.md resume routing for uat_pending includes --session"
+if grep -q 'qa_pending.*debug_inline_qa\|fix_applied.*debug_inline_qa' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md resume routing for qa_pending/fix_applied enters inline QA"
 else
-  fail "debug.md resume routing for uat_pending missing --session flag"
+  fail "debug.md resume routing for qa_pending/fix_applied missing inline QA entry"
 fi
 
 # — QA agent persistence contract separates phase-scoped from debug-session (CM5-01) —

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -336,6 +336,12 @@ else
   fail "debug.md resume routing for qa_pending/fix_applied missing inline QA entry"
 fi
 
+if grep -q 'uat_pending.*debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md resume routing for uat_pending enters inline UAT"
+else
+  fail "debug.md resume routing for uat_pending missing inline UAT entry"
+fi
+
 # — QA agent persistence contract separates phase-scoped from debug-session (CM5-01) —
 
 if grep -q 'Phase-Scoped QA' "$ROOT/agents/vbw-qa.md" 2>/dev/null; then

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -188,18 +188,19 @@ get_suggestion() {
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
   [ "$status" = "investigating" ]
 
-  # After fix → qa_pending: suggest-next for debug should recommend QA
+  # After fix → qa_pending: suggest-next for debug should recommend inline QA via resume
   echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   run bash "$SCRIPTS_DIR/suggest-next.sh" debug
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:qa"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to QA verification"* ]]
 
-  # After QA pass → uat_pending: suggest-next for qa pass should recommend verify
+  # After QA pass → uat_pending: suggest-next for qa pass should recommend inline UAT via resume
   echo '{"mode":"status","status":"uat_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   run bash "$SCRIPTS_DIR/suggest-next.sh" qa pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:verify"* ]]
-  [[ "$output" == *"Run UAT on the debug fix"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to UAT verification"* ]]
 
   # After QA fail → qa_failed: suggest-next for qa fail should recommend debug resume
   echo '{"mode":"status","status":"qa_failed"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"

--- a/tests/discovered-issues-surfacing.bats
+++ b/tests/discovered-issues-surfacing.bats
@@ -575,7 +575,8 @@ load test_helper
 @test "all discovered issues sections include STOP after display" {
   local failed=""
   # verify.md is excluded — its discovered issues flow into remediation, no STOP needed
-  for file in commands/fix.md commands/debug.md commands/qa.md; do
+  # debug.md is excluded — its discovered issues flow into inline QA when status is qa_pending
+  for file in commands/fix.md commands/qa.md; do
     if grep -q 'Discovered Issues' "$PROJECT_ROOT/$file"; then
       if ! grep -qi 'STOP.*Do not take further action' "$PROJECT_ROOT/$file"; then
         failed="${failed} ${file}"

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -73,11 +73,12 @@ EOF
   [[ "$output" == *"Continue investigation"* ]]
 }
 
-@test "suggest-next debug with qa_pending session suggests qa" {
+@test "suggest-next debug with qa_pending session suggests resume for inline QA" {
   create_debug_session "qa_pending"
   run bash "$SCRIPTS_DIR/suggest-next.sh" debug pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:qa"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to QA verification"* ]]
 }
 
 @test "suggest-next debug with qa_failed session suggests resume" {
@@ -88,11 +89,12 @@ EOF
   [[ "$output" == *"QA failures"* ]]
 }
 
-@test "suggest-next debug with uat_pending session suggests verify" {
+@test "suggest-next debug with uat_pending session suggests resume for inline UAT" {
   create_debug_session "uat_pending"
   run bash "$SCRIPTS_DIR/suggest-next.sh" debug pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:verify"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to UAT verification"* ]]
 }
 
 @test "suggest-next debug with uat_failed session suggests resume" {
@@ -120,18 +122,19 @@ EOF
 
 # --- qa context with active debug sessions ---
 
-@test "suggest-next qa pass with uat_pending debug session suggests verify" {
+@test "suggest-next qa pass with uat_pending debug session suggests resume for inline UAT" {
   create_debug_session "uat_pending"
   run bash "$SCRIPTS_DIR/suggest-next.sh" qa pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:verify"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to UAT verification"* ]]
 }
 
-@test "suggest-next qa pass with qa_pending debug session suggests verify" {
+@test "suggest-next qa pass with qa_pending debug session suggests resume for inline QA" {
   create_debug_session "qa_pending"
   run bash "$SCRIPTS_DIR/suggest-next.sh" qa pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:verify"* ]]
+  [[ "$output" == *"/vbw:debug --resume"* ]]
 }
 
 @test "suggest-next qa fail with active debug session suggests resume" {

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -135,6 +135,7 @@ EOF
   run bash "$SCRIPTS_DIR/suggest-next.sh" qa pass
   [ "$status" -eq 0 ]
   [[ "$output" == *"/vbw:debug --resume"* ]]
+  [[ "$output" == *"Continue to QA verification"* ]]
 }
 
 @test "suggest-next qa fail with active debug session suggests resume" {


### PR DESCRIPTION
Fixes #405

## What

Absorbs QA verification and UAT checkpoints directly into the `/vbw:debug` command flow. Previously, debug was a relay race: debug → STOP → `/qa --session` → STOP → `/verify --session` → STOP. Now the user never leaves `/debug` — QA runs inline automatically after the fix, and UAT runs inline after QA passes.

### Modified files:
- **`commands/debug.md`**: Added `<debug_inline_qa>` and `<debug_inline_uat>` sections; updated resume routing for `qa_pending`/`fix_applied`/`uat_pending`; added AskUserQuestion to frontmatter for UAT checkpoints
- **`scripts/suggest-next.sh`**: Replaced all standalone `/vbw:qa --session` and `/vbw:verify --session` suggestions with `/vbw:debug --resume` for debug session contexts
- **`testing/verify-debug-session-contract.sh`**: Added contract checks for inline QA/UAT sections, AskUserQuestion frontmatter, resume routing (including uat_pending)
- **`tests/debug-session-lifecycle.bats`**: Updated assertions for inline flow (resume → QA → UAT chain)
- **`tests/suggest-next-debug-session.bats`**: Updated all debug session suggestions to expect `/vbw:debug --resume`
- **`tests/discovered-issues-surfacing.bats`**: Excluded `debug.md` from the unconditional STOP assertion (same pattern as `verify.md`) — debug now continues to inline QA after displaying discovered issues when a fix has been committed
- **`testing/verify-config-defaults-sync.sh`**: Replaced `echo | grep -qx` pipes with here-strings (`grep -qx <<< "$var"`) to fix SIGPIPE-induced false negatives in CI (pre-existing bug, not from this PR's feature changes)

## Why

The relay-race pattern forced users to remember which command to run next and manually chain three separate invocations. The root cause was architectural: `/debug` treated QA and UAT as external concerns instead of owning the full lifecycle. This fix absorbs those steps into `/debug` itself, making it the single entry point for the entire debug workflow.

## How

- **Inline QA (`<debug_inline_qa>`)**: After a fix is applied (status `qa_pending`), QA runs automatically — no confirmation gate. Compiles QA context, resolves effort profile and model/maxTurns, spawns `vbw-qa` via Task tool, parses verdict, persists results, transitions to UAT or loops back to investigation on failure. Turbo profile skips QA entirely (by design).
- **Inline UAT (`<debug_inline_uat>`)**: After QA passes (status `uat_pending`), generates 1-3 human-verifiable checkpoints, uses AskUserQuestion for each CHECKPOINT, persists results, marks complete on all-pass or loops back to investigation on failure.
- **UAT prompt gate**: When `auto_uat=false` (the default), uses AskUserQuestion to confirm before starting UAT. When `auto_uat=true`, skips the prompt and proceeds directly. QA has no confirmation gate — it always runs automatically.
- **Resume routing**: `--resume` from `qa_pending`/`fix_applied` jumps directly to inline QA; from `uat_pending` jumps directly to inline UAT. Both paths include preambles to resolve EFFORT_PROFILE and AUTO_UAT for the resumed context.
- **suggest-next.sh**: All debug session contexts now suggest `/vbw:debug --resume` instead of standalone commands.

## Acceptance criteria verification

1. **QA runs inline after fix**: Satisfied by `<debug_inline_qa>` section — QA runs automatically with no confirmation gate.
2. **UAT runs inline after QA**: Satisfied by `<debug_inline_uat>` section. End of inline QA routes PASS → inline UAT.
3. **UAT pass → complete + moved**: UAT calls `set-status .vbw-planning complete`. Tested in `debug-session-lifecycle.bats`.
4. **QA failure → re-investigation**: QA failure handler re-enters investigation from Step 3 with failure context prepended.
5. **UAT failure → re-investigation**: UAT failure handler re-enters investigation from Step 3 with failure context prepended.
6. **auto_uat=false prompts before UAT**: UAT section has prompt gate checking `AUTO_UAT != "true"` → AskUserQuestion. QA has no gate (runs automatically).
7. **--resume from qa_pending → QA**: debug.md routes `qa_pending`/`fix_applied` directly to `<debug_inline_qa>`. EFFORT_PROFILE fallback present.
8. **--resume from uat_pending → UAT**: debug.md routes `uat_pending` directly to `<debug_inline_uat>`. AUTO_UAT re-resolution present.
9. **suggest-next.sh updated**: All debug session suggestions use `/vbw:debug --resume`. Zero instances of `/vbw:qa --session` or `/vbw:verify --session` for debug sessions.
10. **BATS tests pass**: 2754 tests pass, 0 failures.
11. **Contract tests pass**: 39/39 contract checks pass.
12. **run-all.sh green**: All lint, contract, and BATS checks pass.

## Testing

- **BATS (Tier 1)**: Updated `debug-session-lifecycle.bats` and `suggest-next-debug-session.bats` with inline flow assertions. Updated `discovered-issues-surfacing.bats` to exclude `debug.md` from unconditional STOP check.
- **Contract (Tier 2)**: Updated `verify-debug-session-contract.sh` with inline QA/UAT section checks, AskUserQuestion frontmatter check (scoped to YAML header), resume routing checks (both qa_pending and uat_pending)
- **Smoke (Tier 3)**: Command markdown flow requires sandbox testing

## QA summary

- **Primary QA (Claude)**: 4 rounds. Rounds 1-3 had findings (all fixed). Round 4 clean.
- **Cross-model QA (GPT-5.4)**: 2 rounds. Round 1 had 1 low finding (fixed). Round 2 clean (2 false positives).
- **Copilot PR review**: 9 rounds. R1: 3 fixed/1 FP. R2: 3 fixed. R3: 2 FPs. R4: 3 fixed. R5: 2 fixed. R6: 2 fixed. R7: clean. R8: 2 fixed (heredoc alignment). R9: PR description updated.
- **User-requested change**: Removed QA confirmation gate — QA now runs automatically after fix. UAT gates on `auto_uat` config only.
- **CI fix**: Pre-existing SIGPIPE in `verify-config-defaults-sync.sh` fixed (here-strings replace pipes).
- **Related issues filed**: #411 (fix case in suggest-next.sh), #413 (flaky parallel BATS tests)