### PR TITLE
fix(tests): stabilize live PID fixtures

### DIFF
--- a/tests/agent-health-integration.bats
+++ b/tests/agent-health-integration.bats
@@ -17,17 +17,17 @@ teardown() {
 @test "agent-health integration: lifecycle start → idle → stop" {
   cd "$TEST_TEMP_DIR"
 
-  # Start a background process to get a live PID
-  sleep 30 &
-  LIVE_PID=$!
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
   # Simulate SubagentStart hook
-  echo "{\"pid\":\"$LIVE_PID\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Verify health file created
   [ -f "$HEALTH_DIR/dev.json" ]
   run jq -r '.pid' "$HEALTH_DIR/dev.json"
-  [ "$output" = "$LIVE_PID" ]
+  [ "$output" = "$live_pid" ]
   run jq -r '.idle_count' "$HEALTH_DIR/dev.json"
   [ "$output" = "0" ]
 
@@ -43,9 +43,6 @@ teardown() {
 
   # Verify health file removed
   [ ! -f "$HEALTH_DIR/dev.json" ]
-
-  # Cleanup background process
-  kill $LIVE_PID 2>/dev/null || true
 }
 
 # Integration Test 2: Orphan recovery (idle with dead PID clears task owner)
@@ -93,12 +90,12 @@ EOF
 @test "agent-health integration: stuck agent detection" {
   cd "$TEST_TEMP_DIR"
 
-  # Start background process
-  sleep 30 &
-  LIVE_PID=$!
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
   # Simulate SubagentStart
-  echo "{\"pid\":\"$LIVE_PID\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # First idle: idle_count = 1
   run bash -c "echo '{\"agent_type\":\"vbw-qa\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
@@ -118,7 +115,4 @@ EOF
   [[ "$output" == *"idle_count=3"* ]]
   run jq -r '.idle_count' "$HEALTH_DIR/qa.json"
   [ "$output" = "3" ]
-
-  # Cleanup
-  kill $LIVE_PID 2>/dev/null || true
 }

--- a/tests/agent-health.bats
+++ b/tests/agent-health.bats
@@ -89,11 +89,10 @@ run_health_via_wrapper() {
 # Test 2: idle increments count
 @test "agent-health: idle increments count" {
   cd "$TEST_TEMP_DIR"
-  # Create health file with a long-lived PID (PID 1 on Linux/macOS is init)
-  # For test purposes, we'll use a background sleep process
-  sleep 30 &
-  SLEEP_PID=$!
-  echo "{\"pid\":\"$SLEEP_PID\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
+  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Run idle
   echo '{"agent_type":"vbw-qa"}' | bash "$SCRIPTS_DIR/agent-health.sh" idle >/dev/null
@@ -101,17 +100,15 @@ run_health_via_wrapper() {
   # Check idle count
   run jq -r '.idle_count' "$HEALTH_DIR/qa.json"
   [ "$output" = "1" ]
-
-  # Cleanup
-  kill $SLEEP_PID 2>/dev/null || true
 }
 
 # Test 3: idle stuck advisory at count >= 3
 @test "agent-health: idle stuck advisory" {
   cd "$TEST_TEMP_DIR"
-  sleep 30 &
-  SLEEP_PID=$!
-  echo "{\"pid\":\"$SLEEP_PID\",\"agent_type\":\"vbw-scout\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
+  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-scout\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Run idle 3 times
   for i in 1 2 3; do
@@ -122,8 +119,6 @@ run_health_via_wrapper() {
   run bash -c "echo '{\"agent_type\":\"vbw-scout\"}' | bash '$SCRIPTS_DIR/agent-health.sh' idle | jq -r '.hookSpecificOutput.additionalContext'"
   [[ "$output" == *"stuck"* ]]
   [[ "$output" == *"idle_count=4"* ]]
-
-  kill $SLEEP_PID 2>/dev/null || true
 }
 
 # Test 4: orphan recovery clears owner
@@ -201,10 +196,11 @@ EOF
 }
 EOF
 
-  sleep 30 &
-  LIVE_PID=$!
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
-  echo "{\"pid\":\"$LIVE_PID\",\"agent_id\":\"agent-live\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  echo "{\"pid\":\"$live_pid\",\"agent_id\":\"agent-live\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   local dead_pid
   dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
@@ -216,7 +212,6 @@ EOF
   run jq -r '.owner' "$TASKS_DIR/task-shared.json"
   [ "$output" = "dev" ]
 
-  kill $LIVE_PID 2>/dev/null || true
   rm -rf "$TASKS_DIR"
 }
 
@@ -234,9 +229,10 @@ EOF
 # Test 5: stop removes health file
 @test "agent-health: stop removes health file" {
   cd "$TEST_TEMP_DIR"
-  sleep 30 &
-  SLEEP_PID=$!
-  echo "{\"pid\":\"$SLEEP_PID\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
+  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-qa\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
   # Verify file exists
   [ -f "$HEALTH_DIR/qa.json" ]
@@ -246,8 +242,6 @@ EOF
 
   # Verify file removed
   [ ! -f "$HEALTH_DIR/qa.json" ]
-
-  kill $SLEEP_PID 2>/dev/null || true
 }
 
 @test "agent-health: start ignores bare native agent_type even in a VBW session" {
@@ -316,10 +310,11 @@ EOF
 }
 EOF
 
-  sleep 30 &
-  LIVE_PID=$!
+  local live_pid
+  assign_live_pid live_pid || fail "assign_live_pid failed"
+  kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
-  echo "{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-map-duo\",\"pid\":\"$LIVE_PID\"}" | bash "$SCRIPTS_DIR/agent-health.sh" idle >/dev/null
+  echo "{\"teammate_name\":\"dev-01\",\"team_name\":\"vbw-map-duo\",\"pid\":\"$live_pid\"}" | bash "$SCRIPTS_DIR/agent-health.sh" idle >/dev/null
 
   local dead_pid
   dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
@@ -330,8 +325,6 @@ EOF
   [ "$output" = "" ]
   run jq -r '.owner' "$TASKS_DIR/vbw-map-duo/task-map.json"
   [ "$output" = "dev" ]
-
-  kill $LIVE_PID 2>/dev/null || true
 }
 
 @test "agent-health: orphan recovery preserves role-owned task when same-team teammate has no pid" {

--- a/tests/agent-shutdown-integration.bats
+++ b/tests/agent-shutdown-integration.bats
@@ -203,9 +203,9 @@ simulate_session_stop() {
 
 @test "prune keeps alive PIDs and removes dead ones" {
   cd "$TEST_TEMP_DIR"
-  # Start a real background process to get a live PID
-  sleep 30 &
-  local alive_pid=$!
+  local alive_pid
+  assign_live_pid alive_pid || fail "assign_live_pid failed"
+  kill -0 "$alive_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
   local dead1 dead2
   dead1=$(get_dead_pid) || fail "get_dead_pid failed"
@@ -225,8 +225,6 @@ simulate_session_stop() {
   [ "$status" -ne 0 ]
   run grep "^${dead2}$" ".vbw-planning/.agent-pids"
   [ "$status" -ne 0 ]
-
-  kill "$alive_pid" 2>/dev/null || true
 }
 
 @test "prune is a no-op when .agent-pids does not exist" {
@@ -246,8 +244,9 @@ simulate_session_stop() {
   echo "$stale_pid" > ".vbw-planning/.agent-pids.tmp"
 
   # Put a live PID in the real file
-  sleep 30 &
-  local alive_pid=$!
+  local alive_pid
+  assign_live_pid alive_pid || fail "assign_live_pid failed"
+  kill -0 "$alive_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
   local dead1
   dead1=$(get_dead_pid) || fail "get_dead_pid failed"
@@ -263,8 +262,6 @@ simulate_session_stop() {
 
   # Temp file should be cleaned up
   [ ! -f ".vbw-planning/.agent-pids.tmp" ]
-
-  kill "$alive_pid" 2>/dev/null || true
 }
 
 @test "prune recovers from stale lock left by crashed process" {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -58,6 +58,18 @@ get_dead_pid() {
   echo "$p"
 }
 
+# Assign a PID that is guaranteed alive for the duration of the current Bats
+# test shell. Intentionally uses the top-level shell PID (`$$`) rather than a
+# disposable background child, `$BASHPID` in command substitution, or an
+# external `bash -c 'echo $$'` shell, all of which can produce short-lived PIDs
+# that reintroduce liveness flakes.
+assign_live_pid() {
+  local var_name="${1:-}"
+  [ -n "$var_name" ] || return 1
+  kill -0 "$$" 2>/dev/null || return 1
+  printf -v "$var_name" '%s' "$$"
+}
+
 # Run phase-detect.sh with retry on empty or incomplete output.
 # Under heavy parallel BATS execution, transient fork/exec or pipe failures can
 # cause the subprocess to produce zero output or only the EXIT-trap fallback


### PR DESCRIPTION
## Linked Issue

Fixes #418

Related note: while validating this branch, the pre-existing flaky `phase-detect` failure tracked in #414 reproduced once on an early dirty run and was documented there. A clean rerun passed; this PR does not attempt to fix #414.

## What

This change removes the last unstable live-PID test fixtures from the flaky PID-liveness cluster. `tests/test_helper.bash` now provides a deterministic live-PID helper based on the current Bats shell, and the affected tests in `tests/agent-shutdown-integration.bats`, `tests/agent-health.bats`, and `tests/agent-health-integration.bats` now use that helper instead of spawning disposable `sleep 30 &` processes. The behavioral goal is unchanged: the tests still exercise the real `kill -0`-based liveness logic in the runtime scripts, but they no longer depend on a background child staying alive long enough under parallel Bats execution.

## Why

The original fix for #418 eliminated hardcoded dead-PID collisions, but the reopened failures showed a second root cause: the so-called live-PID fixtures were themselves disposable child processes. Under parallel Bats runs, those `sleep 30 &` helpers could disappear before `agent-pid-tracker.sh prune` or `agent-health.sh orphan_recovery` performed their `kill -0` checks. When that happened, `.agent-pids` was correctly deleted or the `another live teammate` branch was correctly skipped, and the tests failed nondeterministically. The correct architectural fix is to make the live-fixture contract deterministic by using the current Bats shell PID, which is guaranteed to remain alive for the duration of the test while still exercising the same production code paths.

## How

- `tests/test_helper.bash` — Added `assign_live_pid()` to bind a stable live PID from the current Bats shell (`$$`) and documented why this must not use `$BASHPID`, command substitution, or an external `bash -c` shell.
- `tests/agent-shutdown-integration.bats` — Replaced the remaining live `sleep 30 &` fixtures in the prune tests with `assign_live_pid()` and kept the dead-PID coverage via `get_dead_pid()`.
- `tests/agent-health.bats` — Replaced the remaining live `sleep 30 &` fixtures in the idle, stuck-advisory, same-role-live-teammate, stop, and legacy team-scope tests with `assign_live_pid()`.
- `tests/agent-health-integration.bats` — Replaced the remaining live `sleep 30 &` fixtures in lifecycle and stuck-agent integration coverage with `assign_live_pid()`.
- `tests/agent-health-idle.bats` — Not modified, but served as the reference precedent because it already used `$$` successfully for live-PID scenarios.
- `scripts/agent-pid-tracker.sh` — Unchanged; the fix preserves the real prune behavior and only stabilizes the test fixture.
- `scripts/agent-health.sh` — Unchanged; the fix preserves the real orphan-recovery behavior and only stabilizes the test fixture.

## Acceptance criteria verification

Issue #418 does not include a numbered `Acceptance Criteria` section, so verification here is mapped to the explicit failure modes and root-cause statements in the issue body and reopen comments.

1. **The prune tests no longer depend on disposable live child processes.**  
   Satisfied by `tests/test_helper.bash` (`assign_live_pid()`, around lines 61-71) and its use in `tests/agent-shutdown-integration.bats` around lines 204-257.
2. **The reopened `.agent-pids`-missing prune failure is covered by a stable live-PID fixture.**  
   Satisfied by `tests/agent-shutdown-integration.bats` around lines 204-227 (`prune keeps alive PIDs and removes dead ones`) and lines 239-257 (`prune ignores leftover .agent-pids.tmp from interrupted prune`).
3. **The related `agent-health` liveness flakes use the same stable fixture.**  
   Satisfied by `tests/agent-health.bats` around lines 91-121, 196-216, 229-242, and 310-325, plus `tests/agent-health-integration.bats` around lines 17-31 and 90-117.
4. **The fix remains test-only and preserves production behavior.**  
   Satisfied by the fact that only four test files changed on this branch; `scripts/agent-pid-tracker.sh` and `scripts/agent-health.sh` were intentionally left untouched.
5. **The flaky cluster is revalidated with repeated targeted runs and a clean full-suite rerun.**  
   Satisfied by repeated targeted stress loops on the three touched Bats files plus a clean `bash testing/run-all.sh` result showing `BATS: 2853 passed, 0 failed`.

## Testing

- [x] Repeated targeted runs of `tests/agent-shutdown-integration.bats`
- [x] Repeated targeted runs of `tests/agent-health.bats`
- [x] Repeated targeted runs of `tests/agent-health-integration.bats`
- [x] Repeated combined runs of the three-file flaky cluster
- [x] `bash testing/run-all.sh` from the feature worktree

Targeted validation performed in this branch:
- `tests/agent-health.bats` — 20/20 passed
- `tests/agent-health-integration.bats` — 20/20 passed
- `tests/agent-shutdown-integration.bats` + `tests/agent-health.bats` + `tests/agent-health-integration.bats` — 20/20 passed
- Clean authoritative full-suite rerun — `Lint checks: 1/1 passed`, `Contract checks: 39/39 passed`, `BATS: 2853 passed, 0 failed`

## QA summary

- **Primary QA rounds completed:** 3 rounds with `qa-investigator`  
  - Round 1: 0 findings — evidence commit `1ca3929`  
  - Round 2: 0 findings — evidence commit `d3f4ba8`  
  - Round 3: 0 findings — evidence commits `22b74d1` and `cdab802` (duplicate empty evidence commit from a retry; no code changes between them)
- **Cross-model rounds completed:** 1 round with `qa-investigator-gpt-54` (GPT-5.4)  
  - Round 1: 0 findings — evidence commit `8d580c6`
- **Copilot PR review rounds completed:** 1 round  
  - Round 1: Copilot review state `COMMENTED`, 0 unresolved Copilot-authored threads, 0 actionable findings requiring changes
- **CI/CD:** all required checks green (14/14 successful)
- **Post-review main sync:** not needed (`origin/main` remained 0 commits ahead)
- **Findings fixed vs false positives:**  
  - Primary QA: 0 fixed, 0 false positives  
  - Cross-model QA: 0 fixed, 0 false positives  
  - Copilot review: 0 fixed, 0 false positives  
  - Pre-existing unrelated observation during validation: one reproduction of issue #414 documented on #414; not part of this PR’s scope and not counted as a finding against this branch
