### PR TITLE
fix(skills): update CLI syntax to match skills@1.5.0

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -243,7 +243,7 @@ If any settings.json changes or plugins installed: display `(restart Claude Code
 **2d. find-skills bootstrap:** Check `find_skills_available` from detect-stack JSON.
 - `true`: display "✓ Skills.sh registry — available"
 - `false`: AskUserQuestion: "○ Skills.sh Registry\n\nVBW can search the Skills.sh registry (~2000 community skills) to find\nskills matching your project. This requires the find-skills meta-skill.\nInstall it now?" Options: "Install (Recommended)" / "Skip"
-  - Approved: `npx skills add vercel-labs/skills --skill find-skills -g -y`
+  - Approved: `npx -y -p skills skill add https://github.com/vercel-labs/skills/tree/main/skills/find-skills -g`
   - Declined: "○ Skipped. Run /vbw:skills later to search the registry."
 
 ### Step 3: Convergence — augment and search
@@ -259,9 +259,9 @@ If any settings.json changes or plugins installed: display `(restart Claude Code
 
 If greenfield: write `{"conventions": []}`. Display: `○ Conventions — none yet (add with /vbw:teach)`
 
-**3c. Parallel registry search** (if find-skills available): run `npx skills find "<stack-item>"` for ALL detected_stack items **in parallel** (multiple concurrent Bash calls). Deduplicate against installed skills. If detected_stack empty, search by project type. Display results with `(registry)` tag.
+**3c. Parallel registry search** (if find-skills available): run `npx -y -p skills skill search "<stack-item>"` for ALL detected_stack items **in parallel** (multiple concurrent Bash calls). Deduplicate against installed skills. If detected_stack empty, search by project type. Display results with `(registry)` tag.
 
-**3d. Unified skill prompt:** Combine curated (from 2b) + registry (from 3c) results into single AskUserQuestion multiSelect. Tag `(curated)` or `(registry)`. Max 4 options + "Skip". Install selected: `npx skills add <skill> -g -y`.
+**3d. Unified skill prompt:** Combine curated (from 2b) + registry (from 3c) results into single AskUserQuestion multiSelect. Tag `(curated)` or `(registry)`. Max 4 options + "Skip". Install selected: `npx -y -p skills skill add <skill> -g`.
 
 ### Step 3.5: Generate bootstrap CLAUDE.md
 

--- a/commands/skills.md
+++ b/commands/skills.md
@@ -51,10 +51,10 @@ From `suggestions[]` in Context JSON (recommended but not installed). Display in
 
 ### Step 4: Dynamic registry search
 
-**4a.** If `find_skills_available` is false: AskUserQuestion to install find-skills (`npx skills add vercel-labs/skills --skill find-skills -g -y`). Declined → skip to Step 5.
+**4a.** If `find_skills_available` is false: AskUserQuestion to install find-skills (`npx -y -p skills skill add https://github.com/vercel-labs/skills/tree/main/skills/find-skills -g`). Declined → skip to Step 5.
 
 **4b.** Search when: --search passed (search for query) | no --search but unmapped stack items (auto-search each) | all mapped → skip.
-Run `npx skills find "<query>"`. Display results with `(registry)` tag. If npx unavailable: "⚠ skills CLI not found."
+Run `npx -y -p skills skill search "<query>"`. Display results with `(registry)` tag. If npx unavailable: "⚠ skills CLI not found."
 
 ### Step 5: Offer installation
 
@@ -87,13 +87,13 @@ If the user typed `skip`, STOP here after displaying `○ No skills selected for
 
 AskUserQuestion (single select) — "Where should these skills be installed?":
 - **Project (Recommended)** — "Installed to `./.claude/skills/`, scoped to this project only."
-- **Global** — "Installed to `~/.agents/skills/`, available in all projects."
+- **Global** — "Installed to `~/.claude/skills/`, available in all projects."
 
 Store the choice as SCOPE. If the user typed `skip` in Step 5: skip this step.
 
 ### Step 6: Install selected
 
-`npx skills add <skill> -y` (project scope) or `npx skills add <skill> -g -y` (global scope) per selection, based on SCOPE from Step 5b. This step runs only when one or more skills were selected in Step 5. Display ✓ or ✗ per skill. "➜ Skills take effect immediately — no restart needed."
+`npx -y -p skills skill add <skill>` (project scope) or `npx -y -p skills skill add <skill> -g` (global scope) per selection, based on SCOPE from Step 5b. This step runs only when one or more skills were selected in Step 5. Display ✓ or ✗ per skill. "➜ Skills take effect immediately — no restart needed."
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

`/vbw:skills` and `/vbw:init` embed `npx skills …` commands that match an early/pre-1.0 API of [`vercel-labs/skills`](https://github.com/vercel-labs/skills). Against the current `skills@1.5.0` on npm they fail silently or loudly, so the Skills.sh registry integration is effectively broken end-to-end.

Reproduction with a fresh install:

```
$ npx -y -p skills skill add vercel-labs/skills --skill find-skills -g -y
error: unknown option '--skill'

$ npx -y -p skills skill find python
error: unknown command 'find'
```

`detect-stack.sh` therefore always reports `find_skills_available: false`, the bootstrap step in `/vbw:init` never installs `find-skills`, and every registry search in `/vbw:skills` falls through.

## Fix

- Invoke via `npx -y -p skills skill …` — the package's bin is `skill` (singular); calling it as `skills` collides with npm's own command dispatcher on some setups.
- Drop the removed `--skill <name>` flag; pass the skill as the `<source>` positional. For non-registry skills the full GitHub tree URL works: `https://github.com/vercel-labs/skills/tree/main/skills/<name>`.
- Rename `skills find` → `skill search` (the CLI was renamed).
- Drop `-y` from `skill add` (not a valid flag; kept on `npx` itself).
- Correct the displayed global install path from `~/.agents/skills/` to `~/.claude/skills/`, which is what `skill add -g` actually uses per its own `--help`.

Files touched: `commands/init.md`, `commands/skills.md`.

## Verified

Against `skills@1.5.0`:

```
$ npx -y -p skills skill add \
    https://github.com/vercel-labs/skills/tree/main/skills/find-skills -g
✔ Installed find-skills (global)
  → /home/tux/.claude/skills/find-skills

$ bash scripts/detect-stack.sh . | jq .find_skills_available
true

$ npx -y -p skills skill search python
<registry results>
```

## Test plan

- [ ] /vbw:init on fresh machine: bootstrap installs find-skills without error
- [ ] /vbw:skills: registry search returns results for detected stack
- [ ] /vbw:skills install: both project and global scope succeed
- [ ] detect-stack.sh reports find_skills_available: true after install