### PR TITLE
feat(fix): add fix-commit marker and context for inline QA/UAT (#150)

### DIFF
--- a/commands/fix.md
+++ b/commands/fix.md
@@ -91,6 +91,7 @@ Config: Pre-injected by SessionStart hook.
       Files: {changed files}
     ```
 
+    Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-fix-marker.sh .vbw-planning 2>/dev/null || true` silently — this persists fix context for inline QA/UAT.
     Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/suggest-next.sh fix` and display.
 
     Committed, with discovered issues (Dev reported pre-existing failures):
@@ -114,6 +115,7 @@ Config: Pre-injected by SessionStart hook.
     invoke /vbw:todo, and do NOT enter an interactive loop. The user decides
     whether to track these. If no discovered issues: omit the section entirely.
     After displaying discovered issues, STOP. Do not take further action.
+    Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-fix-marker.sh .vbw-planning 2>/dev/null || true` silently — this persists fix context for inline QA/UAT.
     Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/suggest-next.sh fix` and display.
 
     Dev stopped:

--- a/commands/fix.md
+++ b/commands/fix.md
@@ -114,7 +114,7 @@ Config: Pre-injected by SessionStart hook.
     This is **display-only**. Do NOT edit STATE.md, do NOT add todos, do NOT
     invoke /vbw:todo, and do NOT enter an interactive loop. The user decides
     whether to track these. If no discovered issues: omit the section entirely.
-    After displaying discovered issues, STOP. Do not take further action.
+    After displaying discovered issues, **STOP. Do not take further action** on discovered issues (no auto-fix, no auto-track, no investigation)—just display them.
     Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/write-fix-marker.sh .vbw-planning 2>/dev/null || true` silently — this persists fix context for inline QA/UAT.
     Run `bash `!`echo /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`/scripts/suggest-next.sh fix` and display.
 

--- a/scripts/compile-fix-commit-context.sh
+++ b/scripts/compile-fix-commit-context.sh
@@ -41,7 +41,7 @@ if [ "$marker_mtime" -le 0 ] || [ "$now" -le 0 ]; then
 fi
 
 age=$(( now - marker_mtime ))
-if [ "$age" -gt 86400 ]; then
+if [ "$age" -lt 0 ] || [ "$age" -gt 86400 ]; then
   echo "fix_context=empty"
   exit 0
 fi

--- a/scripts/compile-fix-commit-context.sh
+++ b/scripts/compile-fix-commit-context.sh
@@ -31,21 +31,19 @@ if [ ! -f "$marker_file" ]; then
   exit 0
 fi
 
-# Check staleness (24 hours = 86400 seconds)
-if command -v stat &>/dev/null; then
-  if [[ "$OSTYPE" == darwin* ]]; then
-    marker_mtime=$(stat -f '%m' "$marker_file" 2>/dev/null) || marker_mtime=0
-  else
-    marker_mtime=$(stat -c '%Y' "$marker_file" 2>/dev/null) || marker_mtime=0
-  fi
-  now=$(date +%s 2>/dev/null) || now=0
-  if [ "$marker_mtime" -gt 0 ] && [ "$now" -gt 0 ]; then
-    age=$(( now - marker_mtime ))
-    if [ "$age" -gt 86400 ]; then
-      echo "fix_context=empty"
-      exit 0
-    fi
-  fi
+# Check staleness (24 hours = 86400 seconds); fail-closed on stat/date errors
+marker_mtime=$(stat -c '%Y' "$marker_file" 2>/dev/null || stat -f '%m' "$marker_file" 2>/dev/null || echo 0)
+now=$(date +%s 2>/dev/null || echo 0)
+
+if [ "$marker_mtime" -le 0 ] || [ "$now" -le 0 ]; then
+  echo "fix_context=empty"
+  exit 0
+fi
+
+age=$(( now - marker_mtime ))
+if [ "$age" -gt 86400 ]; then
+  echo "fix_context=empty"
+  exit 0
 fi
 
 # Read marker fields

--- a/scripts/compile-fix-commit-context.sh
+++ b/scripts/compile-fix-commit-context.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# compile-fix-commit-context.sh — Produce compact QA/UAT context from fix marker.
+#
+# Reads .last-fix-commit marker and outputs structured context for
+# QA agent consumption or UAT checkpoint generation.
+#
+# Usage:
+#   compile-fix-commit-context.sh [planning-dir] [mode]
+#
+# Arguments:
+#   planning-dir  — path to .vbw-planning (default: .vbw-planning)
+#   mode          — qa or uat (default: qa)
+#
+# Output (stdout):
+#   First line: fix_context=available or fix_context=empty
+#   If available, followed by --- separator and markdown context block.
+#
+# Exit codes:
+#   0 — always (non-blocking helper)
+
+set -u
+
+PLANNING_DIR="${1:-.vbw-planning}"
+MODE="${2:-qa}"
+
+marker_file="$PLANNING_DIR/.last-fix-commit"
+
+# Check marker exists
+if [ ! -f "$marker_file" ]; then
+  echo "fix_context=empty"
+  exit 0
+fi
+
+# Check staleness (24 hours = 86400 seconds)
+if command -v stat &>/dev/null; then
+  if [[ "$OSTYPE" == darwin* ]]; then
+    marker_mtime=$(stat -f '%m' "$marker_file" 2>/dev/null) || marker_mtime=0
+  else
+    marker_mtime=$(stat -c '%Y' "$marker_file" 2>/dev/null) || marker_mtime=0
+  fi
+  now=$(date +%s 2>/dev/null) || now=0
+  if [ "$marker_mtime" -gt 0 ] && [ "$now" -gt 0 ]; then
+    age=$(( now - marker_mtime ))
+    if [ "$age" -gt 86400 ]; then
+      echo "fix_context=empty"
+      exit 0
+    fi
+  fi
+fi
+
+# Read marker fields
+commit=""
+message=""
+timestamp=""
+description=""
+files=""
+reading_files=false
+
+while IFS= read -r line; do
+  if [ "$reading_files" = true ]; then
+    files="${files}${files:+
+}${line}"
+    continue
+  fi
+  case "$line" in
+    commit=*)     commit="${line#commit=}" ;;
+    message=*)    message="${line#message=}" ;;
+    timestamp=*)  timestamp="${line#timestamp=}" ;;
+    description=*) description="${line#description=}" ;;
+    files=*)
+      files="${line#files=}"
+      reading_files=true
+      ;;
+  esac
+done < "$marker_file"
+
+# Validate minimum required fields
+if [ -z "$commit" ]; then
+  echo "fix_context=empty"
+  exit 0
+fi
+
+# Get change summary from git if available
+change_summary=""
+if command -v git &>/dev/null; then
+  change_summary=$(git show --stat --format='' "$commit" 2>/dev/null | tail -5) || true
+fi
+
+# Format mode title
+if [ "$MODE" = "uat" ]; then
+  title="Fix Commit UAT Context"
+else
+  title="Fix Commit QA Context"
+fi
+
+# Build file list
+file_list=""
+if [ -n "$files" ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] && file_list="${file_list}
+- ${f}"
+  done <<< "$files"
+fi
+
+# Output context
+echo "fix_context=available"
+echo "---"
+echo "## ${title}"
+echo ""
+echo "**Commit:** ${commit} — ${message}"
+if [ -n "$description" ] && [ "$description" != "$message" ]; then
+  echo "**Description:** ${description}"
+fi
+if [ -n "$timestamp" ]; then
+  echo "**Timestamp:** ${timestamp}"
+fi
+if [ -n "$file_list" ]; then
+  echo ""
+  echo "**Files changed:**${file_list}"
+fi
+if [ -n "$change_summary" ]; then
+  echo ""
+  echo "**Change summary:**"
+  echo '```'
+  echo "$change_summary"
+  echo '```'
+fi
+
+exit 0

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -760,6 +760,9 @@ case "$CMD" in
     fi
     if [ "$_fix_debug_handled" = false ]; then
       suggest "/vbw:vibe -- Verify the fix"
+      if [ "$cfg_auto_uat" = true ] && [ -f "$PLANNING_DIR/.last-fix-commit" ]; then
+        suggest "/vbw:verify -- Run UAT on the fix"
+      fi
       suggest "/vbw:vibe -- Continue building"
     fi
     ;;

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -761,17 +761,13 @@ case "$CMD" in
     if [ "$_fix_debug_handled" = false ]; then
       suggest "/vbw:vibe -- Verify the fix"
       if [ "$cfg_auto_uat" = true ] && [ -f "$PLANNING_DIR/.last-fix-commit" ]; then
-        # Only suggest UAT if marker is fresh (<24h)
-        _marker_stale=false
-        if [[ "$OSTYPE" == darwin* ]]; then
-          _marker_mtime=$(stat -f '%m' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null) || _marker_mtime=0
-        else
-          _marker_mtime=$(stat -c '%Y' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null) || _marker_mtime=0
-        fi
-        _now=$(date +%s 2>/dev/null) || _now=0
+        # Only suggest UAT if marker is fresh (<24h); fail-closed on stat/date errors
+        _marker_stale=true
+        _marker_mtime=$(stat -c '%Y' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null || stat -f '%m' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null || echo 0)
+        _now=$(date +%s 2>/dev/null || echo 0)
         if [ "$_marker_mtime" -gt 0 ] && [ "$_now" -gt 0 ]; then
           _marker_age=$(( _now - _marker_mtime ))
-          [ "$_marker_age" -gt 86400 ] && _marker_stale=true
+          [ "$_marker_age" -le 86400 ] && _marker_stale=false
         fi
         if [ "$_marker_stale" = false ]; then
           suggest "/vbw:verify -- Run UAT on the fix"

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -761,7 +761,21 @@ case "$CMD" in
     if [ "$_fix_debug_handled" = false ]; then
       suggest "/vbw:vibe -- Verify the fix"
       if [ "$cfg_auto_uat" = true ] && [ -f "$PLANNING_DIR/.last-fix-commit" ]; then
-        suggest "/vbw:verify -- Run UAT on the fix"
+        # Only suggest UAT if marker is fresh (<24h)
+        _marker_stale=false
+        if [[ "$OSTYPE" == darwin* ]]; then
+          _marker_mtime=$(stat -f '%m' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null) || _marker_mtime=0
+        else
+          _marker_mtime=$(stat -c '%Y' "$PLANNING_DIR/.last-fix-commit" 2>/dev/null) || _marker_mtime=0
+        fi
+        _now=$(date +%s 2>/dev/null) || _now=0
+        if [ "$_marker_mtime" -gt 0 ] && [ "$_now" -gt 0 ]; then
+          _marker_age=$(( _now - _marker_mtime ))
+          [ "$_marker_age" -gt 86400 ] && _marker_stale=true
+        fi
+        if [ "$_marker_stale" = false ]; then
+          suggest "/vbw:verify -- Run UAT on the fix"
+        fi
       fi
       suggest "/vbw:vibe -- Continue building"
     fi

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -767,7 +767,7 @@ case "$CMD" in
         _now=$(date +%s 2>/dev/null || echo 0)
         if [ "$_marker_mtime" -gt 0 ] && [ "$_now" -gt 0 ]; then
           _marker_age=$(( _now - _marker_mtime ))
-          [ "$_marker_age" -le 86400 ] && _marker_stale=false
+          [ "$_marker_age" -ge 0 ] && [ "$_marker_age" -le 86400 ] && _marker_stale=false
         fi
         if [ "$_marker_stale" = false ]; then
           suggest "/vbw:verify -- Run UAT on the fix"

--- a/scripts/write-fix-marker.sh
+++ b/scripts/write-fix-marker.sh
@@ -43,6 +43,9 @@ if [ -z "$DESCRIPTION" ]; then
   DESCRIPTION="$commit_message"
 fi
 
+# Sanitize description to single line (newlines/CRs would corrupt key=value format)
+DESCRIPTION=$(printf '%s' "$DESCRIPTION" | tr '\n\r' '  ')
+
 # Write marker file (overwrite any existing marker)
 marker_file="$PLANNING_DIR/.last-fix-commit"
 {

--- a/scripts/write-fix-marker.sh
+++ b/scripts/write-fix-marker.sh
@@ -5,6 +5,9 @@
 # suggest-next.sh and verify.md can detect recent fix work and offer
 # UAT without requiring PLAN/SUMMARY artifacts.
 #
+# Marker format: key=value lines. The "files" field is a multi-line
+# continuation — each changed file appears on its own line after files=.
+#
 # Usage:
 #   write-fix-marker.sh [planning-dir] [description]
 #
@@ -29,8 +32,8 @@ if ! command -v git &>/dev/null; then
   exit 0
 fi
 
-# Read HEAD commit info
-commit_hash=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
+# Read HEAD commit info (full hash for unambiguous downstream lookups)
+commit_hash=$(git rev-parse HEAD 2>/dev/null) || exit 0
 commit_message=$(git log --format='%s' -1 2>/dev/null) || exit 0
 commit_timestamp=$(git log --format='%aI' -1 2>/dev/null) || exit 0
 changed_files=$(git diff-tree --root --no-commit-id --name-only -r HEAD 2>/dev/null) || exit 0

--- a/scripts/write-fix-marker.sh
+++ b/scripts/write-fix-marker.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# write-fix-marker.sh — Persist the latest fix commit for inline QA/UAT.
+#
+# Writes .last-fix-commit marker to the planning directory so that
+# suggest-next.sh and verify.md can detect recent fix work and offer
+# UAT without requiring PLAN/SUMMARY artifacts.
+#
+# Usage:
+#   write-fix-marker.sh [planning-dir] [description]
+#
+# Arguments:
+#   planning-dir  — path to .vbw-planning (default: .vbw-planning)
+#   description   — optional human description of the fix
+#
+# Always exits 0 — this is a non-blocking helper.
+
+set -u
+
+PLANNING_DIR="${1:-.vbw-planning}"
+DESCRIPTION="${2:-}"
+
+# Validate planning dir exists
+if [ ! -d "$PLANNING_DIR" ]; then
+  exit 0
+fi
+
+# Require git
+if ! command -v git &>/dev/null; then
+  exit 0
+fi
+
+# Read HEAD commit info
+commit_hash=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
+commit_message=$(git log --format='%s' -1 2>/dev/null) || exit 0
+commit_timestamp=$(git log --format='%aI' -1 2>/dev/null) || exit 0
+changed_files=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null) || exit 0
+
+# Fall back to commit message if no description provided
+if [ -z "$DESCRIPTION" ]; then
+  DESCRIPTION="$commit_message"
+fi
+
+# Write marker file (overwrite any existing marker)
+marker_file="$PLANNING_DIR/.last-fix-commit"
+{
+  printf 'commit=%s\n' "$commit_hash"
+  printf 'message=%s\n' "$commit_message"
+  printf 'timestamp=%s\n' "$commit_timestamp"
+  printf 'description=%s\n' "$DESCRIPTION"
+  printf 'files=%s\n' "$changed_files"
+} > "$marker_file" 2>/dev/null || true
+
+exit 0

--- a/scripts/write-fix-marker.sh
+++ b/scripts/write-fix-marker.sh
@@ -33,7 +33,7 @@ fi
 commit_hash=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
 commit_message=$(git log --format='%s' -1 2>/dev/null) || exit 0
 commit_timestamp=$(git log --format='%aI' -1 2>/dev/null) || exit 0
-changed_files=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null) || exit 0
+changed_files=$(git diff-tree --root --no-commit-id --name-only -r HEAD 2>/dev/null) || exit 0
 
 # Fall back to commit message if no description provided
 if [ -z "$DESCRIPTION" ]; then

--- a/tests/compile-fix-commit-context.bats
+++ b/tests/compile-fix-commit-context.bats
@@ -107,6 +107,24 @@ create_marker() {
   [[ "${lines[0]}" == "fix_context=empty" ]]
 }
 
+@test "outputs fix_context=empty when marker has future timestamp" {
+  echo "fix" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix: future"
+  create_marker
+
+  # Set marker timestamp 2 hours in the future (clock skew scenario)
+  if [[ "$OSTYPE" == darwin* ]]; then
+    touch -t "$(date -v+2H '+%Y%m%d%H%M.%S')" "$PLANNING_DIR/.last-fix-commit"
+  else
+    touch -d "2 hours" "$PLANNING_DIR/.last-fix-commit"
+  fi
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=empty" ]]
+}
+
 # ── integration: write then compile ──────────────────────
 
 @test "write-then-compile round trip produces valid context" {

--- a/tests/compile-fix-commit-context.bats
+++ b/tests/compile-fix-commit-context.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  export PLANNING_DIR="$TEST_TEMP_DIR/.vbw-planning"
+  mkdir -p "$PLANNING_DIR"
+
+  # Initialize a git repo so compile script can run git show
+  cd "$TEST_TEMP_DIR"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  echo "initial" > file.txt
+  git add file.txt
+  git commit -q -m "initial commit"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+# Helper: create a marker file from the current HEAD
+create_marker() {
+  bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR" "${1:-}"
+}
+
+# ── basic context output ─────────────────────────────────
+
+@test "outputs fix_context=available with valid marker" {
+  echo "fix" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix(ui): button crash"
+  create_marker
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=available" ]]
+  [[ "$output" == *"---"* ]]
+  [[ "$output" == *"## Fix Commit QA Context"* ]]
+  [[ "$output" == *"fix(ui): button crash"* ]]
+  [[ "$output" == *"fix.sh"* ]]
+}
+
+@test "uat mode uses UAT title" {
+  echo "fix" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix: thing"
+  create_marker
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR" "uat"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Fix Commit UAT Context"* ]]
+}
+
+@test "shows custom description when different from commit message" {
+  echo "fix" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix: thing"
+  create_marker "Fixed the login crash"
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Fixed the login crash"* ]]
+}
+
+# ── empty context cases ──────────────────────────────────
+
+@test "outputs fix_context=empty when no marker exists" {
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=empty" ]]
+  # Should be only one line
+  [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "outputs fix_context=empty when planning dir missing" {
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "/nonexistent/dir"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=empty" ]]
+}
+
+@test "outputs fix_context=empty for stale marker (>24h)" {
+  echo "fix" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix: old"
+  create_marker
+
+  # Backdate the marker by 25 hours
+  if [[ "$OSTYPE" == darwin* ]]; then
+    touch -t "$(date -v-25H '+%Y%m%d%H%M.%S')" "$PLANNING_DIR/.last-fix-commit"
+  else
+    touch -d "25 hours ago" "$PLANNING_DIR/.last-fix-commit"
+  fi
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=empty" ]]
+}
+
+@test "outputs fix_context=empty when marker has no commit field" {
+  echo "message=something" > "$PLANNING_DIR/.last-fix-commit"
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=empty" ]]
+}
+
+# ── integration: write then compile ──────────────────────
+
+@test "write-then-compile round trip produces valid context" {
+  echo "fix" > button.sh
+  git add button.sh
+  git commit -q -m "fix(button): handle null ref"
+  create_marker "Fixed null reference in button handler"
+
+  run bash "$SCRIPTS_DIR/compile-fix-commit-context.sh" "$PLANNING_DIR" "qa"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "fix_context=available" ]]
+  [[ "$output" == *"handle null ref"* ]]
+  [[ "$output" == *"Fixed null reference in button handler"* ]]
+  [[ "$output" == *"button.sh"* ]]
+}

--- a/tests/suggest-next-fix-uat.bats
+++ b/tests/suggest-next-fix-uat.bats
@@ -64,3 +64,20 @@ enable_auto_uat() {
   [[ "$output" == *"Verify the fix"* ]]
   [[ "$output" == *"Continue building"* ]]
 }
+
+@test "fix does not suggest UAT when marker is stale (>24h)" {
+  enable_auto_uat
+  create_fix_marker
+  # Backdate marker by 25 hours
+  if [[ "$OSTYPE" == darwin* ]]; then
+    touch -t "$(date -v-25H '+%Y%m%d%H%M.%S')" "$TEST_TEMP_DIR/.vbw-planning/.last-fix-commit"
+  else
+    touch -d "25 hours ago" "$TEST_TEMP_DIR/.vbw-planning/.last-fix-commit"
+  fi
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Run UAT on the fix"* ]]
+  # Should still have other suggestions
+  [[ "$output" == *"Verify the fix"* ]]
+  [[ "$output" == *"Continue building"* ]]
+}

--- a/tests/suggest-next-fix-uat.bats
+++ b/tests/suggest-next-fix-uat.bats
@@ -81,3 +81,20 @@ enable_auto_uat() {
   [[ "$output" == *"Verify the fix"* ]]
   [[ "$output" == *"Continue building"* ]]
 }
+
+@test "fix does not suggest UAT when marker has future timestamp" {
+  enable_auto_uat
+  create_fix_marker
+  # Set marker timestamp 2 hours in the future (clock skew scenario)
+  if [[ "$OSTYPE" == darwin* ]]; then
+    touch -t "$(date -v+2H '+%Y%m%d%H%M.%S')" "$TEST_TEMP_DIR/.vbw-planning/.last-fix-commit"
+  else
+    touch -d "2 hours" "$TEST_TEMP_DIR/.vbw-planning/.last-fix-commit"
+  fi
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Run UAT on the fix"* ]]
+  # Should still have other suggestions
+  [[ "$output" == *"Verify the fix"* ]]
+  [[ "$output" == *"Continue building"* ]]
+}

--- a/tests/suggest-next-fix-uat.bats
+++ b/tests/suggest-next-fix-uat.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  create_test_config
+  echo '# Project' > "$TEST_TEMP_DIR/.vbw-planning/PROJECT.md"
+  cd "$TEST_TEMP_DIR"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+# Helper: create a .last-fix-commit marker
+create_fix_marker() {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/.last-fix-commit" <<'EOF'
+commit=abc1234
+message=fix(button): handle null ref
+timestamp=2025-01-01T12:00:00+00:00
+description=Fixed the button crash
+files=src/button.sh
+EOF
+}
+
+# Helper: enable auto_uat in config
+enable_auto_uat() {
+  local cfg="$TEST_TEMP_DIR/.vbw-planning/config.json"
+  local tmp
+  tmp=$(mktemp)
+  jq '.auto_uat = true' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+}
+
+# ── fix branch: non-debug suggestions ────────────────────
+
+@test "fix suggests verify-the-fix and continue-building by default" {
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Verify the fix"* ]]
+  [[ "$output" == *"Continue building"* ]]
+}
+
+@test "fix does not suggest UAT when auto_uat is false" {
+  create_fix_marker
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Run UAT on the fix"* ]]
+}
+
+@test "fix does not suggest UAT when auto_uat is true but no marker" {
+  enable_auto_uat
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Run UAT on the fix"* ]]
+}
+
+@test "fix suggests UAT when auto_uat is true and marker exists" {
+  enable_auto_uat
+  create_fix_marker
+  run bash "$SCRIPTS_DIR/suggest-next.sh" fix pass
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Run UAT on the fix"* ]]
+  [[ "$output" == *"Verify the fix"* ]]
+  [[ "$output" == *"Continue building"* ]]
+}

--- a/tests/write-fix-marker.bats
+++ b/tests/write-fix-marker.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  export PLANNING_DIR="$TEST_TEMP_DIR/.vbw-planning"
+  mkdir -p "$PLANNING_DIR"
+
+  # Initialize a git repo so write-fix-marker.sh can read commit info
+  cd "$TEST_TEMP_DIR"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  echo "initial" > file.txt
+  git add file.txt
+  git commit -q -m "initial commit"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+# ── basic marker creation ────────────────────────────────
+
+@test "writes marker file with correct fields" {
+  echo "fix content" > fix.sh
+  git add fix.sh
+  git commit -q -m "fix(button): handle null ref"
+
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+
+  [ -f "$PLANNING_DIR/.last-fix-commit" ]
+  grep -q "^commit=" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "^message=fix(button): handle null ref" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "^timestamp=" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "^description=fix(button): handle null ref" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "^files=fix.sh" "$PLANNING_DIR/.last-fix-commit"
+}
+
+@test "uses custom description when provided" {
+  echo "fix" > fix2.sh
+  git add fix2.sh
+  git commit -q -m "fix: quick patch"
+
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR" "Fixed the login crash"
+  [ "$status" -eq 0 ]
+
+  grep -q "^description=Fixed the login crash" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "^message=fix: quick patch" "$PLANNING_DIR/.last-fix-commit"
+}
+
+@test "overwrites existing marker" {
+  echo "first" > a.txt
+  git add a.txt
+  git commit -q -m "first fix"
+  bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR"
+
+  echo "second" > b.txt
+  git add b.txt
+  git commit -q -m "second fix"
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+
+  grep -q "^message=second fix" "$PLANNING_DIR/.last-fix-commit"
+  # first fix message should be gone
+  ! grep -q "^message=first fix" "$PLANNING_DIR/.last-fix-commit"
+}
+
+# ── graceful degradation ─────────────────────────────────
+
+@test "exits 0 when planning dir does not exist" {
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "/nonexistent/path"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits 0 with default planning dir when called with no args" {
+  # No .vbw-planning in cwd, so it exits gracefully
+  cd /tmp
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "records multiple changed files" {
+  echo "a" > alpha.txt
+  echo "b" > beta.txt
+  git add alpha.txt beta.txt
+  git commit -q -m "multi-file fix"
+
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+
+  grep -q "alpha.txt" "$PLANNING_DIR/.last-fix-commit"
+  grep -q "beta.txt" "$PLANNING_DIR/.last-fix-commit"
+}

--- a/tests/write-fix-marker.bats
+++ b/tests/write-fix-marker.bats
@@ -113,3 +113,31 @@ teardown() {
   [ "$status" -eq 0 ]
   grep -q "first.txt" "$planning/.last-fix-commit"
 }
+
+# ── fix.md integration contract ──────────────────────────
+
+@test "fix.md calls write-fix-marker.sh before suggest-next.sh in both success paths" {
+  local fix_md="$PROJECT_ROOT/commands/fix.md"
+  # Both success paths must call write-fix-marker.sh before suggest-next.sh
+  # Extract line numbers for each call pattern
+  local marker_lines suggest_lines
+  marker_lines=$(grep -n 'write-fix-marker\.sh' "$fix_md" | cut -d: -f1)
+  suggest_lines=$(grep -n 'suggest-next\.sh' "$fix_md" | cut -d: -f1)
+
+  # Must have at least 2 marker calls (one per success path)
+  local marker_count
+  marker_count=$(echo "$marker_lines" | wc -l | tr -d ' ')
+  [ "$marker_count" -ge 2 ]
+
+  # Each marker call must precede a suggest-next call
+  for m_line in $marker_lines; do
+    local found_after=false
+    for s_line in $suggest_lines; do
+      if [ "$s_line" -gt "$m_line" ]; then
+        found_after=true
+        break
+      fi
+    done
+    [ "$found_after" = true ]
+  done
+}

--- a/tests/write-fix-marker.bats
+++ b/tests/write-fix-marker.bats
@@ -77,7 +77,9 @@ teardown() {
 
 @test "exits 0 with default planning dir when called with no args" {
   # No .vbw-planning in cwd, so it exits gracefully
-  cd /tmp
+  local empty_cwd="$TEST_TEMP_DIR/no-default-planning"
+  mkdir -p "$empty_cwd"
+  cd "$empty_cwd"
   run bash "$SCRIPTS_DIR/write-fix-marker.sh"
   [ "$status" -eq 0 ]
 }

--- a/tests/write-fix-marker.bats
+++ b/tests/write-fix-marker.bats
@@ -94,3 +94,22 @@ teardown() {
   grep -q "alpha.txt" "$PLANNING_DIR/.last-fix-commit"
   grep -q "beta.txt" "$PLANNING_DIR/.last-fix-commit"
 }
+
+@test "records files for root commit" {
+  # Create a fresh repo with only one commit (root commit)
+  local root_dir="$TEST_TEMP_DIR/root-repo"
+  mkdir -p "$root_dir"
+  cd "$root_dir"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  local planning="$root_dir/.vbw-planning"
+  mkdir -p "$planning"
+  echo "first" > first.txt
+  git add first.txt
+  git commit -q -m "initial fix"
+
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$planning"
+  [ "$status" -eq 0 ]
+  grep -q "first.txt" "$planning/.last-fix-commit"
+}

--- a/tests/write-fix-marker.bats
+++ b/tests/write-fix-marker.bats
@@ -116,6 +116,23 @@ teardown() {
   grep -q "first.txt" "$planning/.last-fix-commit"
 }
 
+@test "sanitizes newlines in description to single line" {
+  local desc_with_newlines=$'line one\nline two\nline three'
+  run bash "$SCRIPTS_DIR/write-fix-marker.sh" "$PLANNING_DIR" "$desc_with_newlines"
+  [ "$status" -eq 0 ]
+  # Description must be a single line (no embedded newlines)
+  local desc_line
+  desc_line=$(grep '^description=' "$PLANNING_DIR/.last-fix-commit")
+  # Count lines — should be exactly 1
+  local line_count
+  line_count=$(echo "$desc_line" | wc -l | tr -d ' ')
+  [ "$line_count" -eq 1 ]
+  # All three parts should be present (joined with spaces)
+  [[ "$desc_line" == *"line one"* ]]
+  [[ "$desc_line" == *"line two"* ]]
+  [[ "$desc_line" == *"line three"* ]]
+}
+
 # ── fix.md integration contract ──────────────────────────
 
 @test "fix.md calls write-fix-marker.sh before suggest-next.sh in both success paths" {
@@ -131,15 +148,31 @@ teardown() {
   marker_count=$(echo "$marker_lines" | wc -l | tr -d ' ')
   [ "$marker_count" -ge 2 ]
 
-  # Each marker call must precede a suggest-next call
+  # Each marker call must be followed by a suggest-next call before the next
+  # marker call, so we verify ordering within the same success block rather
+  # than allowing any later suggest-next anywhere in the file to satisfy it.
+  local marker_array=()
+  local m_line
   for m_line in $marker_lines; do
-    local found_after=false
+    marker_array+=("$m_line")
+  done
+
+  local i next_marker s_line found_in_block
+  for i in "${!marker_array[@]}"; do
+    m_line="${marker_array[$i]}"
+    next_marker=""
+    if [ $((i + 1)) -lt "${#marker_array[@]}" ]; then
+      next_marker="${marker_array[$((i + 1))]}"
+    fi
+
+    found_in_block=false
     for s_line in $suggest_lines; do
-      if [ "$s_line" -gt "$m_line" ]; then
-        found_after=true
+      if [ "$s_line" -gt "$m_line" ] && { [ -z "$next_marker" ] || [ "$s_line" -lt "$next_marker" ]; }; then
+        found_in_block=true
         break
       fi
     done
-    [ "$found_after" = true ]
+
+    [ "$found_in_block" = true ]
   done
 }


### PR DESCRIPTION
Fixes #150

## What

Adds fix-commit marker infrastructure and context compilation scripts that bridge `/fix` success to downstream QA/UAT. After a successful fix commit, a marker file is written to `.vbw-planning/.last-fix-commit` containing commit metadata. `suggest-next.sh` conditionally offers a `/vbw:verify` UAT suggestion when `auto_uat=true` and a fresh marker exists.

**Files modified:**
- `scripts/write-fix-marker.sh` (NEW) — writes `.vbw-planning/.last-fix-commit` with commit hash, message, timestamp, description, and changed files
- `scripts/compile-fix-commit-context.sh` (NEW) — reads the marker and produces compact QA/UAT context (`fix_context=available` or `fix_context=empty`)
- `commands/fix.md` (MODIFIED) — calls `write-fix-marker.sh` in both success paths (no-issues and with-discovered-issues) before `suggest-next.sh`
- `scripts/suggest-next.sh` (MODIFIED) — fix branch now conditionally suggests `/vbw:verify -- Run UAT on the fix` when `auto_uat=true`, marker exists, and marker is fresh (<24h)
- `tests/write-fix-marker.bats` (NEW) — 8 BATS tests covering marker creation, root commits, graceful degradation, and fix.md ordering contract
- `tests/compile-fix-commit-context.bats` (NEW) — 7 BATS tests covering available/empty output, UAT mode, staleness, round-trip
- `tests/suggest-next-fix-uat.bats` (NEW) — 6 BATS tests covering UAT suggestion gating (auto_uat, marker presence, staleness)

## Why

`/fix` had no post-commit QA/UAT bridge — after a successful fix, the user had to manually invoke `/vbw:qa` or `/vbw:verify`. This adds Phase 1 infrastructure (marker + context + conditional suggestion) for the inline QA/UAT lifecycle that #405 will complete. The marker pattern follows the existing `write-debug-session.sh` / `compile-debug-session-context.sh` pattern.

## How

- **write-fix-marker.sh**: Reads `git rev-parse --short HEAD`, `git log --format`, and `git diff-tree --root` to capture commit metadata. Writes key=value marker. Always exits 0 (non-blocking helper).
- **compile-fix-commit-context.sh**: Reads marker, checks 24h staleness via `stat` (platform-aware macOS/Linux), runs `git show --stat` for change summary. Two modes (qa/uat) with different titles.
- **fix.md**: Both success paths call `write-fix-marker.sh .vbw-planning` silently before `suggest-next.sh fix`.
- **suggest-next.sh**: Fix branch checks `cfg_auto_uat=true` AND marker exists AND inline `stat`-based 24h freshness check before adding UAT suggestion.

## Acceptance Criteria Verification

1. **Marker written with commit, message, timestamp, description, files** — satisfied by `write-fix-marker.sh` lines 33-50, tested in `write-fix-marker.bats` tests 1-3, 6-7
2. **compile-fix-commit-context.sh reads marker → fix_context=available/empty** — satisfied by `compile-fix-commit-context.sh` lines 59-129, tested in `compile-fix-commit-context.bats` tests 1-4
3. **Stale markers (>24h) → fix_context=empty** — satisfied by `compile-fix-commit-context.sh` lines 34-49, tested in `compile-fix-commit-context.bats` test 5
4. **suggest-next.sh suggests UAT when auto_uat=true AND fresh marker exists** — satisfied by `suggest-next.sh` lines 762-780, tested in `suggest-next-fix-uat.bats` test 4
5. **Does NOT suggest UAT when auto_uat=false, marker missing, or marker stale** — satisfied by same gating logic, tested in `suggest-next-fix-uat.bats` tests 2, 3, 5
6. **fix.md calls write-fix-marker.sh in both success paths before suggest-next.sh** — satisfied by `fix.md` lines 94-95 and 118-119, tested in `write-fix-marker.bats` test 8 (ordering contract)
7. **Scripts exit 0 gracefully** — satisfied by explicit `exit 0` paths, tested in `write-fix-marker.bats` tests 4-5
8. **BATS tests cover all changes** — 21 new BATS tests across 3 files, including staleness, root-commit, and ordering contract
9. **testing/run-all.sh green** — 2874 passed, 0 failed (lint 1/1, contracts 39/39)

## Testing

- 3 new BATS test files (21 tests total)
- Full suite: 2874 BATS passed, 39 contract checks passed, lint clean
- Known flaky: `phase-detect.bats` test tracked in #414 (pre-existing, not caused by this change)

## QA Summary

- **Primary QA (Claude):** 3 rounds, all clean (0 findings)
- **Cross-model QA (GPT-5.4):** 3 rounds
  - Round 1: 3 medium findings — F-01 (staleness check missing in suggest-next.sh), F-02 (contradictory STOP in fix.md), F-03 (observation: flaky test #414, pre-existing)
  - Round 2: 1 medium + 1 low — F-01 (root-commit files empty, `--root` flag fix), F-02 (root-commit test gap)
  - Round 3: 1 low — F-01 (contract test for marker ordering in fix.md)
  - All findings fixed
- **Copilot PR review:** pending