### PR TITLE
fix(scripts): remove extract_summary_status() override in recover-state.sh

### DIFF
--- a/scripts/recover-state.sh
+++ b/scripts/recover-state.sh
@@ -13,13 +13,9 @@ _RS_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [ -f "$_RS_SCRIPT_DIR/summary-utils.sh" ]; then
   # shellcheck source=summary-utils.sh
   . "$_RS_SCRIPT_DIR/summary-utils.sh"
-  # Bridge wrappers: recover-state.sh call sites use these names
+  # Bridge wrapper: recover-state.sh call sites use this name
   is_plan_finalized() { is_summary_terminal "$1"; }
-  extract_summary_status() {
-    local f="$1"
-    [ -f "$f" ] || return 1
-    sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' "$f" 2>/dev/null | head -1 | tr -d '[:space:]'
-  }
+  # extract_summary_status() is provided by summary-utils.sh — do not override
 else
   # Safe default: treat plans as not finalized when helpers unavailable
   is_plan_finalized() { return 1; }

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -481,9 +481,9 @@ done
 # definitions that coexist with the sourced helper create split-brain parsing.
 for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh; do
   # Count function definitions of extract_summary_status()
-  def_count=$(grep -cE '^\s*extract_summary_status\s*\(\)' "$ROOT/scripts/$script" 2>/dev/null || echo "0")
+  def_count=$(grep -cE '^\s*extract_summary_status\s*\(\)' "$ROOT/scripts/$script" 2>/dev/null) || def_count=0
   # Count source lines for summary-utils.sh
-  source_count=$(grep -cE '^\s*\.\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null || echo "0")
+  source_count=$(grep -cE '^\s*\.\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null) || source_count=0
   # If the script sources summary-utils.sh AND defines extract_summary_status() more than once
   # (the fallback else-stub), that means there's an override in the sourced branch.
   # If it doesn't source summary-utils.sh, any definition is a standalone (not an override).

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -481,9 +481,9 @@ done
 # definitions that coexist with the sourced helper create split-brain parsing.
 for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh; do
   # Count function definitions of extract_summary_status()
-  def_count=$(grep -cE '^\s*extract_summary_status\s*\(\)' "$ROOT/scripts/$script" 2>/dev/null) || def_count=0
+  def_count=$(grep -cE '^[[:space:]]*extract_summary_status[[:space:]]*\(\)' "$ROOT/scripts/$script" 2>/dev/null) || def_count=0
   # Count source lines for summary-utils.sh (matches both `. file` and `source file`)
-  source_count=$(grep -cE '^\s*(\.|source)\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null) || source_count=0
+  source_count=$(grep -cE '^[[:space:]]*(\.|source)[[:space:]]+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null) || source_count=0
   # If the script sources summary-utils.sh AND defines extract_summary_status() more than once
   # (the fallback else-stub), that means there's an override in the sourced branch.
   # If it doesn't source summary-utils.sh, any definition is a standalone (not an override).

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -482,8 +482,8 @@ done
 for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh; do
   # Count function definitions of extract_summary_status()
   def_count=$(grep -cE '^\s*extract_summary_status\s*\(\)' "$ROOT/scripts/$script" 2>/dev/null) || def_count=0
-  # Count source lines for summary-utils.sh
-  source_count=$(grep -cE '^\s*\.\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null) || source_count=0
+  # Count source lines for summary-utils.sh (matches both `. file` and `source file`)
+  source_count=$(grep -cE '^\s*(\.|source)\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null) || source_count=0
   # If the script sources summary-utils.sh AND defines extract_summary_status() more than once
   # (the fallback else-stub), that means there's an override in the sourced branch.
   # If it doesn't source summary-utils.sh, any definition is a standalone (not an override).

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -476,6 +476,24 @@ for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-
   fi
 done
 
+# Verify no consumer script overrides extract_summary_status() after sourcing summary-utils.sh.
+# Fallback stubs in else-blocks (for when summary-utils.sh is missing) are allowed — only
+# definitions that coexist with the sourced helper create split-brain parsing.
+for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh; do
+  # Count function definitions of extract_summary_status()
+  def_count=$(grep -cE '^\s*extract_summary_status\s*\(\)' "$ROOT/scripts/$script" 2>/dev/null || echo "0")
+  # Count source lines for summary-utils.sh
+  source_count=$(grep -cE '^\s*\.\s+.*summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null || echo "0")
+  # If the script sources summary-utils.sh AND defines extract_summary_status() more than once
+  # (the fallback else-stub), that means there's an override in the sourced branch.
+  # If it doesn't source summary-utils.sh, any definition is a standalone (not an override).
+  if [ "$source_count" -gt 0 ] && [ "$def_count" -gt 1 ]; then
+    fail "integration: $script overrides extract_summary_status() after sourcing summary-utils.sh"
+  else
+    pass "integration: $script does not override extract_summary_status()"
+  fi
+done
+
 # ===== Summary =====
 
 echo ""

--- a/tests/recover-state-integration.bats
+++ b/tests/recover-state-integration.bats
@@ -640,3 +640,61 @@ STATE
   recovered_phase=$(jq -r '.phase' .vbw-planning/.execution-state.json 2>/dev/null)
   [ "$recovered_phase" = "1" ]
 }
+
+# --- Edge-case tests: recover-state uses shared summary-utils parser ---
+
+@test "recover-state: parses SUMMARY with CRLF line endings" {
+  cd "$TEST_TEMP_DIR"
+  local tmp
+  tmp=$(mktemp)
+  jq '.event_recovery = true' .vbw-planning/config.json > "$tmp" && mv "$tmp" .vbw-planning/config.json
+
+  echo "title: Build UI" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf -- '---\r\nstatus: complete\r\n---\r\n# Summary\r\n' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/recover-state.sh" 1 ".vbw-planning/phases"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.plans[0].status == "complete"' >/dev/null
+}
+
+@test "recover-state: parses SUMMARY with quoted status value" {
+  cd "$TEST_TEMP_DIR"
+  local tmp
+  tmp=$(mktemp)
+  jq '.event_recovery = true' .vbw-planning/config.json > "$tmp" && mv "$tmp" .vbw-planning/config.json
+
+  echo "title: Build UI" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf -- '---\nstatus: "complete"\n---\n# Summary\n' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/recover-state.sh" 1 ".vbw-planning/phases"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.plans[0].status == "complete"' >/dev/null
+}
+
+@test "recover-state: parses SUMMARY with whitespace-padded status" {
+  cd "$TEST_TEMP_DIR"
+  local tmp
+  tmp=$(mktemp)
+  jq '.event_recovery = true' .vbw-planning/config.json > "$tmp" && mv "$tmp" .vbw-planning/config.json
+
+  echo "title: Build UI" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf -- '---\nstatus:   complete   \n---\n# Summary\n' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/recover-state.sh" 1 ".vbw-planning/phases"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.plans[0].status == "complete"' >/dev/null
+}
+
+@test "recover-state: parses SUMMARY with leading blank line and BOM" {
+  cd "$TEST_TEMP_DIR"
+  local tmp
+  tmp=$(mktemp)
+  jq '.event_recovery = true' .vbw-planning/config.json > "$tmp" && mv "$tmp" .vbw-planning/config.json
+
+  echo "title: Build UI" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '\xef\xbb\xbf\n---\nstatus: complete\n---\n# Summary\n' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/recover-state.sh" 1 ".vbw-planning/phases"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.plans[0].status == "complete"' >/dev/null
+}


### PR DESCRIPTION
## Linked Issue

Fixes #428

Also filed #431 as a follow-up observation (session-start.sh reconcile block has the same old parser — out of scope for this PR).

## What

Removes the `extract_summary_status()` override in `scripts/recover-state.sh` that duplicated parser logic after sourcing `scripts/summary-utils.sh`. Adds edge-case BATS tests and a contract check to prevent future overrides.

**Files modified:**
- `scripts/recover-state.sh` — Removed the subprocess-based `sed | head | tr` override of `extract_summary_status()`; recovery now uses the shared pure-bash parser from `summary-utils.sh`
- `tests/recover-state-integration.bats` — Added 4 edge-case tests (CRLF, quoted status, whitespace-padded, BOM+leading blank line)
- `testing/verify-summary-utils-contract.sh` — Added contract check that prevents consumer scripts from overriding `extract_summary_status()` after sourcing the shared helper

## Why

PR #429 (fixing #414) hardened the hot path by moving summary status extraction to a pure-bash helper in `summary-utils.sh` to avoid intermittent failures under parallel verification. However, `recover-state.sh` was still overriding that helper with the older fragile `sed | head | tr` pipeline, creating a split-brain implementation. The correct architectural fix is to remove the override entirely and let the shared helper handle all edge cases uniformly.

## How

- **`scripts/recover-state.sh`**: Removed the 5-line `extract_summary_status()` function override (lines 18-22 in the old code). The `is_plan_finalized()` bridge wrapper to `is_summary_terminal()` is retained. The else-block fallback stub (for when `summary-utils.sh` is missing) is unchanged.
- **`tests/recover-state-integration.bats`**: Added 4 tests that exercise `recover-state.sh` with CRLF line endings, quoted status values, whitespace-padded status values, and BOM+leading blank line before frontmatter. These validate criterion 3.
- **`testing/verify-summary-utils-contract.sh`**: Added a loop that counts `extract_summary_status()` definitions in each consumer script; fails if a script that sources `summary-utils.sh` also defines the function more than once (the else-block fallback counts as 1; an override in the sourced branch would be 2+). QA round 1 also fixed the `grep -cE ... || echo "0"` pattern to use proper exit-code handling.

## Acceptance Criteria Verification

1. **`scripts/recover-state.sh` does not override `extract_summary_status()`** — Satisfied: the override is removed at line 18, replaced with a comment. Verified by contract check.
2. **Recovery uses shared parser from `summary-utils.sh`** — Satisfied: line 15 sources `summary-utils.sh`, line 89 calls `extract_summary_status()` from the shared lib.
3. **Correct for all input classes** — Satisfied: 4 new edge-case tests (CRLF, quoted, whitespace-padded, BOM) + existing normal frontmatter test all pass.
4. **Existing recovery tests pass** — Satisfied: 30/30 recover-state-integration.bats tests pass, 2853/2853 total BATS.
5. **Contract check prevents future split** — Satisfied: new check in `verify-summary-utils-contract.sh` catches overrides. 48/48 contract assertions pass.

## Testing

- [x] `bash testing/run-all.sh` — 39/39 contract checks, 2853/2853 BATS, lint clean
- [x] `bats tests/recover-state-integration.bats` — 30/30 (including 4 new edge-case tests)
- [x] `bash testing/verify-summary-utils-contract.sh` — 48/48 (including new override check)

## QA Summary

- **Primary QA (Claude)**: 3 rounds. Round 1: 1 low finding (grep fallback pattern in contract check — fixed in `dd8767e`). Rounds 2-3: zero findings.
- **Cross-model QA (GPT-5.4)**: 1 round. Zero contract/regression findings. 1 low observation (session-start.sh reconcile block — filed as #431, out of scope).
- **Copilot PR review**: Pending (Phase 4.5)
- **Findings fixed**: 1 (QA round 1). **False positives**: 0.