### PR TITLE
fix(skills): unify global skills path resolution around CLAUDE_DIR cascade

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -33,7 +33,7 @@ Project files:
 ```
 Skills:
 ```
-!`for _d in "${CLAUDE_CONFIG_DIR:-}" "$HOME/.config/claude-code" "$HOME/.claude"; do [ -z "$_d" ] && continue; [ -d "$_d/skills/" ] && ls "$_d/skills/" 2>/dev/null && break; done || echo "No global skills"`
+!`if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then _cd="$CLAUDE_CONFIG_DIR"; elif [ -d "$HOME/.config/claude-code" ]; then _cd="$HOME/.config/claude-code"; else _cd="$HOME/.claude"; fi; ls "$_cd/skills/" 2>/dev/null || echo "No global skills"`
 ```
 ```
 !`ls .claude/skills/ 2>/dev/null || echo "No project skills"`

--- a/commands/skills.md
+++ b/commands/skills.md
@@ -87,7 +87,7 @@ If the user typed `skip`, STOP here after displaying `○ No skills selected for
 
 AskUserQuestion (single select) — "Where should these skills be installed?":
 - **Project (Recommended)** — "Installed to `./.claude/skills/`, scoped to this project only."
-- **Global** — "Installed to `~/.claude/skills/`, available in all projects."
+- **Global** — "Installed to `<global_skills_dir>/`, available in all projects." (Use the `global_skills_dir` value from the Stack detection Context JSON as the display path.)
 
 Store the choice as SCOPE. If the user typed `skip` in Step 5: skip this step.
 

--- a/scripts/detect-stack.sh
+++ b/scripts/detect-stack.sh
@@ -204,6 +204,7 @@ jq -n \
   --arg recommended "$RECOMMENDED_SKILLS" \
   --arg suggestions "$SUGGESTIONS" \
   --argjson find_skills "$FIND_SKILLS" \
+  --arg global_skills_dir "$CLAUDE_DIR/skills" \
   '{
     detected_stack: ($detected | split(",") | map(select(. != ""))),
     installed: {
@@ -213,5 +214,6 @@ jq -n \
     },
     recommended_skills: ($recommended | split(",") | map(select(. != ""))),
     suggestions: ($suggestions | split(",") | map(select(. != ""))),
-    find_skills_available: $find_skills
+    find_skills_available: $find_skills,
+    global_skills_dir: $global_skills_dir
   }'

--- a/tests/resolve-claude-dir.bats
+++ b/tests/resolve-claude-dir.bats
@@ -111,6 +111,11 @@ teardown() {
   # Should find test-skill in custom dir
   echo "$output" | jq -e '.installed.global' >/dev/null
   [[ "$output" == *"test-skill"* ]]
+
+  # global_skills_dir should reflect the custom CLAUDE_CONFIG_DIR
+  local gsd
+  gsd=$(echo "$output" | jq -r '.global_skills_dir')
+  [[ "$gsd" == "$CLAUDE_CONFIG_DIR/skills" ]]
 }
 
 @test "detect-stack.sh uses default HOME/.claude when CLAUDE_CONFIG_DIR unset" {
@@ -123,6 +128,11 @@ teardown() {
 
   echo "$output" | jq -e '.installed.global' >/dev/null
   [[ "$output" == *"default-skill"* ]]
+
+  # global_skills_dir should reflect the default HOME/.claude
+  local gsd
+  gsd=$(echo "$output" | jq -r '.global_skills_dir')
+  [[ "$gsd" == "$HOME/.claude/skills" ]]
 }
 
 # --- hook-wrapper.sh tests ---


### PR DESCRIPTION
Fixes #435

## What

Unified global skills path resolution across three files that previously used inconsistent approaches. `detect-stack.sh` now emits a `global_skills_dir` field from the resolved `CLAUDE_DIR`. `skills.md` Step 5b references this field dynamically. `init.md` inline cascade now matches `resolve-claude-dir.sh` semantics.

## Why

Three independent resolution approaches existed for the same concept (global skills path):
1. `detect-stack.sh` — sourced `resolve-claude-dir.sh` correctly but didn't expose the resolved path in its JSON output
2. `skills.md` Step 5b — hardcoded `~/.claude/skills/`, which is wrong when `CLAUDE_CONFIG_DIR` or `$HOME/.config/claude-code` exists
3. `init.md` — used a for-loop that iterated all candidates and picked the first with a `skills/` subdir, which has different semantics than the canonical cascade (the canonical cascade picks the config dir based on the dir's existence, not the skills subdir's existence)

The root cause is that `resolve-claude-dir.sh` defines a canonical cascade but its result wasn't available to LLM-consumed markdown. Adding `global_skills_dir` to the `detect-stack.sh` JSON output makes the resolved path available to `skills.md` via its existing template expansion.

## How

- **scripts/detect-stack.sh**: Added `--arg global_skills_dir "$CLAUDE_DIR/skills"` and `global_skills_dir: $global_skills_dir` to the jq JSON output. `CLAUDE_DIR` is already resolved by the sourced `resolve-claude-dir.sh`.
- **commands/skills.md**: Step 5b now says "Use the `global_skills_dir` value from the Stack detection Context JSON as the display path" instead of hardcoding `~/.claude/skills/`.
- **commands/init.md**: Replaced the ad-hoc `for _d in ... do ... && break; done` loop with an inline `if/elif/else` cascade that matches `resolve-claude-dir.sh` exactly: `CLAUDE_CONFIG_DIR` → `$HOME/.config/claude-code` → `$HOME/.claude`.
- **tests/resolve-claude-dir.bats**: Added `global_skills_dir` assertions to both existing detect-stack.sh tests to prevent silent regression.

## Acceptance criteria verification

1. **Step 5b display text dynamically reflects resolved CLAUDE_DIR path**: Satisfied — `commands/skills.md` Step 5b references `global_skills_dir` from Context JSON, which comes from `detect-stack.sh` via `resolve-claude-dir.sh`.
2. **`commands/init.md` and `commands/skills.md` agree on global skills path(s)**: Satisfied — both now resolve through the same `CLAUDE_CONFIG_DIR` → `.config/claude-code` → `.claude` cascade.
3. **All existing tests pass**: Satisfied — 2853 BATS, 39/39 contracts, 1/1 lint.

## Testing

- [x] Load plugin locally with `claude --plugin-dir .`
- [x] `bash testing/run-all.sh` passes (2853 BATS, 39/39 contracts, 1/1 lint)
- [x] `bash scripts/detect-stack.sh .` outputs valid JSON with `global_skills_dir` field
- [x] Two new assertions in `tests/resolve-claude-dir.bats` validate `global_skills_dir` for both `CLAUDE_CONFIG_DIR` and default `HOME/.claude` cases
- [x] No load errors
- [x] Existing commands still work

## QA summary

| Phase | Rounds | Model | Findings | Fixed | False Positives |
|-------|--------|-------|----------|-------|-----------------|
| Primary QA | 3 | Claude | 1 low (missing test) | 1 | 0 |
| Cross-model QA | 1 | GPT-5.4 | 2 observations | 0 (filed #444, #414 exists) | 0 |
| Copilot review | TBD | — | — | — | — |