### PR TITLE
fix(tests): replace hardcoded dead PIDs with get_dead_pid helper

### DIFF
--- a/scripts/agent-pid-tracker.sh
+++ b/scripts/agent-pid-tracker.sh
@@ -72,7 +72,7 @@ release_lock() {
 cmd_register() {
   local pid="$1"
   # Validate PID format (positive integer, no leading zeros)
-  if ! echo "$pid" | grep -qE '^[1-9][0-9]*$'; then
+  if ! [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
     echo "ERROR: Invalid PID format: $pid" >&2
     return 1
   fi
@@ -98,7 +98,7 @@ cmd_register() {
 cmd_unregister() {
   local pid="$1"
   # Validate PID format (positive integer, no leading zeros)
-  if ! echo "$pid" | grep -qE '^[1-9][0-9]*$'; then
+  if ! [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
     echo "ERROR: Invalid PID format: $pid" >&2
     return 1
   fi
@@ -135,7 +135,7 @@ cmd_list() {
   while IFS= read -r pid; do
     [ -z "$pid" ] && continue
     # Validate positive integer PID
-    if ! echo "$pid" | grep -qE '^[1-9][0-9]*$'; then
+    if ! [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
       continue
     fi
     # Check if process exists
@@ -161,7 +161,7 @@ cmd_prune() {
 
   while IFS= read -r pid; do
     [ -z "$pid" ] && continue
-    echo "$pid" | grep -qE '^[1-9][0-9]*$' || continue
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] || continue
     if kill -0 "$pid" 2>/dev/null; then
       echo "$pid" >> "$temp_file"
       kept=$((kept + 1))

--- a/tests/agent-health-integration.bats
+++ b/tests/agent-health-integration.bats
@@ -66,7 +66,9 @@ teardown() {
 EOF
 
   # Create health file with dead PID
-  echo '{"pid":"99999","agent_type":"vbw-dev"}' | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  echo "{\"pid\":\"$dead_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Verify health file created
   [ -f "$HEALTH_DIR/dev.json" ]
@@ -77,7 +79,7 @@ EOF
   # Verify orphan recovery message
   [[ "$output" == *"Orphan recovery"* ]]
   [[ "$output" == *"task-orphan"* ]]
-  [[ "$output" == *"PID 99999 is dead"* ]]
+  [[ "$output" == *"PID $dead_pid is dead"* ]]
 
   # Verify task owner cleared
   run jq -r '.owner' "$TASKS_DIR/task-orphan.json"

--- a/tests/agent-health-integration.bats
+++ b/tests/agent-health-integration.bats
@@ -67,7 +67,7 @@ EOF
 
   # Create health file with dead PID
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Verify health file created

--- a/tests/agent-health.bats
+++ b/tests/agent-health.bats
@@ -144,7 +144,7 @@ EOF
 
   # Create health file with dead PID
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Run idle — should detect dead PID and clear owner
@@ -175,7 +175,7 @@ EOF
 EOF
 
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
@@ -207,7 +207,7 @@ EOF
   echo "{\"pid\":\"$LIVE_PID\",\"agent_id\":\"agent-live\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
@@ -322,7 +322,7 @@ EOF
   echo "{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-map-duo\",\"pid\":\"$LIVE_PID\"}" | bash "$SCRIPTS_DIR/agent-health.sh" idle >/dev/null
 
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"$dead_pid\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"task-phase"* ]]
 
@@ -362,7 +362,7 @@ EOF
 EOF
 
   local dead_pid
-  dead_pid=$(get_dead_pid)
+  dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"$dead_pid\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"still tracked"* ]]
 

--- a/tests/agent-health.bats
+++ b/tests/agent-health.bats
@@ -143,7 +143,9 @@ run_health_via_wrapper() {
 EOF
 
   # Create health file with dead PID
-  echo '{"pid":"99999","agent_type":"vbw-dev"}' | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  echo "{\"pid\":\"$dead_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Run idle — should detect dead PID and clear owner
   run bash -c "echo '{\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
@@ -172,9 +174,11 @@ EOF
 }
 EOF
 
-  echo '{"pid":"99998","agent_id":"agent-stop-001","agent_type":"vbw:vbw-dev","name":"dev-01"}' | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
-  run bash -c "echo '{\"pid\":\"99998\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
+  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"task-stop"* ]]
 
   run jq -r '.owner' "$TASKS_DIR/task-stop.json"
@@ -201,9 +205,12 @@ EOF
   LIVE_PID=$!
 
   echo "{\"pid\":\"$LIVE_PID\",\"agent_id\":\"agent-live\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
-  echo '{"pid":"99997","agent_id":"agent-dead","agent_type":"vbw-dev"}' | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
-  run bash -c "echo '{\"pid\":\"99997\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+
+  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"another live teammate"* ]]
 
   run jq -r '.owner' "$TASKS_DIR/task-shared.json"
@@ -314,7 +321,9 @@ EOF
 
   echo "{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-map-duo\",\"pid\":\"$LIVE_PID\"}" | bash "$SCRIPTS_DIR/agent-health.sh" idle >/dev/null
 
-  run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"99995\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"$dead_pid\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"task-phase"* ]]
 
   run jq -r '.owner' "$TASKS_DIR/vbw-phase-01/task-phase.json"
@@ -352,7 +361,9 @@ EOF
 }
 EOF
 
-  run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"99994\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
+  local dead_pid
+  dead_pid=$(get_dead_pid)
+  run bash -c "echo '{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-phase-01\",\"pid\":\"$dead_pid\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"still tracked"* ]]
 
   run jq -r '.owner' "$TASKS_DIR/vbw-phase-01/task-shared-nopid.json"

--- a/tests/agent-shutdown-integration.bats
+++ b/tests/agent-shutdown-integration.bats
@@ -186,8 +186,13 @@ simulate_session_stop() {
 
 @test "prune removes all dead PIDs and deletes the file" {
   cd "$TEST_TEMP_DIR"
-  # Write fake dead PIDs
-  printf '99991\n99992\n99993\n' > ".vbw-planning/.agent-pids"
+  # Generate guaranteed-dead PIDs instead of hardcoded values that may
+  # collide with live processes under parallel BATS execution
+  local dead1 dead2 dead3
+  dead1=$(get_dead_pid)
+  dead2=$(get_dead_pid)
+  dead3=$(get_dead_pid)
+  printf '%s\n%s\n%s\n' "$dead1" "$dead2" "$dead3" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
   [ "$status" -eq 0 ]
@@ -202,7 +207,10 @@ simulate_session_stop() {
   sleep 30 &
   local alive_pid=$!
 
-  printf "${alive_pid}\n99994\n99995\n" > ".vbw-planning/.agent-pids"
+  local dead1 dead2
+  dead1=$(get_dead_pid)
+  dead2=$(get_dead_pid)
+  printf '%s\n%s\n%s\n' "${alive_pid}" "$dead1" "$dead2" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
   [ "$status" -eq 0 ]
@@ -213,9 +221,9 @@ simulate_session_stop() {
   [ "$status" -eq 0 ]
 
   # Dead PIDs should be gone
-  run grep "^99994$" ".vbw-planning/.agent-pids"
+  run grep "^${dead1}$" ".vbw-planning/.agent-pids"
   [ "$status" -ne 0 ]
-  run grep "^99995$" ".vbw-planning/.agent-pids"
+  run grep "^${dead2}$" ".vbw-planning/.agent-pids"
   [ "$status" -ne 0 ]
 
   kill "$alive_pid" 2>/dev/null || true
@@ -233,13 +241,17 @@ simulate_session_stop() {
 @test "prune ignores leftover .agent-pids.tmp from interrupted prune" {
   cd "$TEST_TEMP_DIR"
   # Simulate interrupted prune that left a stale temp file with a dead PID
-  echo "12345" > ".vbw-planning/.agent-pids.tmp"
+  local stale_pid
+  stale_pid=$(get_dead_pid)
+  echo "$stale_pid" > ".vbw-planning/.agent-pids.tmp"
 
   # Put a live PID in the real file
   sleep 30 &
   local alive_pid=$!
 
-  printf "${alive_pid}\n99996\n" > ".vbw-planning/.agent-pids"
+  local dead1
+  dead1=$(get_dead_pid)
+  printf '%s\n%s\n' "${alive_pid}" "$dead1" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
   [ "$status" -eq 0 ]
@@ -258,10 +270,14 @@ simulate_session_stop() {
 @test "prune recovers from stale lock left by crashed process" {
   cd "$TEST_TEMP_DIR"
   # Simulate stale lock from a crashed process
+  local stale_lock_pid dead1 dead2
+  stale_lock_pid=$(get_dead_pid)
+  dead1=$(get_dead_pid)
+  dead2=$(get_dead_pid)
   mkdir -p "$VBW_AGENT_PID_LOCK_DIR"
-  echo "99999" > "$VBW_AGENT_PID_LOCK_DIR/pid"
+  echo "$stale_lock_pid" > "$VBW_AGENT_PID_LOCK_DIR/pid"
 
-  printf '99997\n99998\n' > ".vbw-planning/.agent-pids"
+  printf '%s\n%s\n' "$dead1" "$dead2" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
   [ "$status" -eq 0 ]
@@ -276,9 +292,12 @@ simulate_session_stop() {
 @test "prune recovers from stale lock directory with no pid file" {
   cd "$TEST_TEMP_DIR"
   # Simulate stale lock dir with no pid file (edge case: lock created but pid write failed)
+  local dead1 dead2
+  dead1=$(get_dead_pid)
+  dead2=$(get_dead_pid)
   mkdir -p "$VBW_AGENT_PID_LOCK_DIR"
 
-  printf '99997\n99998\n' > ".vbw-planning/.agent-pids"
+  printf '%s\n%s\n' "$dead1" "$dead2" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
   [ "$status" -eq 0 ]

--- a/tests/agent-shutdown-integration.bats
+++ b/tests/agent-shutdown-integration.bats
@@ -189,9 +189,9 @@ simulate_session_stop() {
   # Generate guaranteed-dead PIDs instead of hardcoded values that may
   # collide with live processes under parallel BATS execution
   local dead1 dead2 dead3
-  dead1=$(get_dead_pid)
-  dead2=$(get_dead_pid)
-  dead3=$(get_dead_pid)
+  dead1=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead2=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead3=$(get_dead_pid) || fail "get_dead_pid failed"
   printf '%s\n%s\n%s\n' "$dead1" "$dead2" "$dead3" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
@@ -208,8 +208,8 @@ simulate_session_stop() {
   local alive_pid=$!
 
   local dead1 dead2
-  dead1=$(get_dead_pid)
-  dead2=$(get_dead_pid)
+  dead1=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead2=$(get_dead_pid) || fail "get_dead_pid failed"
   printf '%s\n%s\n%s\n' "${alive_pid}" "$dead1" "$dead2" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
@@ -242,7 +242,7 @@ simulate_session_stop() {
   cd "$TEST_TEMP_DIR"
   # Simulate interrupted prune that left a stale temp file with a dead PID
   local stale_pid
-  stale_pid=$(get_dead_pid)
+  stale_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "$stale_pid" > ".vbw-planning/.agent-pids.tmp"
 
   # Put a live PID in the real file
@@ -250,7 +250,7 @@ simulate_session_stop() {
   local alive_pid=$!
 
   local dead1
-  dead1=$(get_dead_pid)
+  dead1=$(get_dead_pid) || fail "get_dead_pid failed"
   printf '%s\n%s\n' "${alive_pid}" "$dead1" > ".vbw-planning/.agent-pids"
 
   run bash "$SCRIPTS_DIR/agent-pid-tracker.sh" prune
@@ -271,9 +271,9 @@ simulate_session_stop() {
   cd "$TEST_TEMP_DIR"
   # Simulate stale lock from a crashed process
   local stale_lock_pid dead1 dead2
-  stale_lock_pid=$(get_dead_pid)
-  dead1=$(get_dead_pid)
-  dead2=$(get_dead_pid)
+  stale_lock_pid=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead1=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead2=$(get_dead_pid) || fail "get_dead_pid failed"
   mkdir -p "$VBW_AGENT_PID_LOCK_DIR"
   echo "$stale_lock_pid" > "$VBW_AGENT_PID_LOCK_DIR/pid"
 
@@ -293,8 +293,8 @@ simulate_session_stop() {
   cd "$TEST_TEMP_DIR"
   # Simulate stale lock dir with no pid file (edge case: lock created but pid write failed)
   local dead1 dead2
-  dead1=$(get_dead_pid)
-  dead2=$(get_dead_pid)
+  dead1=$(get_dead_pid) || fail "get_dead_pid failed"
+  dead2=$(get_dead_pid) || fail "get_dead_pid failed"
   mkdir -p "$VBW_AGENT_PID_LOCK_DIR"
 
   printf '%s\n%s\n' "$dead1" "$dead2" > ".vbw-planning/.agent-pids"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -41,6 +41,18 @@ teardown_temp_dir() {
   unset VBW_AGENT_PID_LOCK_DIR _ORIG_HOME _ORIG_GIT_CONFIG_NOSYSTEM _ORIG_GIT_CONFIG_GLOBAL
 }
 
+# Generate a PID that is guaranteed dead. Spawns a short-lived process,
+# kills it, waits for it to exit, and returns its PID. Avoids hardcoded
+# PIDs that may collide with live processes under parallel BATS execution.
+get_dead_pid() {
+  local p
+  sleep 999 &
+  p=$!
+  kill "$p" 2>/dev/null
+  wait "$p" 2>/dev/null || true
+  echo "$p"
+}
+
 # Run phase-detect.sh with retry on empty or incomplete output.
 # Under heavy parallel BATS execution, transient fork/exec or pipe failures can
 # cause the subprocess to produce zero output or only the EXIT-trap fallback

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -53,9 +53,7 @@ get_dead_pid() {
   kill "$p" 2>/dev/null || kill -9 "$p" 2>/dev/null || true
   wait "$p" 2>/dev/null || true
   if kill -0 "$p" 2>/dev/null; then
-    kill -9 "$p" 2>/dev/null || true
-    wait "$p" 2>/dev/null || true
-    kill -0 "$p" 2>/dev/null && return 1
+    return 1
   fi
   echo "$p"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -41,9 +41,10 @@ teardown_temp_dir() {
   unset VBW_AGENT_PID_LOCK_DIR _ORIG_HOME _ORIG_GIT_CONFIG_NOSYSTEM _ORIG_GIT_CONFIG_GLOBAL
 }
 
-# Generate a PID that is guaranteed dead. Spawns a short-lived process,
-# kills it, waits for it to exit, and returns its PID. Avoids hardcoded
-# PIDs that may collide with live processes under parallel BATS execution.
+# Generate a PID that is guaranteed dead. Spawns a process intended to stay
+# alive until killed, kills it, waits for it to exit, and returns its PID.
+# Avoids hardcoded PIDs that may collide with live processes under parallel
+# BATS execution.
 get_dead_pid() {
   local p
   sleep 999 &

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -48,8 +48,14 @@ get_dead_pid() {
   local p
   sleep 999 &
   p=$!
-  kill "$p" 2>/dev/null
+  [[ -n "$p" ]] || return 1
+  kill "$p" 2>/dev/null || kill -9 "$p" 2>/dev/null || true
   wait "$p" 2>/dev/null || true
+  if kill -0 "$p" 2>/dev/null; then
+    kill -9 "$p" 2>/dev/null || true
+    wait "$p" 2>/dev/null || true
+    kill -0 "$p" 2>/dev/null && return 1
+  fi
   echo "$p"
 }
 


### PR DESCRIPTION
Fixes #418

## What

Eliminates flaky PID-related test failures in `agent-shutdown-integration.bats` and `agent-health.bats` by replacing hardcoded "dead" PIDs (99991-99999) with a reliable `get_dead_pid()` helper, and replacing multi-process `echo | grep` pipelines in `agent-pid-tracker.sh` with bash-native `[[ =~ ]]` regex matching.

## Why

Under parallel BATS execution (12 workers), macOS PIDs cycle quickly and hardcoded PIDs 99991-99999 can collide with live processes. When `kill -0` succeeds on a "dead" PID that's actually alive, prune/orphan-recovery tests fail non-deterministically. This is the same root cause as #414 — multi-process operations and hardcoded assumptions that don't hold under parallel execution.

## How

- **`tests/test_helper.bash`**: Added `get_dead_pid()` helper that spawns `sleep 999 &`, kills it, waits for reaping, and verifies via `kill -0` that the PID is actually dead. Includes input validation, SIGKILL fallback, and PID-reuse safety (returns non-zero instead of killing an unrelated process).
- **`tests/agent-shutdown-integration.bats`**: Replaced all hardcoded PIDs (99991-99999) with `get_dead_pid()` calls across 5 prune tests. All calls guarded with `|| fail`.
- **`tests/agent-health.bats`**: Replaced all hardcoded PIDs (99994-99999) with `get_dead_pid()` calls across 5 orphan-recovery tests. All calls guarded with `|| fail`.
- **`tests/agent-health-integration.bats`**: Replaced hardcoded PID 99999 with `get_dead_pid()` in 1 orphan-recovery test. Guarded with `|| fail`.
- **`scripts/agent-pid-tracker.sh`**: Replaced 4 instances of `echo "$pid" | grep -qE '^[1-9][0-9]*$'` with bash-native `[[ "$pid" =~ ^[1-9][0-9]*$ ]]` — eliminates unnecessary subprocesses.

## Acceptance Criteria Verification

1. ✅ `scripts/agent-pid-tracker.sh` uses `[[ =~ ]]` instead of `echo | grep` for PID validation — all 4 instances replaced (lines 50, 65, 100, 109)
2. ✅ `tests/test_helper.bash` provides `get_dead_pid()` that spawns→kills→waits a process — function at lines 46-60 with input validation, SIGKILL fallback, kill -0 verification, and PID-reuse safety
3. ✅ All hardcoded PIDs 99991-99999 removed from test files — zero occurrences remain
4. ✅ BATS suite passes at full parallelism (12 workers) — 2849 passed, 0 failed
5. ✅ All `get_dead_pid()` call sites guarded with `|| fail "get_dead_pid failed"` — 18 call sites across 3 test files

## Testing

- [x] `bash testing/run-all.sh` — 2849 passed, 0 failed (lint + contracts + BATS)
- [x] ShellCheck clean on all modified files
- [x] CI green — all 14 checks passed (8 BATS shards + serial + lint + contracts + QA evidence + linked issue)

## QA Summary

| Phase | Rounds | Model | Findings |
|-------|--------|-------|----------|
| Primary QA (Phase 3) | 3 | Claude (qa-investigator) | R1: 1 low (fixed in 27840a7); R2-R3: 0 |
| Cross-model QA (Phase 3.5) | 1 | GPT-5.4 (qa-investigator-gpt-54) | 0 |
| Copilot PR Review (Phase 4.5) | 5 | GitHub Copilot | R2: 1 (hardened get_dead_pid, 0e9d3bc); R3: 13 (added || fail guards, caef9ad); R4: 1 (PID-reuse safety, b1ee443); R1,R5: 0 |
| **Total** | **10** | | **16 findings fixed, 0 false positives** |

- CI/CD: All 14 required checks green on 33da8e0
- Post-review main sync: Not needed (0 commits behind)
