### PR TITLE
fix(tests): harden run_phase_detect retry with exponential backoff and completeness check

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -43,18 +43,25 @@ teardown_temp_dir() {
 
 # Run phase-detect.sh with retry on empty output.
 # Under heavy parallel BATS execution, transient fork/exec failures can cause
-# the subprocess to produce zero output. Retrying handles this reliably.
+# the subprocess to produce zero output. Retries with exponential backoff
+# (0.1s doubling → 0.1, 0.2, 0.4, 0.8, 1.6s ≈ 3.1s total) handle this
+# reliably. Returns 1 if all retries produce empty output.
 # Sets BATS globals: $output, $status (same as `run`).
 run_phase_detect() {
   local _pd_script_dir="${1:-$SCRIPTS_DIR}"
   local _pd_attempt=0
-  while [ $_pd_attempt -lt 3 ]; do
+  local _pd_backoff="0.1"
+  while [ $_pd_attempt -lt 5 ]; do
     run bash "$_pd_script_dir/phase-detect.sh"
     [ -n "$output" ] && return 0
     _pd_attempt=$((_pd_attempt + 1))
-    sleep 0.1
+    if [ $_pd_attempt -lt 5 ]; then
+      sleep "$_pd_backoff"
+      _pd_backoff=$(awk "BEGIN {printf \"%.1f\", $_pd_backoff * 2}")
+    fi
   done
-  return 0
+  echo "run_phase_detect: all 5 retries returned empty output" >&2
+  return 1
 }
 
 vbw_cache_prefix_for_root() {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -41,26 +41,31 @@ teardown_temp_dir() {
   unset VBW_AGENT_PID_LOCK_DIR _ORIG_HOME _ORIG_GIT_CONFIG_NOSYSTEM _ORIG_GIT_CONFIG_GLOBAL
 }
 
-# Run phase-detect.sh with retry on empty output.
-# Under heavy parallel BATS execution, transient fork/exec failures can cause
-# the subprocess to produce zero output. Retries with exponential backoff
-# (0.1s doubling → sleeps of 0.1, 0.2, 0.4, 0.8s ≈ 1.5s total) handle this
-# reliably. Returns 1 if all retries produce empty output.
+# Run phase-detect.sh with retry on empty or incomplete output.
+# Under heavy parallel BATS execution, transient fork/exec or pipe failures can
+# cause the subprocess to produce zero output or only the EXIT-trap fallback
+# (qa_status=none + execution_state=none). Retries with exponential backoff
+# (sleeps of 0.1, 0.2, 0.4, 0.8s ≈ 1.5s total) handle both cases.
+# Output is considered complete when it contains "next_phase_state=" — a field
+# present in every normal code path of phase-detect.sh but absent from the
+# trap-only fallback.
+# Returns 1 if all 5 attempts produce empty or incomplete output.
 # Sets BATS globals: $output, $status (same as `run`).
 run_phase_detect() {
   local _pd_script_dir="${1:-$SCRIPTS_DIR}"
+  local _pd_sleeps=(0.1 0.2 0.4 0.8)
   local _pd_attempt=0
-  local _pd_backoff="0.1"
   while [ $_pd_attempt -lt 5 ]; do
     run bash "$_pd_script_dir/phase-detect.sh"
-    [ -n "$output" ] && return 0
-    _pd_attempt=$((_pd_attempt + 1))
-    if [ $_pd_attempt -lt 5 ]; then
-      sleep "$_pd_backoff"
-      _pd_backoff=$(awk "BEGIN {printf \"%.1f\", $_pd_backoff * 2}")
+    if [ -n "$output" ] && [[ "$output" == *"next_phase_state="* ]]; then
+      return 0
     fi
+    if [ $_pd_attempt -lt 4 ]; then
+      sleep "${_pd_sleeps[$_pd_attempt]}"
+    fi
+    _pd_attempt=$((_pd_attempt + 1))
   done
-  echo "run_phase_detect: all 5 retries returned empty output" >&2
+  echo "run_phase_detect: all 5 retries returned empty or incomplete output" >&2
   return 1
 }
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -44,7 +44,7 @@ teardown_temp_dir() {
 # Run phase-detect.sh with retry on empty output.
 # Under heavy parallel BATS execution, transient fork/exec failures can cause
 # the subprocess to produce zero output. Retries with exponential backoff
-# (0.1s doubling → 0.1, 0.2, 0.4, 0.8, 1.6s ≈ 3.1s total) handle this
+# (0.1s doubling → sleeps of 0.1, 0.2, 0.4, 0.8s ≈ 1.5s total) handle this
 # reliably. Returns 1 if all retries produce empty output.
 # Sets BATS globals: $output, $status (same as `run`).
 run_phase_detect() {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -49,7 +49,9 @@ teardown_temp_dir() {
 # Output is considered complete when it contains "next_phase_state=" — a field
 # present in every normal code path of phase-detect.sh but absent from the
 # trap-only fallback.
-# Returns 1 if all 5 attempts produce empty or incomplete output.
+# Returns 1 and sets status=1 if all 5 attempts produce empty or incomplete
+# output, so callers' `[ "$status" -eq 0 ]` assertions fail with a clear
+# diagnostic rather than a confusing content mismatch.
 # Sets BATS globals: $output, $status (same as `run`).
 run_phase_detect() {
   local _pd_script_dir="${1:-$SCRIPTS_DIR}"
@@ -65,7 +67,9 @@ run_phase_detect() {
     fi
     _pd_attempt=$((_pd_attempt + 1))
   done
-  echo "run_phase_detect: all 5 retries returned empty or incomplete output" >&2
+  output="run_phase_detect: all 5 retries returned empty or incomplete output"
+  status=1
+  echo "$output" >&2
   return 1
 }
 


### PR DESCRIPTION
## Linked Issue

Fixes #413

## What

Hardens the `run_phase_detect()` test helper in `tests/test_helper.bash` to eliminate flaky BATS failures under 12-worker parallel execution. The function now uses exponential backoff, output completeness validation, and explicit failure signaling.

## Why

Under heavy parallel BATS execution (12 workers), `phase-detect.sh` occasionally produces either:
1. **Empty output** — transient fork/exec failures return zero bytes
2. **Incomplete/trap-fallback output** — the EXIT trap fires on abnormal termination, producing only `qa_status=none` + `execution_state=none` (missing all normal fields like `next_phase_state=`)

The old `run_phase_detect()` only checked for empty output (`[ -n "$output" ]`) with a fixed 0.1s retry, and returned 0 even when all retries failed. This caused random assertion failures in downstream tests that checked output content.

The correct fix addresses both failure modes at the retry layer rather than modifying `phase-detect.sh` itself, since the script works correctly — the issue is transient process-level failures under load.

## How

**`tests/test_helper.bash`** — `run_phase_detect()` function:
- **Increased retries** from 3 to 5
- **Replaced awk-computed backoff** with a bash array `(0.1 0.2 0.4 0.8)` — eliminates locale sensitivity where `awk` might produce `0,2` instead of `0.2` in non-C locales
- **Added completeness check**: requires `next_phase_state=` in output (present in ALL normal `phase-detect.sh` code paths but absent from the EXIT trap fallback) alongside the existing non-empty check
- **Returns 1 with stderr diagnostic** when all retries exhausted (was `return 0`) — all 173 callers assert `status -eq 0`, so exhaustion now produces a clear, immediate test failure instead of a cryptic content assertion failure downstream
- **Skips sleep after final attempt** to avoid unnecessary delay on exhaustion

## Acceptance criteria verification

1. **`run_phase_detect()` retries with longer backoff and fails explicitly on exhaustion** — satisfied by exponential backoff array `(0.1, 0.2, 0.4, 0.8s ≈ 1.5s total)` and `return 1` with diagnostic message (`tests/test_helper.bash` lines 44-68)
2. **`bash testing/run-all.sh` with 12 workers passes consistently** — verified with 5 consecutive clean runs (2754 tests, 0 failed each run)
3. **No test behavior changes** — only the retry/failure mechanism in the helper was modified; all callers continue to use the same `run_phase_detect` → `[ "$status" -eq 0 ]` → content assertion pattern

## Testing

- [x] `bash testing/run-all.sh` — 39/39 contract checks, 2754/0 BATS, 1/1 lint
- [x] 5 consecutive clean runs with 12 workers (default configuration)
- [x] No new tests needed — existing 173 callers across `phase-detect.bats`, `auto-uat.bats`, `archive-uat-guard.bats`, and `extract-uat-issues.bats` exercise the helper

## QA summary

| Phase | Rounds | Model | Findings |
|-------|--------|-------|----------|
| Primary QA (Phase 3) | 3 | Claude Opus 4.6 | Round 1: 1 low (comment inaccuracy — fixed). Rounds 2-3: clean |
| Cross-model QA (Phase 3.5) | 2 | GPT-5.4 | Round 1: 1 low (locale-sensitive awk — fixed with bash array + completeness check). Round 2: 1 medium false positive (empirical proof not checked in — runs were performed) |
| Copilot PR review | Pending | — | — |