### PR TITLE
test(report): add contract test for temp-file diagnostic handoff

### DIFF
--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -44,6 +44,7 @@ printf '%s\t%s\n' \
   prefer-teams-canonicalization testing/verify-prefer-teams-canonicalization.sh \
   qa-persistence-contract      testing/verify-qa-persistence-contract.sh \
   report-template-contract     testing/verify-report-template-contract.sh \
+  report-diag-handoff          testing/verify-report-diag-handoff.sh \
   discussion-engine-contract   testing/verify-discussion-engine-contract.sh \
   debug-session-contract       testing/verify-debug-session-contract.sh \
   askuserquestion-contract     testing/verify-askuserquestion-contract.sh \

--- a/testing/verify-report-diag-handoff.sh
+++ b/testing/verify-report-diag-handoff.sh
@@ -154,6 +154,20 @@ else
   fail "DIAG_FILE path: Method 1 code block missing /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
 fi
 
+# Verify the session-scoped path appears in Method 2 section
+if printf '%s\n' "$method2_section" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
+  pass "DIAG_FILE path: Method 2 section uses session-scoped path"
+else
+  fail "DIAG_FILE path: Method 2 section missing /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+fi
+
+# Verify the session-scoped path appears in Method 4 section
+if printf '%s\n' "$method4_section" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
+  pass "DIAG_FILE path: Method 4 section uses session-scoped path"
+else
+  fail "DIAG_FILE path: Method 4 section missing /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+fi
+
 echo ""
 echo "==============================="
 echo "TOTAL: $PASS PASS, $FAIL FAIL"

--- a/testing/verify-report-diag-handoff.sh
+++ b/testing/verify-report-diag-handoff.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-report-diag-handoff.sh — Verify the temp-file diagnostic handoff
+# pattern in commands/report.md.
+#
+# Guards against structural drift in the DIAG_FILE temp-file flow introduced
+# in #341. Validates that step 1 persists diagnostics, Method 1 appends from
+# the temp file with success-only cleanup, Methods 2/4 read from the temp
+# file, and the path uses the session-scoped fallback.
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPORT="$ROOT/commands/report.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+# Extract body below frontmatter
+report_body=$(awk '/^---$/{d++; next} d>=2' "$REPORT")
+
+echo "=== Report Diagnostic Handoff Contract Verification ==="
+
+# --- Check 1: Step 1 code block references tee "$DIAG_FILE" ---
+
+echo ""
+echo "--- Step 1: diagnostic persistence ---"
+
+if printf '%s\n' "$report_body" | grep -qF 'tee "$DIAG_FILE"'; then
+  pass "step 1: contains tee \"\$DIAG_FILE\" for diagnostic persistence"
+else
+  fail "step 1: missing tee \"\$DIAG_FILE\" — diagnostics must be persisted to temp file"
+fi
+
+# --- Check 2: Method 1 appends diagnostic content from temp file ---
+
+echo ""
+echo "--- Method 1: temp-file append ---"
+
+if printf '%s\n' "$report_body" | grep -qF 'cat "$DIAG_FILE" >> "$ISSUE_BODY_FILE"'; then
+  pass "method 1: contains cat \"\$DIAG_FILE\" >> \"\$ISSUE_BODY_FILE\" append pattern"
+else
+  fail "method 1: missing cat \"\$DIAG_FILE\" >> \"\$ISSUE_BODY_FILE\" — diagnostics must be appended from temp file"
+fi
+
+# --- Check 3: Method 1 cleanup is inside an if guard (success-only) ---
+
+echo ""
+echo "--- Method 1: success-only cleanup ---"
+
+# Extract the Method 1 bash code block. The block starts after "Method 1"
+# header and the first ```bash delimiter, ends at the matching ```.
+# The code block may be indented (e.g. 4 spaces inside a markdown list).
+# Within that block, verify rm -f "$DIAG_FILE" is between
+# "if gh issue create" and "fi".
+method1_block=$(printf '%s\n' "$report_body" | awk '
+  /Method 1/ { in_method=1 }
+  in_method && /```bash/ { in_code=1; next }
+  in_method && in_code && /^[[:space:]]*```[[:space:]]*$/ { exit }
+  in_code { print }
+')
+
+# Verify the if-guard structure: "if gh issue create" ... "rm -f "$DIAG_FILE"" ... "fi"
+if_line=""
+rm_line=""
+fi_line=""
+lineno=0
+while IFS= read -r line; do
+  lineno=$((lineno + 1))
+  case "$line" in
+    *'if gh issue create'*) if_line=$lineno ;;
+    *'rm -f "$DIAG_FILE"'*) rm_line=$lineno ;;
+  esac
+  # Match standalone fi (possibly with leading whitespace)
+  if printf '%s' "$line" | grep -qxE '[[:space:]]*fi[[:space:]]*'; then
+    if [ -n "$if_line" ] && [ -n "$rm_line" ]; then
+      fi_line=$lineno
+      break
+    fi
+  fi
+done < <(printf '%s\n' "$method1_block")
+
+if [ -n "$if_line" ] && [ -n "$rm_line" ] && [ -n "$fi_line" ] &&
+   [ "$if_line" -lt "$rm_line" ] && [ "$rm_line" -lt "$fi_line" ]; then
+  pass "method 1: rm -f \"\$DIAG_FILE\" is inside if-guard (lines $if_line < $rm_line < $fi_line)"
+else
+  fail "method 1: rm -f \"\$DIAG_FILE\" must be inside 'if gh issue create ... then ... fi' guard"
+fi
+
+# --- Check 4: Methods 2 and 4 reference $DIAG_FILE ---
+
+echo ""
+echo "--- Methods 2 and 4: temp-file references ---"
+
+# Extract Method 2 section (between "Method 2" and "Method 3" headers)
+method2_section=$(printf '%s\n' "$report_body" | awk '
+  /\*\*Method 2/ { found=1; next }
+  /\*\*Method 3/ { if (found) exit }
+  found { print }
+')
+
+if printf '%s\n' "$method2_section" | grep -qF 'DIAG_FILE'; then
+  pass "method 2: references DIAG_FILE for reading diagnostics"
+else
+  fail "method 2: missing DIAG_FILE reference — must read diagnostics from temp file"
+fi
+
+# Extract Method 4 section (from "Method 4" to end of body)
+method4_section=$(printf '%s\n' "$report_body" | awk '
+  /\*\*Method 4/ { found=1; next }
+  found { print }
+')
+
+if printf '%s\n' "$method4_section" | grep -qF 'DIAG_FILE'; then
+  pass "method 4: references DIAG_FILE for reading diagnostics"
+else
+  fail "method 4: missing DIAG_FILE reference — must read diagnostics from temp file"
+fi
+
+# --- Check 5: DIAG_FILE path uses CLAUDE_SESSION_ID:-default ---
+
+echo ""
+echo "--- DIAG_FILE path: session-scoped ---"
+
+if printf '%s\n' "$report_body" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
+  pass "DIAG_FILE path: uses /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+else
+  fail "DIAG_FILE path: missing session-scoped path pattern /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+fi
+
+# Verify the pattern appears in both step 1 and Method 1 (at least 2 occurrences)
+diag_path_count=$(printf '%s\n' "$report_body" | grep -cF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt' || true)
+if [ "$diag_path_count" -ge 2 ]; then
+  pass "DIAG_FILE path: appears $diag_path_count times (step 1 + methods)"
+else
+  fail "DIAG_FILE path: expected >= 2 occurrences, found $diag_path_count — must appear in step 1 and filing methods"
+fi
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/testing/verify-report-diag-handoff.sh
+++ b/testing/verify-report-diag-handoff.sh
@@ -63,7 +63,7 @@ echo "--- Method 1: success-only cleanup ---"
 # Within that block, verify rm -f "$DIAG_FILE" is between
 # "if gh issue create" and "fi".
 method1_block=$(printf '%s\n' "$report_body" | awk '
-  /Method 1/ { in_method=1 }
+  /\*\*Method 1/ { in_method=1 }
   in_method && /```bash/ { in_code=1; next }
   in_method && in_code && /^[[:space:]]*```[[:space:]]*$/ { exit }
   in_code { print }

--- a/testing/verify-report-diag-handoff.sh
+++ b/testing/verify-report-diag-handoff.sh
@@ -32,24 +32,42 @@ echo "=== Report Diagnostic Handoff Contract Verification ==="
 
 # --- Check 1: Step 1 code block references tee "$DIAG_FILE" ---
 
+# Extract step 1 code block (first ```bash block in the body, before any Method header)
+step1_block=$(printf '%s\n' "$report_body" | awk '
+  /\*\*Method/ { exit }
+  /```bash/ { in_code=1; next }
+  in_code && /^[[:space:]]*```[[:space:]]*$/ { exit }
+  in_code { print }
+')
+
 echo ""
 echo "--- Step 1: diagnostic persistence ---"
 
-if printf '%s\n' "$report_body" | grep -qF 'tee "$DIAG_FILE"'; then
+if printf '%s\n' "$step1_block" | grep -qF 'tee "$DIAG_FILE"'; then
   pass "step 1: contains tee \"\$DIAG_FILE\" for diagnostic persistence"
 else
-  fail "step 1: missing tee \"\$DIAG_FILE\" — diagnostics must be persisted to temp file"
+  fail "step 1: missing tee \"\$DIAG_FILE\" in step 1 code block — diagnostics must be persisted to temp file"
 fi
 
 # --- Check 2: Method 1 appends diagnostic content from temp file ---
 
+# Extract the Method 1 bash code block. The block starts after "**Method 1"
+# header and the first ```bash delimiter, ends at the matching ```.
+# The code block may be indented (e.g. 4 spaces inside a markdown list).
+method1_block=$(printf '%s\n' "$report_body" | awk '
+  /\*\*Method 1/ { in_method=1 }
+  in_method && /```bash/ { in_code=1; next }
+  in_method && in_code && /^[[:space:]]*```[[:space:]]*$/ { exit }
+  in_code { print }
+')
+
 echo ""
 echo "--- Method 1: temp-file append ---"
 
-if printf '%s\n' "$report_body" | grep -qF 'cat "$DIAG_FILE" >> "$ISSUE_BODY_FILE"'; then
+if printf '%s\n' "$method1_block" | grep -qF 'cat "$DIAG_FILE" >> "$ISSUE_BODY_FILE"'; then
   pass "method 1: contains cat \"\$DIAG_FILE\" >> \"\$ISSUE_BODY_FILE\" append pattern"
 else
-  fail "method 1: missing cat \"\$DIAG_FILE\" >> \"\$ISSUE_BODY_FILE\" — diagnostics must be appended from temp file"
+  fail "method 1: missing cat \"\$DIAG_FILE\" >> \"\$ISSUE_BODY_FILE\" in Method 1 code block"
 fi
 
 # --- Check 3: Method 1 cleanup is inside an if guard (success-only) ---
@@ -57,17 +75,8 @@ fi
 echo ""
 echo "--- Method 1: success-only cleanup ---"
 
-# Extract the Method 1 bash code block. The block starts after "Method 1"
-# header and the first ```bash delimiter, ends at the matching ```.
-# The code block may be indented (e.g. 4 spaces inside a markdown list).
-# Within that block, verify rm -f "$DIAG_FILE" is between
+# Within method1_block, verify rm -f "$DIAG_FILE" is between
 # "if gh issue create" and "fi".
-method1_block=$(printf '%s\n' "$report_body" | awk '
-  /\*\*Method 1/ { in_method=1 }
-  in_method && /```bash/ { in_code=1; next }
-  in_method && in_code && /^[[:space:]]*```[[:space:]]*$/ { exit }
-  in_code { print }
-')
 
 # Verify the if-guard structure: "if gh issue create" ... "rm -f "$DIAG_FILE"" ... "fi"
 if_line=""
@@ -108,10 +117,10 @@ method2_section=$(printf '%s\n' "$report_body" | awk '
   found { print }
 ')
 
-if printf '%s\n' "$method2_section" | grep -qF 'DIAG_FILE'; then
-  pass "method 2: references DIAG_FILE for reading diagnostics"
+if printf '%s\n' "$method2_section" | grep -qF 'cat "$DIAG_FILE"'; then
+  pass "method 2: references cat \"\$DIAG_FILE\" for reading diagnostics"
 else
-  fail "method 2: missing DIAG_FILE reference — must read diagnostics from temp file"
+  fail "method 2: missing cat \"\$DIAG_FILE\" — must read diagnostics from temp file"
 fi
 
 # Extract Method 4 section (from "Method 4" to end of body)
@@ -120,10 +129,10 @@ method4_section=$(printf '%s\n' "$report_body" | awk '
   found { print }
 ')
 
-if printf '%s\n' "$method4_section" | grep -qF 'DIAG_FILE'; then
-  pass "method 4: references DIAG_FILE for reading diagnostics"
+if printf '%s\n' "$method4_section" | grep -qF 'cat "$DIAG_FILE"'; then
+  pass "method 4: references cat \"\$DIAG_FILE\" for reading diagnostics"
 else
-  fail "method 4: missing DIAG_FILE reference — must read diagnostics from temp file"
+  fail "method 4: missing cat \"\$DIAG_FILE\" — must read diagnostics from temp file"
 fi
 
 # --- Check 5: DIAG_FILE path uses CLAUDE_SESSION_ID:-default ---
@@ -131,18 +140,18 @@ fi
 echo ""
 echo "--- DIAG_FILE path: session-scoped ---"
 
-if printf '%s\n' "$report_body" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
-  pass "DIAG_FILE path: uses /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+# Verify the session-scoped path appears in the step 1 code block
+if printf '%s\n' "$step1_block" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
+  pass "DIAG_FILE path: step 1 code block uses session-scoped path"
 else
-  fail "DIAG_FILE path: missing session-scoped path pattern /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
+  fail "DIAG_FILE path: step 1 code block missing /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
 fi
 
-# Verify the pattern appears in both step 1 and Method 1 (at least 2 occurrences)
-diag_path_count=$(printf '%s\n' "$report_body" | grep -cF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt' || true)
-if [ "$diag_path_count" -ge 2 ]; then
-  pass "DIAG_FILE path: appears $diag_path_count times (step 1 + methods)"
+# Verify the session-scoped path appears in the Method 1 code block
+if printf '%s\n' "$method1_block" | grep -qF '/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt'; then
+  pass "DIAG_FILE path: Method 1 code block uses session-scoped path"
 else
-  fail "DIAG_FILE path: expected >= 2 occurrences, found $diag_path_count — must appear in step 1 and filing methods"
+  fail "DIAG_FILE path: Method 1 code block missing /tmp/vbw-diag-report-\${CLAUDE_SESSION_ID:-default}.txt"
 fi
 
 echo ""


### PR DESCRIPTION
## Linked Issue

Fixes #398

## What

Added a new contract test `testing/verify-report-diag-handoff.sh` (9 checks) that verifies the temp-file diagnostic handoff pattern in `commands/report.md`. Registered it in `testing/list-contract-tests.sh`.

## Why

There was no automated test coverage for the `/vbw:report` temp-file diagnostic handoff introduced in #341. The existing `verify-report-template-contract.sh` covers template alignment and classification criteria but not the `DIAG_FILE` temp-file flow (persistence, append, success-only cleanup, cross-method path consistency).

## How

- **`testing/verify-report-diag-handoff.sh`** (new): Contract test with 9 section-specific assertions:
  1. Step 1 code block contains `tee "$DIAG_FILE"` for diagnostic persistence
  2. Method 1 code block contains `cat "$DIAG_FILE" >> "$ISSUE_BODY_FILE"` append pattern
  3. Method 1 `rm -f "$DIAG_FILE"` is inside `if gh issue create ... fi` guard (success-only cleanup)
  4. Method 2 section references `cat "$DIAG_FILE"` for reading diagnostics
  5. Method 4 section references `cat "$DIAG_FILE"` for reading diagnostics
  6. Step 1 code block uses session-scoped path `/tmp/vbw-diag-report-${CLAUDE_SESSION_ID:-default}.txt`
  7. Method 1 code block uses session-scoped path
  8. Method 2 section uses session-scoped path
  9. Method 4 section uses session-scoped path

  All assertions extract the relevant section (step 1 code block, Method 1 code block, Method 2 section, Method 4 section) before grepping, preventing false matches from other sections.

- **`testing/list-contract-tests.sh`**: Added `report-diag-handoff` registration entry after `report-template-contract`.

## Acceptance Criteria Verification

1. **At least one automated test verifies the temp-file handoff pattern in `commands/report.md`**: Satisfied by `testing/verify-report-diag-handoff.sh` with 9 checks covering all 5 proposed verification points from the issue.
2. **The test is registered in `testing/list-contract-tests.sh`**: Satisfied — registered as `report-diag-handoff` at line 47.
3. **`bash testing/run-all.sh` passes with the new test included**: Satisfied — 39/39 contract checks, 2754/2754 BATS tests, lint clean.

## Testing

- [x] `bash testing/verify-report-diag-handoff.sh` — 9/9 PASS
- [x] `bash testing/run-all.sh` — 39/39 contract, 2754/2754 BATS, lint clean
- [x] ShellCheck clean on new script

## QA Summary

- **Primary QA (Claude)**: 3 rounds
  - Round 1: 1 low finding fixed (awk pattern `/Method 1/` → `/\*\*Method 1/`)
  - Rounds 2–3: clean
- **Cross-model QA (GPT-5.4)**: 3 rounds
  - Round 1: 1 medium finding fixed (tightened all assertions to section-specific extraction)
  - Round 2: 1 medium finding fixed (added Method 2/4 session-scoped path assertions)
  - Round 3: 1 low false positive (QA agent tooling limitation — can't execute tests)
- **Copilot PR review**: Pending
- **Total findings**: 3 fixed, 1 false positive