### PR TITLE
fix(scripts): stabilize phase-detect QA pending status under parallel BATS

### DIFF
--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -60,7 +60,7 @@ verification_writer() {
   [ -f "$verification_file" ] || return 0
   awk '
     BEGIN { in_fm=0 }
-    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^writer:/ { sub(/^writer:[[:space:]]*/, ""); print; exit }
   ' "$verification_file" 2>/dev/null
@@ -721,7 +721,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
           if [ -n "$_uv_verif" ] && [ -f "$_uv_verif" ]; then
             _qa_done_result=$(awk '
               BEGIN { in_fm=0 }
-              !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+              NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
               in_fm && /^---[[:space:]]*$/ { exit }
               in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
             ' "$_uv_verif" 2>/dev/null) || _qa_done_result=""
@@ -740,7 +740,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
                 # Staleness check for remediated path
                 _vac_rem=$(awk '
                   BEGIN { in_fm=0 }
-                  !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+                  NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
                   in_fm && /^---[[:space:]]*$/ { exit }
                   in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
                 ' "$_uv_verif" 2>/dev/null) || _vac_rem=""
@@ -774,7 +774,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
         elif [ -n "$_uv_verif" ] && [ -f "$_uv_verif" ]; then
           _qa_result=$(awk '
             BEGIN { in_fm=0 }
-            !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+            NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
             in_fm && /^---[[:space:]]*$/ { exit }
             in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
           ' "$_uv_verif" 2>/dev/null) || _qa_result=""
@@ -796,7 +796,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
               # Staleness check: if code changed since QA verified, treat as pending
               _vac=$(awk '
                 BEGIN { in_fm=0 }
-                !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+                NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
                 in_fm && /^---[[:space:]]*$/ { exit }
                 in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
               ' "$_uv_verif" 2>/dev/null) || _vac=""
@@ -879,7 +879,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
     if [ "$_qa_attention" = "none" ] && [ -n "$_qa_verif_scan" ] && [ -f "$_qa_verif_scan" ]; then
       _qa_result_scan=$(awk '
         BEGIN { in_fm=0 }
-        !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+        NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
         in_fm && /^---[[:space:]]*$/ { exit }
         in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
       ' "$_qa_verif_scan" 2>/dev/null) || _qa_result_scan=""
@@ -900,7 +900,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
             PROCEED_TO_UAT)
           _vac_scan=$(awk '
             BEGIN { in_fm=0 }
-            !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+            NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
             in_fm && /^---[[:space:]]*$/ { exit }
             in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
           ' "$_qa_verif_scan" 2>/dev/null) || _vac_scan=""
@@ -1357,7 +1357,7 @@ _pd_build_uat_issue_lines() {
   if [ "$_pd_base_count" -eq 0 ]; then
     _pd_fm_issues=$(awk '
       BEGIN { in_fm=0 }
-      !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm && /^[[:space:]]*issues[[:space:]]*:/ {
         val=$0; sub(/^[^:]*:[[:space:]]*/, "", val); gsub(/[[:space:]]+$/, "", val)

--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -22,8 +22,16 @@ list_child_dirs_sorted() {
   local parent="$1"
   [ -d "$parent" ] || return 0
 
-  find "$parent" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null |
-    (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+  # Collect via bash glob (avoids find pipeline under parallel fd contention).
+  # Then sort with version sort (printf is a builtin → much less fd-sensitive
+  # than find, which traverses the filesystem and can fail under exhaustion).
+  local dirs=() d
+  for d in "$parent"/*/; do
+    [ -d "$d" ] && dirs+=("${d%/}")
+  done
+  [ ${#dirs[@]} -gt 0 ] || return 0
+  printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+    printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
 }
 
 phase_relative_path() {
@@ -52,7 +60,7 @@ verification_writer() {
   [ -f "$verification_file" ] || return 0
   awk '
     BEGIN { in_fm=0 }
-    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^writer:/ { sub(/^writer:[[:space:]]*/, ""); print; exit }
   ' "$verification_file" 2>/dev/null
@@ -713,7 +721,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
           if [ -n "$_uv_verif" ] && [ -f "$_uv_verif" ]; then
             _qa_done_result=$(awk '
               BEGIN { in_fm=0 }
-              NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+              !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
               in_fm && /^---[[:space:]]*$/ { exit }
               in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
             ' "$_uv_verif" 2>/dev/null) || _qa_done_result=""
@@ -732,7 +740,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
                 # Staleness check for remediated path
                 _vac_rem=$(awk '
                   BEGIN { in_fm=0 }
-                  NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+                  !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
                   in_fm && /^---[[:space:]]*$/ { exit }
                   in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
                 ' "$_uv_verif" 2>/dev/null) || _vac_rem=""
@@ -766,7 +774,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
         elif [ -n "$_uv_verif" ] && [ -f "$_uv_verif" ]; then
           _qa_result=$(awk '
             BEGIN { in_fm=0 }
-            NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+            !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
             in_fm && /^---[[:space:]]*$/ { exit }
             in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
           ' "$_uv_verif" 2>/dev/null) || _qa_result=""
@@ -788,7 +796,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
               # Staleness check: if code changed since QA verified, treat as pending
               _vac=$(awk '
                 BEGIN { in_fm=0 }
-                NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+                !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
                 in_fm && /^---[[:space:]]*$/ { exit }
                 in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
               ' "$_uv_verif" 2>/dev/null) || _vac=""
@@ -871,7 +879,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
     if [ "$_qa_attention" = "none" ] && [ -n "$_qa_verif_scan" ] && [ -f "$_qa_verif_scan" ]; then
       _qa_result_scan=$(awk '
         BEGIN { in_fm=0 }
-        NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+        !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
         in_fm && /^---[[:space:]]*$/ { exit }
         in_fm && /^result:/ { sub(/^result:[[:space:]]*/, ""); print; exit }
       ' "$_qa_verif_scan" 2>/dev/null) || _qa_result_scan=""
@@ -892,7 +900,7 @@ if [ ${#PHASE_DIRS[@]} -gt 0 ]; then
             PROCEED_TO_UAT)
           _vac_scan=$(awk '
             BEGIN { in_fm=0 }
-            NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+            !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
             in_fm && /^---[[:space:]]*$/ { exit }
             in_fm && /^verified_at_commit:/ { sub(/^verified_at_commit:[[:space:]]*/, ""); print; exit }
           ' "$_qa_verif_scan" 2>/dev/null) || _vac_scan=""
@@ -1349,7 +1357,7 @@ _pd_build_uat_issue_lines() {
   if [ "$_pd_base_count" -eq 0 ]; then
     _pd_fm_issues=$(awk '
       BEGIN { in_fm=0 }
-      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+      !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm && /^[[:space:]]*issues[[:space:]]*:/ {
         val=$0; sub(/^[^:]*:[[:space:]]*/, "", val); gsub(/[[:space:]]+$/, "", val)

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -119,7 +119,7 @@ resolve_phase_number_from_phase_dir() {
   uat_file=$(find "$dir" -maxdepth 1 ! -name '.*' -name '*-UAT.md' ! -name '*-SOURCE-UAT.md' 2>/dev/null | (sort -V 2>/dev/null || sort) | head -1)
   if [ -n "$uat_file" ] && [ -f "$uat_file" ]; then
     num=$(awk '
-      !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
+      NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm {
         lower = tolower($0)
@@ -148,7 +148,7 @@ resolve_phase_number_from_phase_dir() {
   fi
   if [ -n "$uat_file" ] && [ -f "$uat_file" ]; then
     num=$(awk '
-      !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
+      NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm {
         lower = tolower($0)

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -116,7 +116,7 @@ resolve_phase_number_from_phase_dir() {
   uat_file=$(find "$dir" -maxdepth 1 ! -name '.*' -name '*-UAT.md' ! -name '*-SOURCE-UAT.md' 2>/dev/null | (sort -V 2>/dev/null || sort) | head -1)
   if [ -n "$uat_file" ] && [ -f "$uat_file" ]; then
     num=$(awk '
-      NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+      !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm {
         lower = tolower($0)
@@ -145,7 +145,7 @@ resolve_phase_number_from_phase_dir() {
   fi
   if [ -n "$uat_file" ] && [ -f "$uat_file" ]; then
     num=$(awk '
-      NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+      !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm {
         lower = tolower($0)

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -19,7 +19,12 @@ list_canonical_phase_dirs() {
 
 count_phase_plans() {
   local dir="$1"
-  find "$dir" -maxdepth 1 ! -name '.*' \( -name '[0-9]*-PLAN.md' -o -name 'PLAN.md' \) 2>/dev/null | wc -l | tr -d ' '
+  local count=0
+  local f
+  for f in "$dir"/[0-9]*-PLAN.md "$dir"/PLAN.md; do
+    [ -f "$f" ] && count=$((count + 1))
+  done
+  echo "$count"
 }
 
 phase_dir_display_name() {

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -6,15 +6,18 @@ list_canonical_phase_dirs() {
   local parent="$1"
   [ -d "$parent" ] || return 0
 
-  find "$parent" -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
-    while IFS= read -r dir; do
-      [ -n "$dir" ] || continue
-      base=$(basename "$dir")
-      case "$base" in
-        [0-9]*-*) echo "$dir" ;;
-      esac
-    done |
-    (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+  # Collect phase dirs via bash glob (avoids find pipeline under parallel
+  # fd contention). Only match NN-slug pattern (canonical phase dirs).
+  local dirs=() d base
+  for d in "$parent"/*/; do
+    [ -d "$d" ] || continue
+    base="${d%/}"
+    base="${base##*/}"
+    case "$base" in [0-9]*-*) dirs+=("${d%/}") ;; esac
+  done
+  [ ${#dirs[@]} -gt 0 ] || return 0
+  printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+    printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
 }
 
 count_phase_plans() {

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -35,7 +35,12 @@ if [ -f "$SCRIPT_DIR/phase-state-utils.sh" ]; then
 else
   count_phase_plans() {
     local dir="$1"
-    find "$dir" -maxdepth 1 ! -name '.*' \( -name '[0-9]*-PLAN.md' -o -name 'PLAN.md' \) 2>/dev/null | wc -l | tr -d ' '
+    local count=0
+    local f
+    for f in "$dir"/[0-9]*-PLAN.md "$dir"/PLAN.md; do
+      [ -f "$f" ] && count=$((count + 1))
+    done
+    echo "$count"
   }
   list_canonical_phase_dirs() {
     local parent="$1"

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -45,13 +45,15 @@ else
   list_canonical_phase_dirs() {
     local parent="$1"
     [ -d "$parent" ] || return 0
-    find "$parent" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null |
-      while IFS= read -r dir; do
-        [ -n "$dir" ] || continue
-        base=$(basename "$dir")
-        case "$base" in [0-9]*-*) echo "$dir" ;; esac
-      done |
-      (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+    local dirs=() d base
+    for d in "$parent"/*/; do
+      [ -d "$d" ] || continue
+      base="${d%/}"; base="${base##*/}"
+      case "$base" in [0-9]*-*) dirs+=("${d%/}") ;; esac
+    done
+    [ ${#dirs[@]} -gt 0 ] || return 0
+    printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+      printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
   }
   find_phase_dir_by_ref() {
     local planning_dir="$1" phase_ref="$2"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -22,13 +22,15 @@ else
   list_canonical_phase_dirs() {
     local parent="$1"
     [ -d "$parent" ] || return 0
-    find "$parent" -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
-      while IFS= read -r dir; do
-        [ -n "$dir" ] || continue
-        base=$(basename "$dir")
-        case "$base" in [0-9]*-*) echo "$dir" ;; esac
-      done |
-      (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+    local dirs=() d base
+    for d in "$parent"/*/; do
+      [ -d "$d" ] || continue
+      base="${d%/}"; base="${base##*/}"
+      case "$base" in [0-9]*-*) dirs+=("${d%/}") ;; esac
+    done
+    [ ${#dirs[@]} -gt 0 ] || return 0
+    printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+      printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
   }
   count_phase_plans() {
     local dir="$1"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -32,7 +32,12 @@ else
   }
   count_phase_plans() {
     local dir="$1"
-    find "$dir" -maxdepth 1 ! -name '.*' \( -name '[0-9]*-PLAN.md' -o -name 'PLAN.md' \) 2>/dev/null | wc -l | tr -d ' '
+    local count=0
+    local f
+    for f in "$dir"/[0-9]*-PLAN.md "$dir"/PLAN.md; do
+      [ -f "$f" ] && count=$((count + 1))
+    done
+    echo "$count"
   }
   phase_dir_display_name() {
     local dir="$1"

--- a/scripts/summary-utils.sh
+++ b/scripts/summary-utils.sh
@@ -1,7 +1,63 @@
 #!/bin/bash
 # summary-utils.sh -- shared helpers for status-aware SUMMARY.md checking
 # Source this from scripts that need status-based completion detection.
-# All functions are portable bash (3.2+), no external dependencies beyond awk.
+# All functions are portable bash (3.2+) with no external process dependencies
+# on the hot path. This keeps summary counting stable under heavily parallel
+# BATS runs where frequent fork/exec can intermittently fail.
+
+trim_summary_value() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+extract_summary_status() {
+  local f="$1"
+  local line value
+  local in_fm=false
+  local saw_content=false
+  local bom=$'\357\273\277'
+
+  [ -f "$f" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+
+    if [ "$saw_content" = false ]; then
+      line="${line#"$bom"}"
+      value=$(trim_summary_value "$line")
+      if [ -z "$value" ]; then
+        continue
+      fi
+      saw_content=true
+      if [[ "$line" =~ ^---[[:space:]]*$ ]]; then
+        in_fm=true
+        continue
+      fi
+      return 0
+    fi
+
+    if [ "$in_fm" = true ]; then
+      if [[ "$line" =~ ^---[[:space:]]*$ ]]; then
+        return 0
+      fi
+      if [[ "$line" =~ ^[[:space:]]*status: ]]; then
+        value="${line#*:}"
+        value=$(trim_summary_value "$value")
+        case "$value" in
+          \"*\") value="${value#\"}"; value="${value%\"}" ;;
+          \'*\') value="${value#\'}"; value="${value%\'}" ;;
+        esac
+        value=$(trim_summary_value "$value")
+        printf '%s\n' "$value"
+        return 0
+      fi
+    fi
+  done < "$f"
+
+  return 0
+}
 
 # is_summary_complete FILE_PATH
 # Returns 0 if SUMMARY exists and has terminal-complete status, 1 otherwise.
@@ -9,20 +65,9 @@
 # "partial" and "failed" are terminal but NOT complete.
 is_summary_complete() {
   local f="$1"
-  [ -f "$f" ] || return 1
   local status
-  status=$(awk '
-    BEGIN { in_fm=0 }
-    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
-    in_fm && /^---[[:space:]]*$/ { exit }
-    in_fm && /^status:/ {
-      sub(/^status:[[:space:]]*/, "")
-      gsub(/[\r"'"'"']/, "")
-      gsub(/[[:space:]]/, "")
-      print
-      exit
-    }
-  ' "$f" 2>/dev/null)
+  [ -f "$f" ] || return 1
+  status=$(extract_summary_status "$f")
   case "$status" in
     complete|completed) return 0 ;;
     *) return 1 ;;
@@ -33,20 +78,9 @@ is_summary_complete() {
 # Returns 0 if SUMMARY exists and has any terminal status (complete|completed|partial|failed).
 is_summary_terminal() {
   local f="$1"
-  [ -f "$f" ] || return 1
   local status
-  status=$(awk '
-    BEGIN { in_fm=0 }
-    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
-    in_fm && /^---[[:space:]]*$/ { exit }
-    in_fm && /^status:/ {
-      sub(/^status:[[:space:]]*/, "")
-      gsub(/[\r"'"'"']/, "")
-      gsub(/[[:space:]]/, "")
-      print
-      exit
-    }
-  ' "$f" 2>/dev/null)
+  [ -f "$f" ] || return 1
+  status=$(extract_summary_status "$f")
   case "$status" in
     complete|completed|partial|failed) return 0 ;;
     *) return 1 ;;
@@ -77,18 +111,7 @@ count_done_summaries() {
   local f st
   for f in "$dir"/*-SUMMARY.md "$dir"/SUMMARY.md; do
     [ -f "$f" ] || continue
-    st=$(awk '
-      BEGIN { in_fm=0 }
-      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
-      in_fm && /^---[[:space:]]*$/ { exit }
-      in_fm && /^status:/ {
-        sub(/^status:[[:space:]]*/, "")
-        gsub(/[\r"'"'"']/, "")
-        gsub(/[[:space:]]/, "")
-        print
-        exit
-      }
-    ' "$f" 2>/dev/null)
+    st=$(extract_summary_status "$f")
     case "$st" in complete|completed|partial) count=$((count + 1)) ;; esac
   done
   echo "$count"

--- a/scripts/summary-utils.sh
+++ b/scripts/summary-utils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # summary-utils.sh -- shared helpers for status-aware SUMMARY.md checking
 # Source this from scripts that need status-based completion detection.
-# All functions are portable bash (3.2+), no external dependencies beyond sed.
+# All functions are portable bash (3.2+), no external dependencies beyond awk.
 
 # is_summary_complete FILE_PATH
 # Returns 0 if SUMMARY exists and has terminal-complete status, 1 otherwise.
@@ -11,7 +11,18 @@ is_summary_complete() {
   local f="$1"
   [ -f "$f" ] || return 1
   local status
-  status=$(tr -d '\r' < "$f" 2>/dev/null | sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' | head -1 | tr -d '[:space:]')
+  status=$(awk '
+    BEGIN { in_fm=0 }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    in_fm && /^---[[:space:]]*$/ { exit }
+    in_fm && /^status:/ {
+      sub(/^status:[[:space:]]*/, "")
+      gsub(/[\r"'"'"']/, "")
+      gsub(/[[:space:]]/, "")
+      print
+      exit
+    }
+  ' "$f" 2>/dev/null)
   case "$status" in
     complete|completed) return 0 ;;
     *) return 1 ;;
@@ -24,7 +35,18 @@ is_summary_terminal() {
   local f="$1"
   [ -f "$f" ] || return 1
   local status
-  status=$(tr -d '\r' < "$f" 2>/dev/null | sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' | head -1 | tr -d '[:space:]')
+  status=$(awk '
+    BEGIN { in_fm=0 }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    in_fm && /^---[[:space:]]*$/ { exit }
+    in_fm && /^status:/ {
+      sub(/^status:[[:space:]]*/, "")
+      gsub(/[\r"'"'"']/, "")
+      gsub(/[[:space:]]/, "")
+      print
+      exit
+    }
+  ' "$f" 2>/dev/null)
   case "$status" in
     complete|completed|partial|failed) return 0 ;;
     *) return 1 ;;
@@ -55,7 +77,18 @@ count_done_summaries() {
   local f st
   for f in "$dir"/*-SUMMARY.md "$dir"/SUMMARY.md; do
     [ -f "$f" ] || continue
-    st=$(tr -d '\r' < "$f" 2>/dev/null | sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' | head -1 | tr -d '[:space:]')
+    st=$(awk '
+      BEGIN { in_fm=0 }
+      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+      in_fm && /^---[[:space:]]*$/ { exit }
+      in_fm && /^status:/ {
+        sub(/^status:[[:space:]]*/, "")
+        gsub(/[\r"'"'"']/, "")
+        gsub(/[[:space:]]/, "")
+        print
+        exit
+      }
+    ' "$f" 2>/dev/null)
     case "$st" in complete|completed|partial) count=$((count + 1)) ;; esac
   done
   echo "$count"

--- a/scripts/summary-utils.sh
+++ b/scripts/summary-utils.sh
@@ -13,7 +13,7 @@ is_summary_complete() {
   local status
   status=$(awk '
     BEGIN { in_fm=0 }
-    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^status:/ {
       sub(/^status:[[:space:]]*/, "")
@@ -37,7 +37,7 @@ is_summary_terminal() {
   local status
   status=$(awk '
     BEGIN { in_fm=0 }
-    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^status:/ {
       sub(/^status:[[:space:]]*/, "")
@@ -79,7 +79,7 @@ count_done_summaries() {
     [ -f "$f" ] || continue
     st=$(awk '
       BEGIN { in_fm=0 }
-      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+      !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm && /^status:/ {
         sub(/^status:[[:space:]]*/, "")

--- a/scripts/summary-utils.sh
+++ b/scripts/summary-utils.sh
@@ -13,7 +13,7 @@ is_summary_complete() {
   local status
   status=$(awk '
     BEGIN { in_fm=0 }
-    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^status:/ {
       sub(/^status:[[:space:]]*/, "")
@@ -37,7 +37,7 @@ is_summary_terminal() {
   local status
   status=$(awk '
     BEGIN { in_fm=0 }
-    !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && /^status:/ {
       sub(/^status:[[:space:]]*/, "")
@@ -79,7 +79,7 @@ count_done_summaries() {
     [ -f "$f" ] || continue
     st=$(awk '
       BEGIN { in_fm=0 }
-      !in_fm && /^---[[:space:]]*$/ { in_fm=1; next }
+      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
       in_fm && /^---[[:space:]]*$/ { exit }
       in_fm && /^status:/ {
         sub(/^status:[[:space:]]*/, "")

--- a/scripts/uat-utils.sh
+++ b/scripts/uat-utils.sh
@@ -58,7 +58,7 @@ extract_status_value() {
   # Try frontmatter first
   result=$(awk '
     BEGIN { in_fm = 0 }
-    !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && tolower($0) ~ /^[[:space:]]*status[[:space:]]*:/ {
       value = $0

--- a/scripts/uat-utils.sh
+++ b/scripts/uat-utils.sh
@@ -58,7 +58,7 @@ extract_status_value() {
   # Try frontmatter first
   result=$(awk '
     BEGIN { in_fm = 0 }
-    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    !in_fm && /^---[[:space:]]*$/ { in_fm = 1; next }
     in_fm && /^---[[:space:]]*$/ { exit }
     in_fm && tolower($0) ~ /^[[:space:]]*status[[:space:]]*:/ {
       value = $0

--- a/scripts/update-phase-total.sh
+++ b/scripts/update-phase-total.sh
@@ -44,17 +44,24 @@ else
   list_canonical_phase_dirs() {
     local parent="$1"
     [ -d "$parent" ] || return 0
-    find "$parent" -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
-      while IFS= read -r dir; do
-        [ -n "$dir" ] || continue
-        base=$(basename "$dir")
-        case "$base" in [0-9]*-*) echo "$dir" ;; esac
-      done |
-      (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+    local dirs=() d base
+    for d in "$parent"/*/; do
+      [ -d "$d" ] || continue
+      base="${d%/}"; base="${base##*/}"
+      case "$base" in [0-9]*-*) dirs+=("${d%/}") ;; esac
+    done
+    [ ${#dirs[@]} -gt 0 ] || return 0
+    printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+      printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
   }
   count_phase_plans() {
     local dir="$1"
-    find "$dir" -maxdepth 1 ! -name '.*' \( -name '[0-9]*-PLAN.md' -o -name 'PLAN.md' \) 2>/dev/null | wc -l | tr -d ' '
+    local count=0
+    local f
+    for f in "$dir"/[0-9]*-PLAN.md "$dir"/PLAN.md; do
+      [ -f "$f" ] && count=$((count + 1))
+    done
+    echo "$count"
   }
   phase_dir_display_name() {
     local dir="$1"

--- a/scripts/vbw-statusline.sh
+++ b/scripts/vbw-statusline.sh
@@ -87,18 +87,25 @@ if [ -f "$_SL_SCRIPT_DIR/phase-state-utils.sh" ]; then
 else
   count_phase_plans() {
     local dir="$1"
-    find "$dir" -maxdepth 1 ! -name '.*' \( -name '[0-9]*-PLAN.md' -o -name 'PLAN.md' \) 2>/dev/null | wc -l | tr -d ' '
+    local count=0
+    local f
+    for f in "$dir"/[0-9]*-PLAN.md "$dir"/PLAN.md; do
+      [ -f "$f" ] && count=$((count + 1))
+    done
+    echo "$count"
   }
   list_canonical_phase_dirs() {
     local parent="$1"
     [ -d "$parent" ] || return 0
-    find "$parent" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null |
-      while IFS= read -r dir; do
-        [ -n "$dir" ] || continue
-        base=$(basename "$dir")
-        case "$base" in [0-9]*-*) echo "$dir" ;; esac
-      done |
-      (sort -V 2>/dev/null || awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-)
+    local dirs=() d base
+    for d in "$parent"/*/; do
+      [ -d "$d" ] || continue
+      base="${d%/}"; base="${base##*/}"
+      case "$base" in [0-9]*-*) dirs+=("${d%/}") ;; esac
+    done
+    [ ${#dirs[@]} -gt 0 ] || return 0
+    printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
+      printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
   }
   find_phase_dir_by_ref() {
     local planning_dir="$1" phase_ref="$2"

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -187,6 +187,15 @@ else
   fail "is_summary_complete: status: \"complete\" (quoted) -> expected 0, got 1"
 fi
 
+# CRLF line endings -> true
+printf -- '---\r\nphase: 01\r\nstatus: complete\r\n---\r\n\r\nDone.\r\n' > "$TMPDIR_BASE/crlf.md"
+
+if is_summary_complete "$TMPDIR_BASE/crlf.md"; then
+  pass "is_summary_complete: CRLF line endings -> 0"
+else
+  fail "is_summary_complete: CRLF line endings -> expected 0, got 1"
+fi
+
 # ===== is_summary_terminal =====
 
 echo ""
@@ -238,6 +247,12 @@ if is_summary_terminal "$TMPDIR_BASE/nofm.md"; then
   fail "is_summary_terminal: no frontmatter -> expected 1, got 0"
 else
   pass "is_summary_terminal: no frontmatter -> 1"
+fi
+
+if is_summary_terminal "$TMPDIR_BASE/crlf.md"; then
+  pass "is_summary_terminal: CRLF line endings -> 0"
+else
+  fail "is_summary_terminal: CRLF line endings -> expected 0, got 1"
 fi
 
 # ===== count_complete_summaries =====

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -187,6 +187,67 @@ else
   fail "is_summary_complete: status: \"complete\" (quoted) -> expected 0, got 1"
 fi
 
+# Leading blank lines before frontmatter -> true
+cat > "$TMPDIR_BASE/leadingblank.md" <<'EOF'
+
+---
+phase: 01
+plan: 01
+status: complete
+---
+
+Done.
+EOF
+
+if is_summary_complete "$TMPDIR_BASE/leadingblank.md"; then
+  pass "is_summary_complete: leading blank line before frontmatter -> 0"
+else
+  fail "is_summary_complete: leading blank line before frontmatter -> expected 0, got 1"
+fi
+
+# UTF-8 BOM before frontmatter -> true
+printf '\357\273\277---\nphase: 01\nplan: 01\nstatus: complete\n---\n\nDone.\n' > "$TMPDIR_BASE/bom.md"
+
+if is_summary_complete "$TMPDIR_BASE/bom.md"; then
+  pass "is_summary_complete: UTF-8 BOM before frontmatter -> 0"
+else
+  fail "is_summary_complete: UTF-8 BOM before frontmatter -> expected 0, got 1"
+fi
+
+# Whitespace-padded status value -> true
+cat > "$TMPDIR_BASE/padded.md" <<'EOF'
+---
+phase: 01
+plan: 01
+status:    complete   
+---
+
+Done.
+EOF
+
+if is_summary_complete "$TMPDIR_BASE/padded.md"; then
+  pass "is_summary_complete: whitespace-padded status -> 0"
+else
+  fail "is_summary_complete: whitespace-padded status -> expected 0, got 1"
+fi
+
+# Quoted whitespace-padded status value -> true
+cat > "$TMPDIR_BASE/quoted-padded.md" <<'EOF'
+---
+phase: 01
+plan: 01
+status: "  complete  "
+---
+
+Done.
+EOF
+
+if is_summary_complete "$TMPDIR_BASE/quoted-padded.md"; then
+  pass "is_summary_complete: quoted whitespace-padded status -> 0"
+else
+  fail "is_summary_complete: quoted whitespace-padded status -> expected 0, got 1"
+fi
+
 # CRLF line endings -> true
 printf -- '---\r\nphase: 01\r\nstatus: complete\r\n---\r\n\r\nDone.\r\n' > "$TMPDIR_BASE/crlf.md"
 
@@ -253,6 +314,30 @@ if is_summary_terminal "$TMPDIR_BASE/crlf.md"; then
   pass "is_summary_terminal: CRLF line endings -> 0"
 else
   fail "is_summary_terminal: CRLF line endings -> expected 0, got 1"
+fi
+
+if is_summary_terminal "$TMPDIR_BASE/leadingblank.md"; then
+  pass "is_summary_terminal: leading blank line before frontmatter -> 0"
+else
+  fail "is_summary_terminal: leading blank line before frontmatter -> expected 0, got 1"
+fi
+
+if is_summary_terminal "$TMPDIR_BASE/bom.md"; then
+  pass "is_summary_terminal: UTF-8 BOM before frontmatter -> 0"
+else
+  fail "is_summary_terminal: UTF-8 BOM before frontmatter -> expected 0, got 1"
+fi
+
+if is_summary_terminal "$TMPDIR_BASE/padded.md"; then
+  pass "is_summary_terminal: whitespace-padded status -> 0"
+else
+  fail "is_summary_terminal: whitespace-padded status -> expected 0, got 1"
+fi
+
+if is_summary_terminal "$TMPDIR_BASE/quoted-padded.md"; then
+  pass "is_summary_terminal: quoted whitespace-padded status -> 0"
+else
+  fail "is_summary_terminal: quoted whitespace-padded status -> expected 0, got 1"
 fi
 
 # ===== count_complete_summaries =====

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2417,7 +2417,11 @@ EOF
 
   run_phase_detect
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "qa_status=pending"
+  echo "$output" | grep -q "qa_status=pending" || {
+    echo "# DIAG: full phase-detect.sh output follows" >&3
+    echo "$output" >&3
+    false
+  }
 }
 
 @test "qa_status is pending for brownfield remediated verification after later commit" {

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2417,7 +2417,39 @@ EOF
 
   run_phase_detect
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "qa_status=pending"
+  echo "$output" | grep -q "qa_status=pending" || {
+    echo "# DIAG: full phase-detect.sh output follows" >&3
+    echo "$output" >&3
+    false
+  }
+}
+
+@test "summary with leading blank line still counts as complete for pending QA routing" {
+  mkdir -p .vbw-planning/phases/01-test
+  echo "# Plan" > .vbw-planning/phases/01-test/01-PLAN.md
+  cat > .vbw-planning/phases/01-test/01-SUMMARY.md <<'EOF'
+
+---
+status: complete
+---
+EOF
+  echo "# My Project" > .vbw-planning/PROJECT.md
+
+  printf '%s\n' \
+    '---' \
+    'result: PASS' \
+    'writer: ' \
+    '---' \
+    '# Verification' \
+    'Passed.' > .vbw-planning/phases/01-test/01-VERIFICATION.md
+
+  run_phase_detect
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "qa_status=pending" || {
+    echo "# DIAG: full phase-detect.sh output follows" >&3
+    echo "$output" >&3
+    false
+  }
 }
 
 @test "qa_status is pending for brownfield remediated verification after later commit" {

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2417,11 +2417,7 @@ EOF
 
   run_phase_detect
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "qa_status=pending" || {
-    echo "# DIAG: full phase-detect.sh output follows" >&3
-    echo "$output" >&3
-    false
-  }
+  echo "$output" | grep -q "qa_status=pending"
 }
 
 @test "qa_status is pending for brownfield remediated verification after later commit" {


### PR DESCRIPTION
## Linked Issue

Fixes #414
Follow-up observation filed separately: #428

## What

This change hardens the `qa_status=pending` detection path that was intermittently failing under the repo’s real parallel runner (`bash testing/run-all.sh` with the default 12 BATS workers plus contract/lint fanout). It replaces fragile subprocess-heavy summary parsing with a shared pure-bash parser, keeps phase-plan enumeration on bash-glob helpers instead of `find|wc|tr`, broadens summary parsing for brownfield frontmatter quirks (leading blank lines / BOM / padded values / CRLF), restores useful failure diagnostics in the flaky `phase-detect` assertion, and adds regression coverage that exercises both the helper contract and the runtime `phase-detect` path.

## Why

The failure was not on the plain `bats -f` path; it was on the real sharded/local-parity runner. Under that load, a fully built phase could intermittently disappear from `phase-detect`’s unverified-phase scan, leaving `qa_status=none` instead of `qa_status=pending`. The initial fix reduced some subprocess fanout, but the branch still flaked. The durable fix was to remove the summary-status subprocess dependency from the hot path entirely and to ensure brownfield summaries are parsed consistently instead of narrowing semantics to “frontmatter must start on line 1.” That restores the invariant a senior engineer would actually want to own: phase-complete / QA-pending routing should be deterministic regardless of runner parallelism or harmless frontmatter formatting differences.

## How

- `scripts/summary-utils.sh` — introduced pure-bash `extract_summary_status()` and routed `is_summary_complete()`, `is_summary_terminal()`, and `count_done_summaries()` through it; broadened parsing to tolerate BOMs, leading blank lines, CRLF, quoted values, and whitespace padding.
- `scripts/phase-state-utils.sh` — uses bash-glob enumeration for canonical phase directories and `count_phase_plans()` so the shared phase helper path no longer depends on `find|wc|tr`.
- `scripts/phase-detect.sh` — uses a bash-glob child-directory sorter on the same route that computes `qa_status`, reducing filesystem subprocess fanout in the flaky control path.
- `scripts/session-start.sh` — updated degraded-mode fallback phase helpers so partial installs still use the same glob-based phase-plan enumeration contract.
- `scripts/state-updater.sh` — same degraded-mode phase-helper alignment as `session-start.sh`.
- `scripts/update-phase-total.sh` — same degraded-mode phase-helper alignment for phase-count updates.
- `scripts/vbw-statusline.sh` — same degraded-mode phase-helper alignment so fallback statusline behavior matches the shared helper contract.
- `testing/verify-summary-utils-contract.sh` — added parser regression coverage for leading blank lines, UTF-8 BOM, whitespace-padded values, quoted whitespace-padded values, and CRLF.
- `tests/phase-detect.bats` — restored `# DIAG` output to the structured flaky assertion and added a runtime brownfield regression case proving a leading-blank `SUMMARY.md` still routes to `qa_status=pending`.

## Acceptance criteria verification

Issue #414 did not include a numbered acceptance checklist, so this PR maps the issue’s explicit contract into verifiable items:

1. **Single-process alternative for `is_summary_complete()`** — satisfied by `scripts/summary-utils.sh` (`extract_summary_status()` and `is_summary_complete()` in the opening helper section and `is_summary_complete()` block). Verified by `testing/verify-summary-utils-contract.sh` complete/completed/quoted/CRLF/brownfield cases.
2. **Single-process alternative for `is_summary_terminal()`** — satisfied by `scripts/summary-utils.sh` (`is_summary_terminal()` using the shared pure-bash parser). Verified by `testing/verify-summary-utils-contract.sh` terminal-status and edge-case cases.
3. **Single-process alternative for `count_done_summaries()` inner status extraction** — satisfied by `scripts/summary-utils.sh` (`count_done_summaries()` now calls `extract_summary_status()` rather than invoking its own pipeline).
4. **`count_phase_plans()` uses a bash glob loop instead of `find|wc|tr`** — satisfied by `scripts/phase-state-utils.sh` (`count_phase_plans()` loop over `"$dir"/[0-9]*-PLAN.md` and `"$dir"/PLAN.md`). Fallback copies in `scripts/session-start.sh`, `scripts/state-updater.sh`, `scripts/update-phase-total.sh`, and `scripts/vbw-statusline.sh` were kept aligned.
5. **Parser handles CRLF, quoted values, whitespace padding, and brownfield frontmatter quirks** — satisfied by `scripts/summary-utils.sh` (`extract_summary_status()`) and verified by `testing/verify-summary-utils-contract.sh` cases for CRLF, quoted values, leading blank line, BOM, padded values, and quoted padded values.
6. **Existing tests pass** — satisfied by repeated successful execution of `bash testing/run-all.sh` from this branch plus green GitHub Actions on the latest pushed commit.
7. **Flaky assertion has useful diagnostics** — satisfied by `tests/phase-detect.bats` where `qa_status is pending when structured phase PASS fails qa-result-gate` now prints `# DIAG: full phase-detect.sh output follows` plus the captured `phase-detect.sh` output on failure.
8. **Fix stabilizes the real runner path, not only `bats -f`** — satisfied by repeated `bash testing/run-all.sh` passes under the real 52-job local-parity fanout; see Testing and QA summary below.

## Testing

- [x] `bash testing/verify-summary-utils-contract.sh`
- [x] `bats -f "qa_status is pending when structured phase PASS fails qa-result-gate" tests/phase-detect.bats`
- [x] `bats -f "summary with leading blank line still counts as complete for pending QA routing" tests/phase-detect.bats`
- [x] `bats -f "qa_status is pending for brownfield PASS verification after later commit" tests/phase-detect.bats`
- [x] `bash testing/run-all.sh`
- [x] Repeated stress verification with the real runner: `bash testing/run-all.sh` passed repeatedly in this worktree, including 5 consecutive looped passes after the final remediation and additional full-suite passes before PR creation and review.
- [x] GitHub Actions are green on the latest pushed commit (`fc222a3`).

## QA summary

- **Primary QA rounds (`qa-investigator`)**: 3 rounds completed.
  - Round 1: clean; recorded in `f72d0c2`.
  - Round 2: no contract/regression findings; observations only; recorded in `6d96762`.
  - Round 3: fresh full-contract re-run on the current branch tip to satisfy the repo’s QA evidence gate; clean; recorded in `fc222a3`.
- **Cross-model QA rounds (`qa-investigator-gpt-54`, GPT-5.4)**: 2 rounds completed.
  - Round 1: found one legitimate low-severity regression (summary parser narrowed brownfield semantics) and two stale observations that were disproved against the live branch; fixed in `7d8c0d7`.
  - Round 2: zero contract/regression findings; one downstream observation in unchanged `scripts/recover-state.sh` filed separately as #428; recorded in `d53952f`.
- **Copilot PR review rounds**: 1 summary-only review returned with no inline comments / zero review threads on the changed diff. The later `fc222a3` push was an empty QA-evidence bookkeeping commit with no file-diff changes; GitHub reused the no-findings summary review rather than creating a new diff review.

### Findings by phase

- Primary QA: 0 legitimate contract/regression findings fixed; low observations only.
- Cross-model QA: 1 legitimate low regression fixed in `7d8c0d7`; 1 downstream low observation filed separately as #428; stale observations treated as false positives once verified against the actual branch state.
- Copilot review: 0 inline findings; 0 unresolved review threads.

## Branch state

- Branch: `fix/414-flaky-qa-status-pipeline`
- Tip commit: `fc222a3`
- Synced with `origin/main`
- Local authoritative suite green on the branch tip
- Required GitHub Actions checks green on the branch tip