### PR TITLE
fix(skills): correct global install path display from ~/.agents/skills/ to ~/.claude/skills/

### DIFF
--- a/commands/skills.md
+++ b/commands/skills.md
@@ -87,7 +87,7 @@ If the user typed `skip`, STOP here after displaying `○ No skills selected for
 
 AskUserQuestion (single select) — "Where should these skills be installed?":
 - **Project (Recommended)** — "Installed to `./.claude/skills/`, scoped to this project only."
-- **Global** — "Installed to `~/.agents/skills/`, available in all projects."
+- **Global** — "Installed to `~/.claude/skills/`, available in all projects."
 
 Store the choice as SCOPE. If the user typed `skip` in Step 5: skip this step.
 


### PR DESCRIPTION
## Linked Issue

Fixes #433

## What

Single-line fix in `commands/skills.md` Step 5b: corrects the global install path display from `~/.agents/skills/` to `~/.claude/skills/`.

## Why

The Skills.sh CLI (`skills@1.5.0`) installs global skills for Claude Code to `~/.claude/skills/`, not `~/.agents/skills/`. The `~/.agents/skills/` path is the universal agent skills directory, not the Claude Code-specific global path. The display text was misleading users about where their global skills would be installed.

The root cause is that the Step 5b display string was written using the universal agent skills path instead of the Claude Code-specific path. `scripts/detect-stack.sh` correctly checks both `$CLAUDE_DIR/skills/` and `$HOME/.agents/skills/` for *discovery*, but the *install target* for `npx skills add -g` is `~/.claude/skills/`.

## How

- **`commands/skills.md`** (line 90): Changed `~/.agents/skills/` → `~/.claude/skills/` in Step 5b Global option display text. No other changes — CLI syntax (`npx skills add`, `npx skills find`, `--skill`, `-y`) is all correct per upstream `skills@1.5.0`.

## Acceptance criteria verification

1. **`commands/skills.md` Step 5b Global option displays `~/.claude/skills/`** — satisfied at line 90
2. **No other CLI syntax or detection logic changed** — diff is 1 file, 1 line. `scripts/detect-stack.sh`, `scripts/resolve-claude-dir.sh`, and all CLI invocations are untouched.
3. **All existing tests pass** — `bash testing/run-all.sh`: lint 1/1, contract 39/39, BATS 2852/2853 (1 pre-existing flaky test, see #434)

## Testing

- [x] Loaded plugin locally
- [x] Tested affected command (`/vbw:skills`)
- [x] No load errors
- [x] Existing commands still work
- [x] `bash testing/run-all.sh` passes (1 pre-existing flaky test tracked in #434)

## QA summary

| Phase | Rounds | Model | Findings |
|-------|--------|-------|----------|
| Primary QA | 3 | Claude | 0 findings across all rounds |
| Cross-model QA | 1 | GPT-5.4 | 2 observations (both pre-existing, filed as #435 and #436) |

- **#435**: Pre-existing pipeline inconsistency — `resolve-claude-dir.sh` cascade means display path could be wrong on non-default setups (observation, separate issue)
- **#436**: No contract test for Step 5b path text (observation, separate issue)
- **False positives**: 0

## Context

PR #426 attempted to fix Skills.sh integration but its diagnosis was incorrect — the upstream CLI syntax used in VBW (`npx skills add`, `npx skills find`, `--skill`, `-y`) is all valid per `skills@1.5.0`. The only real bug was the display path.