### PR TITLE
fix(suggest-next): add debug-session awareness to fix) case

### DIFF
--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -715,9 +715,8 @@ case "$CMD" in
     ;;
 
   fix)
-    # Check for active debug session (phase_count=0 only —
-    # when phases exist, fix.md itself handles debug-session next-step text
-    # inline, so we must not hijack phase fix suggestions here)
+    # Check for an active debug session only for non-phase work
+    # (phase_count=0), so phase-scoped fix suggestions remain unchanged.
     _fix_debug_handled=false
     if [ "${phase_count:-0}" -eq 0 ] && [ -d "$PLANNING_DIR/debugging" ]; then
       _fix_ds_output=$("$SCRIPT_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null) || true

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -715,8 +715,42 @@ case "$CMD" in
     ;;
 
   fix)
-    suggest "/vbw:qa -- Verify the fix"
-    suggest "/vbw:vibe -- Continue building"
+    # Check for active debug session (phase_count=0 only —
+    # when phases exist, fix.md itself handles debug-session next-step text
+    # inline, so we must not hijack phase fix suggestions here)
+    _fix_debug_handled=false
+    if [ "${phase_count:-0}" -eq 0 ] && [ -d "$PLANNING_DIR/debugging" ]; then
+      _fix_ds_output=$("$SCRIPT_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null) || true
+      if [ -n "$_fix_ds_output" ]; then
+        eval "$_fix_ds_output" 2>/dev/null || true
+        # shellcheck disable=SC2154
+        if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
+          _fix_ds_status="${status:-}"
+          case "$_fix_ds_status" in
+            qa_pending|qa_failed|fix_applied)
+              suggest "/vbw:debug --resume -- Address remaining issues"
+              _fix_debug_handled=true
+              ;;
+            uat_pending)
+              suggest "/vbw:qa -- Verify the fix"
+              _fix_debug_handled=true
+              ;;
+            uat_failed)
+              suggest "/vbw:debug --resume -- Address UAT issues"
+              _fix_debug_handled=true
+              ;;
+            investigating)
+              suggest "/vbw:debug --resume -- Continue debugging"
+              _fix_debug_handled=true
+              ;;
+          esac
+        fi
+      fi
+    fi
+    if [ "$_fix_debug_handled" = false ]; then
+      suggest "/vbw:qa -- Verify the fix"
+      suggest "/vbw:vibe -- Continue building"
+    fi
     ;;
 
   verify)

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -735,7 +735,7 @@ case "$CMD" in
               _fix_debug_handled=true
               ;;
             uat_pending)
-              suggest "/vbw:qa -- Verify the fix"
+              suggest "/vbw:verify -- Run UAT on the debug fix"
               _fix_debug_handled=true
               ;;
             uat_failed)

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -726,8 +726,12 @@ case "$CMD" in
         if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
           _fix_ds_status="${status:-}"
           case "$_fix_ds_status" in
-            qa_pending|qa_failed|fix_applied)
+            qa_pending|fix_applied)
               suggest "/vbw:debug --resume -- Address remaining issues"
+              _fix_debug_handled=true
+              ;;
+            qa_failed)
+              suggest "/vbw:debug --resume -- Address QA failures"
               _fix_debug_handled=true
               ;;
             uat_pending)

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -743,7 +743,7 @@ case "$CMD" in
               _fix_debug_handled=true
               ;;
             investigating)
-              suggest "/vbw:debug --resume -- Continue debugging"
+              suggest "/vbw:debug --resume -- Continue investigation"
               _fix_debug_handled=true
               ;;
           esac

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -179,7 +179,7 @@ EOF
   run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
   [ "$status" -eq 0 ]
   [[ "$output" == *"--resume"* ]]
-  [[ "$output" == *"remaining issues"* ]]
+  [[ "$output" == *"QA failures"* ]]
 }
 
 @test "suggest-next fix with fix_applied debug session suggests resume" {

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -163,3 +163,77 @@ EOF
   [[ "$output" != *"Run UAT on the debug fix"* ]]
   [[ "$output" != *"--resume"* ]]
 }
+
+# --- fix context with active debug sessions ---
+
+@test "suggest-next fix with qa_pending debug session suggests resume" {
+  create_debug_session "qa_pending"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume"* ]]
+  [[ "$output" == *"remaining issues"* ]]
+}
+
+@test "suggest-next fix with qa_failed debug session suggests resume" {
+  create_debug_session "qa_failed"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume"* ]]
+  [[ "$output" == *"remaining issues"* ]]
+}
+
+@test "suggest-next fix with fix_applied debug session suggests resume" {
+  create_debug_session "fix_applied"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume"* ]]
+}
+
+@test "suggest-next fix with uat_pending debug session suggests qa" {
+  create_debug_session "uat_pending"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/vbw:qa"* ]]
+}
+
+@test "suggest-next fix with uat_failed debug session suggests resume" {
+  create_debug_session "uat_failed"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume"* ]]
+  [[ "$output" == *"UAT issues"* ]]
+}
+
+@test "suggest-next fix with investigating debug session suggests resume" {
+  create_debug_session "investigating"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume"* ]]
+  [[ "$output" == *"Continue debugging"* ]]
+}
+
+@test "suggest-next fix with no debug session suggests qa" {
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/vbw:qa"* ]]
+}
+
+@test "suggest-next fix with complete debug session suggests qa" {
+  create_debug_session "complete"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/vbw:qa"* ]]
+  [[ "$output" != *"--resume"* ]]
+}
+
+@test "suggest-next fix with debug session and phases exist defers to default" {
+  create_debug_session "qa_pending"
+  mkdir -p "$TEST_TEMP_DIR/.vbw-planning/phases/01-test"
+  echo '# Plan' > "$TEST_TEMP_DIR/.vbw-planning/phases/01-test/01-PLAN.md"
+  echo '# Summary' > "$TEST_TEMP_DIR/.vbw-planning/phases/01-test/01-SUMMARY.md"
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  # When phases exist, debug-session handler is skipped
+  [[ "$output" != *"--resume"* ]]
+  [[ "$output" == *"/vbw:qa"* ]]
+}

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -209,7 +209,7 @@ EOF
   run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
   [ "$status" -eq 0 ]
   [[ "$output" == *"--resume"* ]]
-  [[ "$output" == *"Continue debugging"* ]]
+  [[ "$output" == *"Continue investigation"* ]]
 }
 
 @test "suggest-next fix with no debug session suggests qa" {

--- a/tests/suggest-next-debug-session.bats
+++ b/tests/suggest-next-debug-session.bats
@@ -189,11 +189,12 @@ EOF
   [[ "$output" == *"--resume"* ]]
 }
 
-@test "suggest-next fix with uat_pending debug session suggests qa" {
+@test "suggest-next fix with uat_pending debug session suggests verify" {
   create_debug_session "uat_pending"
   run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/vbw:qa"* ]]
+  [[ "$output" == *"/vbw:verify"* ]]
+  [[ "$output" == *"UAT"* ]]
 }
 
 @test "suggest-next fix with uat_failed debug session suggests resume" {


### PR DESCRIPTION
## Linked Issue

Fixes #411

## What

Adds debug-session awareness to the `fix)` case in `scripts/suggest-next.sh`. When a debug session is active (standalone, no phases), the fix now suggests `/vbw:debug --resume` instead of `/vbw:qa` for most session states.

## Why

The `fix)` case was written before debug sessions existed and never updated. When a user ran `/vbw:fix` during an active debug session, they were directed to standalone QA (`/vbw:qa`) instead of resuming the debug session — losing debug-session context.

## How

- **`scripts/suggest-next.sh`**: Added a debug-session detection block to the `fix)` case (lines 717-754) using the identical pattern from `qa)` and `verify)` cases — `debug-session-state.sh get-or-latest` → `eval` → branch on `status`. Routes `qa_pending|qa_failed|fix_applied` → `/vbw:debug --resume -- Address remaining issues`, `uat_failed` → `/vbw:debug --resume -- Address UAT issues`, `investigating` → `/vbw:debug --resume -- Continue debugging`, `uat_pending` → `/vbw:qa -- Verify the fix`. The `phase_count=0` guard matches the convention in `qa)` and `verify)`.

- **`tests/suggest-next-debug-session.bats`**: Added 9 new BATS tests covering all debug session statuses (`qa_pending`, `qa_failed`, `fix_applied`, `uat_pending`, `uat_failed`, `investigating`), plus boundary cases (no session, complete session, phases-exist deferral).

## Acceptance Criteria Verification

1. **When a debug session is active and `fix)` is the command context, suggest `/vbw:debug --resume` instead of `/vbw:qa`**: Satisfied by `scripts/suggest-next.sh` lines 728-746, tested in `tests/suggest-next-debug-session.bats` tests 'fix with qa_pending/qa_failed/fix_applied/uat_failed/investigating debug session suggests resume'
2. **When no debug session is active, the existing behavior is preserved (suggest `/vbw:qa`)**: Satisfied by `scripts/suggest-next.sh` lines 749-752, tested in 'fix with no debug session suggests qa' and 'fix with complete debug session suggests qa'
3. **BATS test coverage for the new branch**: 9 new tests in `tests/suggest-next-debug-session.bats` covering every status branch plus edge cases

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] All 2763 BATS tests pass (`bash testing/run-all.sh`)
- [x] All 38 contract checks pass
- [x] All lint checks pass (ShellCheck, bash -n)
- [x] 9 new tests cover every code path in the new `fix)` debug-session block

## QA Summary

- **Primary QA (Claude)**: 3 rounds, zero findings across all rounds
- **Cross-model QA (GPT-5.4)**: 1 round, 1 medium finding (F-01: `phase_count=0` guard limits fix to standalone projects) — classified as false positive (intentional convention matching `qa)` and `verify)` cases; issue scope explicitly says 'standalone fix')
- **Copilot PR review**: Pending