### PR TITLE
perf(testing): auto-throttle local run-all suites across worktrees

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -8,6 +8,8 @@ Run all checks:
 
 - `bash testing/run-all.sh` — runs CI-parity shell lint, contract checks, and bats using the same 4 shard layout and serial-bats split as CI (`jq`, `shellcheck`, and `bats` required locally)
 
+   Local runs start from an 8-worker bats budget and auto-throttle that budget when multiple local `run-all.sh` suites overlap. To pin a different worker count explicitly, use `BATS_WORKERS=N bash testing/run-all.sh`.
+
 Reproduce an individual CI bats shard locally:
 
 - `files=(); while IFS= read -r file; do files+=("$file"); done < <(bash testing/list-bats-files.sh --shardable)`

--- a/testing/README.md
+++ b/testing/README.md
@@ -7,8 +7,7 @@ This folder contains verification scripts for VBW that are safe to run locally a
 Run all checks:
 
 - `bash testing/run-all.sh` — runs CI-parity shell lint, contract checks, and bats using the same shared discovery/helpers and serial-bats split as CI (`jq`, `shellcheck`, and `bats` required locally)
-
-   Local runs start from an 8-worker bats budget and auto-throttle that budget when multiple local `run-all.sh` suites overlap. To pin a different worker count explicitly, use `BATS_WORKERS=N bash testing/run-all.sh`.
+  Local runs start from an 8-worker bats budget and auto-throttle that budget when multiple local `run-all.sh` suites overlap. To pin a different worker count explicitly, use `BATS_WORKERS=N bash testing/run-all.sh`.
 
 Reproduce an individual CI bats shard locally:
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -6,14 +6,14 @@ This folder contains verification scripts for VBW that are safe to run locally a
 
 Run all checks:
 
-- `bash testing/run-all.sh` — runs CI-parity shell lint, contract checks, and bats using the same 4 shard layout and serial-bats split as CI (`jq`, `shellcheck`, and `bats` required locally)
+- `bash testing/run-all.sh` — runs CI-parity shell lint, contract checks, and bats using the same shared discovery/helpers and serial-bats split as CI (`jq`, `shellcheck`, and `bats` required locally)
 
    Local runs start from an 8-worker bats budget and auto-throttle that budget when multiple local `run-all.sh` suites overlap. To pin a different worker count explicitly, use `BATS_WORKERS=N bash testing/run-all.sh`.
 
 Reproduce an individual CI bats shard locally:
 
 - `files=(); while IFS= read -r file; do files+=("$file"); done < <(bash testing/list-bats-files.sh --shardable)`
-- `bash testing/run-bats-shard.sh 1 4 "${files[@]}"`
+- `bash testing/run-bats-shard.sh 1 8 "${files[@]}"`
 
 Run the serial bats files locally:
 

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -9,7 +9,7 @@ LIST_BATS_FILES="$ROOT/testing/list-bats-files.sh"
 LIST_CONTRACT_TESTS="$ROOT/testing/list-contract-tests.sh"
 
 TMPDIR_JOBS="$(mktemp -d)"
-RUN_ALL_STATE_ROOT="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites}"
+RUN_ALL_STATE_ROOT="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites-${UID:-$(id -u)}}"
 RUN_ALL_STATE_DIR=""
 RUN_ALL_TOKEN=""
 RUN_ALL_REPO_KEY=""
@@ -86,23 +86,23 @@ run_all_token_is_valid() {
 
   case "$pid" in
     ''|*[!0-9]*)
-      rm -f "$entry"
+      rm -f "$entry" 2>/dev/null || true
       return 1
       ;;
   esac
 
   if [ -z "$repo_key" ] || [ -z "$process_start" ] || [ -z "$process_command" ]; then
-    rm -f "$entry"
+    rm -f "$entry" 2>/dev/null || true
     return 1
   fi
 
   if [ "$repo_key" != "$RUN_ALL_REPO_KEY" ]; then
-    rm -f "$entry"
+    rm -f "$entry" 2>/dev/null || true
     return 1
   fi
 
   if ! kill -0 "$pid" 2>/dev/null; then
-    rm -f "$entry"
+    rm -f "$entry" 2>/dev/null || true
     return 1
   fi
 
@@ -110,12 +110,12 @@ run_all_token_is_valid() {
   current_command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
 
   if [ -z "$current_start" ] || [ -z "$current_command" ]; then
-    rm -f "$entry"
+    rm -f "$entry" 2>/dev/null || true
     return 1
   fi
 
   if [ "$process_start" != "$current_start" ] || [ "$process_command" != "$current_command" ]; then
-    rm -f "$entry"
+    rm -f "$entry" 2>/dev/null || true
     return 1
   fi
 
@@ -125,7 +125,7 @@ run_all_token_is_valid() {
       ;;
   esac
 
-  rm -f "$entry"
+  rm -f "$entry" 2>/dev/null || true
   return 1
 }
 

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -23,10 +23,12 @@ declare -a JOB_EXIT_CODES=()
 declare -a serial_bats_files=()
 
 cleanup_run_all() {
-  local job_pid
+  local job_pid ppid_of_job
 
   for job_pid in "${JOB_PIDS[@]}"; do
     [ -n "$job_pid" ] || continue
+    ppid_of_job=$(ps -o ppid= -p "$job_pid" 2>/dev/null | tr -d '[:space:]') || continue
+    [ "$ppid_of_job" = "$$" ] || continue
     kill "$job_pid" 2>/dev/null || true
   done
   for job_pid in "${JOB_PIDS[@]}"; do
@@ -120,7 +122,7 @@ run_all_token_is_valid() {
   fi
 
   case "$current_command" in
-    *"testing/run-all.sh"*)
+    *"run-all.sh"*)
       return 0
       ;;
   esac

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -9,8 +9,12 @@ LIST_BATS_FILES="$ROOT/testing/list-bats-files.sh"
 LIST_CONTRACT_TESTS="$ROOT/testing/list-contract-tests.sh"
 
 TMPDIR_JOBS="$(mktemp -d)"
-RUN_ALL_STATE_DIR="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites}"
+RUN_ALL_STATE_ROOT="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites}"
+RUN_ALL_STATE_DIR=""
 RUN_ALL_TOKEN=""
+RUN_ALL_REPO_KEY=""
+RUN_ALL_PROCESS_START=""
+RUN_ALL_PROCESS_COMMAND=""
 
 cleanup_run_all() {
   rm -rf "$TMPDIR_JOBS"
@@ -42,25 +46,83 @@ run_job() {
   JOB_PIDS+=("$!")
 }
 
+initialize_run_all_state() {
+  local repo_identity
+
+  repo_identity="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "$ROOT")"
+  RUN_ALL_REPO_KEY="$(printf '%s' "$repo_identity" | jq -sRr @uri 2>/dev/null || true)"
+  RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT"
+  if [ -n "$RUN_ALL_REPO_KEY" ]; then
+    RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT/$RUN_ALL_REPO_KEY"
+  fi
+  RUN_ALL_PROCESS_START="$(ps -o lstart= -p $$ 2>/dev/null || true)"
+  RUN_ALL_PROCESS_COMMAND="$(ps -o command= -p $$ 2>/dev/null || true)"
+}
+
+run_all_token_is_valid() {
+  local entry="$1"
+  local pid repo_key process_start process_command current_start current_command
+
+  [ -f "$entry" ] || return 1
+
+  pid="$(jq -r '.pid // empty' "$entry" 2>/dev/null || true)"
+  repo_key="$(jq -r '.repo_key // empty' "$entry" 2>/dev/null || true)"
+  process_start="$(jq -r '.process_start // empty' "$entry" 2>/dev/null || true)"
+  process_command="$(jq -r '.process_command // empty' "$entry" 2>/dev/null || true)"
+
+  case "$pid" in
+    ''|*[!0-9]*)
+      rm -f "$entry"
+      return 1
+      ;;
+  esac
+
+  if [ -z "$repo_key" ] || [ -z "$process_start" ] || [ -z "$process_command" ]; then
+    rm -f "$entry"
+    return 1
+  fi
+
+  if [ "$repo_key" != "$RUN_ALL_REPO_KEY" ]; then
+    rm -f "$entry"
+    return 1
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    rm -f "$entry"
+    return 1
+  fi
+
+  current_start="$(ps -o lstart= -p "$pid" 2>/dev/null || true)"
+  current_command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+
+  if [ -z "$current_start" ] || [ -z "$current_command" ]; then
+    rm -f "$entry"
+    return 1
+  fi
+
+  if [ "$process_start" != "$current_start" ] || [ "$process_command" != "$current_command" ]; then
+    rm -f "$entry"
+    return 1
+  fi
+
+  case "$current_command" in
+    *"testing/run-all.sh"*)
+      return 0
+      ;;
+  esac
+
+  rm -f "$entry"
+  return 1
+}
+
 prune_run_all_tokens() {
-  local entry token_name pid
+  local entry
 
   [ -d "$RUN_ALL_STATE_DIR" ] || return 0
 
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
-    token_name="${entry##*/}"
-    pid="${token_name#suite.}"
-    pid="${pid%%.*}"
-    case "$pid" in
-      ''|*[!0-9]*)
-        rm -f "$entry"
-        continue
-        ;;
-    esac
-    if ! kill -0 "$pid" 2>/dev/null; then
-      rm -f "$entry"
-    fi
+    run_all_token_is_valid "$entry" >/dev/null 2>&1 || true
   done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
 }
 
@@ -74,19 +136,34 @@ count_run_all_tokens() {
 
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
-    count=$((count + 1))
+    if run_all_token_is_valid "$entry"; then
+      count=$((count + 1))
+    fi
   done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
 
   echo "$count"
 }
 
 register_run_all_token() {
+  [ -n "$RUN_ALL_REPO_KEY" ] || return 1
+  [ -n "$RUN_ALL_PROCESS_START" ] || return 1
+  [ -n "$RUN_ALL_PROCESS_COMMAND" ] || return 1
   mkdir -p "$RUN_ALL_STATE_DIR" 2>/dev/null || return 1
   prune_run_all_tokens
   RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token" 2>/dev/null)" || {
     RUN_ALL_TOKEN=""
     return 1
   }
+  if ! jq -n \
+    --arg pid "$$" \
+    --arg repo_key "$RUN_ALL_REPO_KEY" \
+    --arg process_start "$RUN_ALL_PROCESS_START" \
+    --arg process_command "$RUN_ALL_PROCESS_COMMAND" \
+    '{pid: $pid, repo_key: $repo_key, process_start: $process_start, process_command: $process_command}' > "$RUN_ALL_TOKEN"; then
+    rm -f "$RUN_ALL_TOKEN"
+    RUN_ALL_TOKEN=""
+    return 1
+  fi
 }
 
 auto_tune_bats_workers() {
@@ -99,6 +176,8 @@ auto_tune_bats_workers() {
 
   echo "$tuned"
 }
+
+initialize_run_all_state
 
 # --- Launch shell lint ---
 run_job lint "shell-lint"                bash "$ROOT/testing/run-lint.sh"

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -218,6 +218,7 @@ auto_tune_bats_workers() {
 }
 
 initialize_run_all_state
+register_run_all_token
 
 # --- Launch shell lint ---
 run_job lint "shell-lint"                bash "$ROOT/testing/run-lint.sh"
@@ -251,7 +252,7 @@ case "$BATS_WORKERS" in
     ;;
 esac
 ACTIVE_RUN_ALL_SUITES=0
-if register_run_all_token; then
+if [ -n "$RUN_ALL_TOKEN" ]; then
   ACTIVE_RUN_ALL_SUITES="$(count_run_all_tokens_with_grace)"
 fi
 

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -49,7 +49,12 @@ run_job() {
 initialize_run_all_state() {
   local repo_identity
 
-  repo_identity="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "$ROOT")"
+  repo_identity="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "$ROOT")"
+  case "$repo_identity" in
+    /*) ;;
+    *) repo_identity="$ROOT/$repo_identity" ;;
+  esac
+  repo_identity="$(cd "$repo_identity" 2>/dev/null && pwd || printf '%s' "$repo_identity")"
   RUN_ALL_REPO_KEY="$(printf '%s' "$repo_identity" | jq -sRr @uri 2>/dev/null || true)"
   RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT"
   if [ -n "$RUN_ALL_REPO_KEY" ]; then

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -16,7 +16,23 @@ RUN_ALL_REPO_KEY=""
 RUN_ALL_PROCESS_START=""
 RUN_ALL_PROCESS_COMMAND=""
 
+declare -a JOB_NAMES=()
+declare -a JOB_PIDS=()
+declare -a JOB_TYPES=()  # "lint", "contract", or "bats"
+declare -a JOB_EXIT_CODES=()
+declare -a serial_bats_files=()
+
 cleanup_run_all() {
+  local job_pid
+
+  for job_pid in "${JOB_PIDS[@]}"; do
+    [ -n "$job_pid" ] || continue
+    kill "$job_pid" 2>/dev/null || true
+  done
+  for job_pid in "${JOB_PIDS[@]}"; do
+    [ -n "$job_pid" ] || continue
+    wait "$job_pid" 2>/dev/null || true
+  done
   rm -rf "$TMPDIR_JOBS"
   if [ -n "$RUN_ALL_TOKEN" ]; then
     rm -f "$RUN_ALL_TOKEN"
@@ -29,13 +45,6 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for CI-parity local verification (install with: brew install jq)."
   exit 1
 fi
-
-# --- Shared parallel job infrastructure ---
-declare -a JOB_NAMES=()
-declare -a JOB_PIDS=()
-declare -a JOB_TYPES=()  # "lint", "contract", or "bats"
-declare -a JOB_EXIT_CODES=()
-declare -a serial_bats_files=()
 
 run_job() {
   local type="$1" name="$2"
@@ -149,13 +158,32 @@ count_run_all_tokens() {
   echo "$count"
 }
 
+count_run_all_tokens_with_grace() {
+  local attempt current_count observed_count=0
+
+  for attempt in 1 2 3 4; do
+    current_count="$(count_run_all_tokens)"
+    if [ "$current_count" -gt "$observed_count" ]; then
+      observed_count="$current_count"
+    fi
+    if [ "$observed_count" -gt 1 ] || [ "$attempt" -eq 4 ]; then
+      break
+    fi
+    sleep 0.05
+  done
+
+  echo "$observed_count"
+}
+
 register_run_all_token() {
+  local final_token
+
   [ -n "$RUN_ALL_REPO_KEY" ] || return 1
   [ -n "$RUN_ALL_PROCESS_START" ] || return 1
   [ -n "$RUN_ALL_PROCESS_COMMAND" ] || return 1
   mkdir -p "$RUN_ALL_STATE_DIR" 2>/dev/null || return 1
   prune_run_all_tokens
-  RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token" 2>/dev/null)" || {
+  RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token.tmp" 2>/dev/null)" || {
     RUN_ALL_TOKEN=""
     return 1
   }
@@ -169,6 +197,13 @@ register_run_all_token() {
     RUN_ALL_TOKEN=""
     return 1
   fi
+  final_token="${RUN_ALL_TOKEN%.tmp}"
+  if ! mv "$RUN_ALL_TOKEN" "$final_token"; then
+    rm -f "$RUN_ALL_TOKEN"
+    RUN_ALL_TOKEN=""
+    return 1
+  fi
+  RUN_ALL_TOKEN="$final_token"
 }
 
 auto_tune_bats_workers() {
@@ -217,7 +252,7 @@ case "$BATS_WORKERS" in
 esac
 ACTIVE_RUN_ALL_SUITES=0
 if register_run_all_token; then
-  ACTIVE_RUN_ALL_SUITES="$(count_run_all_tokens)"
+  ACTIVE_RUN_ALL_SUITES="$(count_run_all_tokens_with_grace)"
 fi
 
 if [ "$BATS_WORKERS_FROM_ENV" = false ] && [ "${GITHUB_ACTIONS:-false}" != "true" ]; then

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -218,7 +218,7 @@ auto_tune_bats_workers() {
 }
 
 initialize_run_all_state
-register_run_all_token
+register_run_all_token || true
 
 # --- Launch shell lint ---
 run_job lint "shell-lint"                bash "$ROOT/testing/run-lint.sh"

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -35,7 +35,7 @@ cleanup_run_all() {
   done
   rm -rf "$TMPDIR_JOBS"
   if [ -n "$RUN_ALL_TOKEN" ]; then
-    rm -f "$RUN_ALL_TOKEN"
+    rm -f "$RUN_ALL_TOKEN" >/dev/null 2>&1 || true
   fi
 }
 

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -9,7 +9,17 @@ LIST_BATS_FILES="$ROOT/testing/list-bats-files.sh"
 LIST_CONTRACT_TESTS="$ROOT/testing/list-contract-tests.sh"
 
 TMPDIR_JOBS="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_JOBS"' EXIT
+RUN_ALL_STATE_DIR="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites}"
+RUN_ALL_TOKEN=""
+
+cleanup_run_all() {
+  rm -rf "$TMPDIR_JOBS"
+  if [ -n "$RUN_ALL_TOKEN" ]; then
+    rm -f "$RUN_ALL_TOKEN"
+  fi
+}
+
+trap cleanup_run_all EXIT
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for CI-parity local verification (install with: brew install jq)."
@@ -32,6 +42,64 @@ run_job() {
   JOB_PIDS+=("$!")
 }
 
+prune_run_all_tokens() {
+  local entry token_name pid
+
+  [ -d "$RUN_ALL_STATE_DIR" ] || return 0
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    token_name="${entry##*/}"
+    pid="${token_name#suite.}"
+    pid="${pid%%.*}"
+    case "$pid" in
+      ''|*[!0-9]*)
+        rm -f "$entry"
+        continue
+        ;;
+    esac
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$entry"
+    fi
+  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
+}
+
+count_run_all_tokens() {
+  local count=0 entry
+
+  [ -d "$RUN_ALL_STATE_DIR" ] || {
+    echo 0
+    return 0
+  }
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    count=$((count + 1))
+  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
+
+  echo "$count"
+}
+
+register_run_all_token() {
+  mkdir -p "$RUN_ALL_STATE_DIR" 2>/dev/null || return 1
+  prune_run_all_tokens
+  RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token" 2>/dev/null)" || {
+    RUN_ALL_TOKEN=""
+    return 1
+  }
+}
+
+auto_tune_bats_workers() {
+  local requested="$1" active_suites="$2" tuned="$1"
+
+  if [ "$active_suites" -gt 1 ]; then
+    tuned=$(((requested + active_suites - 1) / active_suites))
+    [ "$tuned" -lt 2 ] && tuned=2
+  fi
+
+  echo "$tuned"
+}
+
 # --- Launch shell lint ---
 run_job lint "shell-lint"                bash "$ROOT/testing/run-lint.sh"
 
@@ -48,7 +116,11 @@ while IFS=$'\t' read -r name path; do
 done <<< "$CONTRACT_TESTS_OUTPUT"
 
 # --- Launch bats workers concurrently with contract checks ---
-BATS_WORKERS="${BATS_WORKERS:-12}"
+BATS_WORKERS_FROM_ENV=true
+if [ -z "${BATS_WORKERS+x}" ]; then
+  BATS_WORKERS_FROM_ENV=false
+fi
+BATS_WORKERS="${BATS_WORKERS:-8}"
 case "$BATS_WORKERS" in
   ''|*[!0-9]*)
     echo "Invalid BATS_WORKERS=$BATS_WORKERS — falling back to CI shard count (4 workers)."
@@ -59,6 +131,18 @@ case "$BATS_WORKERS" in
     BATS_WORKERS=4
     ;;
 esac
+ACTIVE_RUN_ALL_SUITES=0
+if register_run_all_token; then
+  ACTIVE_RUN_ALL_SUITES="$(count_run_all_tokens)"
+fi
+
+if [ "$BATS_WORKERS_FROM_ENV" = false ] && [ "${GITHUB_ACTIONS:-false}" != "true" ]; then
+  tuned_bats_workers="$(auto_tune_bats_workers "$BATS_WORKERS" "$ACTIVE_RUN_ALL_SUITES")"
+  if [ "$tuned_bats_workers" -ne "$BATS_WORKERS" ]; then
+    echo "Auto-tuned BATS_WORKERS from $BATS_WORKERS to $tuned_bats_workers for $ACTIVE_RUN_ALL_SUITES concurrent local test suite(s). Override with BATS_WORKERS=N."
+    BATS_WORKERS="$tuned_bats_workers"
+  fi
+fi
 bats_launched=false
 bats_missing=false
 if ! command -v bats &>/dev/null && ls "$ROOT/tests/"*.bats &>/dev/null 2>&1; then

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -236,9 +236,9 @@ while IFS=$'\t' read -r name path; do
 done <<< "$CONTRACT_TESTS_OUTPUT"
 
 # --- Launch bats workers concurrently with contract checks ---
-BATS_WORKERS_FROM_ENV=true
-if [ -z "${BATS_WORKERS+x}" ]; then
-  BATS_WORKERS_FROM_ENV=false
+BATS_WORKERS_FROM_ENV=false
+if [ -n "${BATS_WORKERS:-}" ]; then
+  BATS_WORKERS_FROM_ENV=true
 fi
 BATS_WORKERS="${BATS_WORKERS:-8}"
 case "$BATS_WORKERS" in

--- a/testing/verify-ci-workflow-contract.sh
+++ b/testing/verify-ci-workflow-contract.sh
@@ -66,8 +66,9 @@ else
   fail "ci.yml/testing: CI and local runner do not share deterministic serial bats discovery"
 fi
 
-# Local default (12) intentionally differs from CI shard count (8) — local machines
-# have more cores so more workers are efficient. Validate BATS_WORKERS has a numeric default.
+# Local runner starts from a numeric default and may auto-tune downward when
+# concurrent local suites are active. Validate that the base BATS_WORKERS
+# default remains numeric.
 if grep -qE 'BATS_WORKERS="\$\{BATS_WORKERS:-[0-9]+\}"' "$RUN_ALL"; then
   pass "run-all: BATS_WORKERS has a numeric default"
 else

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -84,6 +84,21 @@ SH
   chmod +x "$path"
 }
 
+create_blocking_lint_script() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+: "${LINT_PID_FILE:?}"
+printf '%s\n' "$$" > "$LINT_PID_FILE"
+trap 'exit 0' TERM INT
+while :; do
+  sleep 0.1
+done
+SH
+  chmod +x "$path"
+}
+
 link_runtime_tool() {
   local root="$1"
   local tool_name="$2"
@@ -102,21 +117,6 @@ link_run_all_system_tools() {
   done
 }
 
-wait_for_file_contains() {
-  local needle="$1"
-  local file="$2"
-  local attempt
-
-  for attempt in {1..100}; do
-    if [ -f "$file" ] && grep -q "$needle" "$file"; then
-      return 0
-    fi
-    sleep 0.1
-  done
-
-  return 1
-}
-
 @test "default local worker count auto-tunes when a real peer suite overlaps" {
   local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
   local linked_root="$TEST_TEMP_DIR/stub-repo-auto-tune-worktree"
@@ -132,7 +132,6 @@ wait_for_file_contains() {
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
-  wait_for_file_contains 'Launched' "$first_output"
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
@@ -158,7 +157,6 @@ wait_for_file_contains() {
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
-  wait_for_file_contains 'Launched' "$first_output"
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
@@ -185,6 +183,28 @@ wait_for_file_contains() {
   run env RUN_ALL_STATE_DIR="$state_root" bash -c "cd '$root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
   [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
+}
+
+@test "run-all cleanup reaps background jobs on early failure" {
+  local root="$TEST_TEMP_DIR/stub-repo-early-fail"
+  local host_bash
+  local lint_pid
+  create_stub_workspace "$root"
+  create_blocking_lint_script "$root/testing/run-lint.sh"
+  cat > "$root/testing/list-contract-tests.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$root/testing/list-contract-tests.sh"
+  link_run_all_system_tools "$root"
+  host_bash="$(command -v bash)"
+
+  run env PATH="$root/bin" LINT_PID_FILE="$TEST_TEMP_DIR/lint.pid" "$host_bash" -c "cd '$root' && bash testing/run-all.sh"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'No contract tests discovered'
+
+  lint_pid="$(cat "$TEST_TEMP_DIR/lint.pid")"
+  ! kill -0 "$lint_pid" 2>/dev/null
 }
 
 @test "invalid BATS_WORKERS falls back and keeps serial bats files out of worker batches" {

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -35,6 +35,11 @@ create_stub_workspace() {
 #!/usr/bin/env bash
 : "${BATS_LOG:?}"
 printf '%s\n' "$*" >> "$BATS_LOG"
+if [ -n "${BATS_HOLD_UNTIL_FILE:-}" ]; then
+  while [ ! -f "$BATS_HOLD_UNTIL_FILE" ]; do
+    sleep 0.1
+  done
+fi
 i=1
 for arg in "$@"; do
   printf 'ok %d %s\n' "$i" "$(basename "$arg")"
@@ -79,42 +84,90 @@ link_run_all_system_tools() {
   local root="$1"
   local tool_name
 
-  for tool_name in bash cat dirname find grep jq ls mkdir mktemp rm sort; do
+  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp ps rm sort; do
     link_runtime_tool "$root" "$tool_name"
   done
 }
 
-@test "default local worker count auto-tunes when concurrent suites are active" {
-  local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
-  local state_dir="$TEST_TEMP_DIR/run-all-state"
-  create_stub_workspace "$root"
-  export BATS_LOG="$TEST_TEMP_DIR/bats-auto.log"
-  export PATH="$root/bin:$PATH"
+wait_for_file_contains() {
+  local needle="$1"
+  local file="$2"
+  local attempt
 
-  mkdir -p "$state_dir"
-  : > "$state_dir/suite.$$.existing.token"
-  : > "$state_dir/suite.$PPID.existing.token"
+  for attempt in {1..100}; do
+    if [ -f "$file" ] && grep -q "$needle" "$file"; then
+      return 0
+    fi
+    sleep 0.1
+  done
 
-  run env RUN_ALL_STATE_DIR="$state_dir" bash -c "cd '$root' && bash testing/run-all.sh"
-  [ "$status" -eq 0 ]
-  echo "$output" | grep -q 'Auto-tuned BATS_WORKERS from 8 to 3 for 3 concurrent local test suite(s)'
+  return 1
 }
 
-@test "explicit BATS_WORKERS overrides auto-tuning" {
-  local root="$TEST_TEMP_DIR/stub-repo-pinned-workers"
-  local state_dir="$TEST_TEMP_DIR/run-all-state-pinned"
+@test "default local worker count auto-tunes when a real peer suite overlaps" {
+  local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
+  local state_dir="$TEST_TEMP_DIR/run-all-state"
+  local release_file="$TEST_TEMP_DIR/release-first-run"
+  local first_output="$TEST_TEMP_DIR/first-run.log"
+  local first_bats_log="$TEST_TEMP_DIR/first-bats.log"
+  local second_bats_log="$TEST_TEMP_DIR/second-bats.log"
+  local first_pid
   create_stub_workspace "$root"
-  export BATS_LOG="$TEST_TEMP_DIR/bats-pinned.log"
   export PATH="$root/bin:$PATH"
 
-  mkdir -p "$state_dir"
-  : > "$state_dir/suite.$$.existing.token"
-  : > "$state_dir/suite.$PPID.existing.token"
+  env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  first_pid=$!
+  wait_for_file_contains 'Launched' "$first_output"
 
-  run env RUN_ALL_STATE_DIR="$state_dir" BATS_WORKERS=7 bash -c "cd '$root' && bash testing/run-all.sh"
+  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
+
+  touch "$release_file"
+  wait "$first_pid"
+
+  echo "$output" | grep -q 'Auto-tuned BATS_WORKERS from 8 to 4 for 2 concurrent local test suite(s)'
+}
+
+@test "explicit BATS_WORKERS overrides auto-tuning during real overlap" {
+  local root="$TEST_TEMP_DIR/stub-repo-pinned-workers"
+  local state_dir="$TEST_TEMP_DIR/run-all-state-pinned"
+  local release_file="$TEST_TEMP_DIR/release-pinned-run"
+  local first_output="$TEST_TEMP_DIR/pinned-first-run.log"
+  local first_bats_log="$TEST_TEMP_DIR/pinned-first-bats.log"
+  local second_bats_log="$TEST_TEMP_DIR/pinned-second-bats.log"
+  local first_pid
+  create_stub_workspace "$root"
+  export PATH="$root/bin:$PATH"
+
+  env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  first_pid=$!
+  wait_for_file_contains 'Launched' "$first_output"
+
+  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$root' && bash testing/run-all.sh"
+  [ "$status" -eq 0 ]
+
+  touch "$release_file"
+  wait "$first_pid"
+
   [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
   echo "$output" | grep -q '7 bats workers'
+}
+
+@test "stray token file is ignored and does not self-throttle a lone suite" {
+  local root="$TEST_TEMP_DIR/stub-repo-stray-token"
+  local state_root="$TEST_TEMP_DIR/run-all-state-stray"
+  local repo_key
+  create_stub_workspace "$root"
+  export BATS_LOG="$TEST_TEMP_DIR/bats-stray.log"
+  export PATH="$root/bin:$PATH"
+
+  repo_key=$(printf '%s' "$root/.git" | jq -sRr @uri)
+  mkdir -p "$state_root/$repo_key"
+  printf '{"pid":"%s","repo_key":"%s"}\n' "$$" "$repo_key" > "$state_root/$repo_key/suite.$$.fake.token"
+
+  run env RUN_ALL_STATE_DIR="$state_root" bash -c "cd '$root' && bash testing/run-all.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
 }
 
 @test "invalid BATS_WORKERS falls back and keeps serial bats files out of worker batches" {

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -79,9 +79,42 @@ link_run_all_system_tools() {
   local root="$1"
   local tool_name
 
-  for tool_name in bash cat dirname find grep jq ls mktemp rm sort; do
+  for tool_name in bash cat dirname find grep jq ls mkdir mktemp rm sort; do
     link_runtime_tool "$root" "$tool_name"
   done
+}
+
+@test "default local worker count auto-tunes when concurrent suites are active" {
+  local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
+  local state_dir="$TEST_TEMP_DIR/run-all-state"
+  create_stub_workspace "$root"
+  export BATS_LOG="$TEST_TEMP_DIR/bats-auto.log"
+  export PATH="$root/bin:$PATH"
+
+  mkdir -p "$state_dir"
+  : > "$state_dir/suite.$$.existing.token"
+  : > "$state_dir/suite.$PPID.existing.token"
+
+  run env RUN_ALL_STATE_DIR="$state_dir" bash -c "cd '$root' && bash testing/run-all.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'Auto-tuned BATS_WORKERS from 8 to 3 for 3 concurrent local test suite(s)'
+}
+
+@test "explicit BATS_WORKERS overrides auto-tuning" {
+  local root="$TEST_TEMP_DIR/stub-repo-pinned-workers"
+  local state_dir="$TEST_TEMP_DIR/run-all-state-pinned"
+  create_stub_workspace "$root"
+  export BATS_LOG="$TEST_TEMP_DIR/bats-pinned.log"
+  export PATH="$root/bin:$PATH"
+
+  mkdir -p "$state_dir"
+  : > "$state_dir/suite.$$.existing.token"
+  : > "$state_dir/suite.$PPID.existing.token"
+
+  run env RUN_ALL_STATE_DIR="$state_dir" BATS_WORKERS=7 bash -c "cd '$root' && bash testing/run-all.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
+  echo "$output" | grep -q '7 bats workers'
 }
 
 @test "invalid BATS_WORKERS falls back and keeps serial bats files out of worker batches" {

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -130,7 +130,7 @@ link_run_all_system_tools() {
   create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
-  env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
 
   # Wait for the first suite's token to appear before launching the second,
@@ -144,7 +144,7 @@ link_run_all_system_tools() {
   done
   [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
-  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
+  run env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"
@@ -166,7 +166,7 @@ link_run_all_system_tools() {
   create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
-  env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
 
   # Wait for the first suite's token to appear before launching the second.
@@ -179,7 +179,7 @@ link_run_all_system_tools() {
   done
   [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
-  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
+  run env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"
@@ -201,7 +201,7 @@ link_run_all_system_tools() {
   mkdir -p "$state_root/$repo_key"
   printf '{"pid":"%s","repo_key":"%s"}\n' "$$" "$repo_key" > "$state_root/$repo_key/suite.$$.fake.token"
 
-  run env RUN_ALL_STATE_DIR="$state_root" bash -c "cd '$root' && bash testing/run-all.sh"
+  run env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_root" bash -c "cd '$root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
   [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
 }

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -112,7 +112,7 @@ link_run_all_system_tools() {
   local root="$1"
   local tool_name
 
-  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp mv ps rm sort tr; do
+  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp mv ps rm sleep sort tr; do
     link_runtime_tool "$root" "$tool_name"
   done
 }

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -112,7 +112,7 @@ link_run_all_system_tools() {
   local root="$1"
   local tool_name
 
-  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp ps rm sort; do
+  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp mv ps rm sort trort tr; do
     link_runtime_tool "$root" "$tool_name"
   done
 }
@@ -132,6 +132,17 @@ link_run_all_system_tools() {
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
+
+  # Wait for the first suite's token to appear before launching the second,
+  # otherwise the second suite may not see the first as a concurrent peer.
+  local token_found=false
+  for _wait in $(seq 1 100); do
+    if compgen -G "$state_dir"/*/*.token >/dev/null 2>&1; then
+      token_found=true; break
+    fi
+    sleep 0.1
+  done
+  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; return 1; }
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
@@ -157,6 +168,16 @@ link_run_all_system_tools() {
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
+
+  # Wait for the first suite's token to appear before launching the second.
+  local token_found=false
+  for _wait in $(seq 1 100); do
+    if compgen -G "$state_dir"/*/*.token >/dev/null 2>&1; then
+      token_found=true; break
+    fi
+    sleep 0.1
+  done
+  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; return 1; }
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -70,7 +70,7 @@ create_stub_git_worktree_pair() {
   git -C "$primary_root" add .
   git -C "$primary_root" commit -q -m 'test: seed stub workspace'
   git -C "$primary_root" branch linked-worktree
-  git -C "$primary_root" worktree add "$linked_root" linked-worktree >/dev/null
+  git -C "$primary_root" worktree add -q "$linked_root" linked-worktree >/dev/null 2>&1
 }
 
 create_failing_stub_script() {

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -60,6 +60,19 @@ SH
   touch "$root/tests/alpha.bats" "$root/tests/beta.bats" "$root/tests/statusline-cache-isolation.bats"
 }
 
+create_stub_git_worktree_pair() {
+  local primary_root="$1"
+  local linked_root="$2"
+
+  git -C "$primary_root" init -q
+  git -C "$primary_root" config user.email test@example.com
+  git -C "$primary_root" config user.name 'Test User'
+  git -C "$primary_root" add .
+  git -C "$primary_root" commit -q -m 'test: seed stub workspace'
+  git -C "$primary_root" branch linked-worktree
+  git -C "$primary_root" worktree add "$linked_root" linked-worktree >/dev/null
+}
+
 create_failing_stub_script() {
   local path="$1"
   mkdir -p "$(dirname "$path")"
@@ -106,6 +119,7 @@ wait_for_file_contains() {
 
 @test "default local worker count auto-tunes when a real peer suite overlaps" {
   local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
+  local linked_root="$TEST_TEMP_DIR/stub-repo-auto-tune-worktree"
   local state_dir="$TEST_TEMP_DIR/run-all-state"
   local release_file="$TEST_TEMP_DIR/release-first-run"
   local first_output="$TEST_TEMP_DIR/first-run.log"
@@ -113,13 +127,14 @@ wait_for_file_contains() {
   local second_bats_log="$TEST_TEMP_DIR/second-bats.log"
   local first_pid
   create_stub_workspace "$root"
+  create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
   wait_for_file_contains 'Launched' "$first_output"
 
-  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$root' && bash testing/run-all.sh"
+  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"
@@ -130,6 +145,7 @@ wait_for_file_contains() {
 
 @test "explicit BATS_WORKERS overrides auto-tuning during real overlap" {
   local root="$TEST_TEMP_DIR/stub-repo-pinned-workers"
+  local linked_root="$TEST_TEMP_DIR/stub-repo-pinned-workers-worktree"
   local state_dir="$TEST_TEMP_DIR/run-all-state-pinned"
   local release_file="$TEST_TEMP_DIR/release-pinned-run"
   local first_output="$TEST_TEMP_DIR/pinned-first-run.log"
@@ -137,13 +153,14 @@ wait_for_file_contains() {
   local second_bats_log="$TEST_TEMP_DIR/pinned-second-bats.log"
   local first_pid
   create_stub_workspace "$root"
+  create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
   env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
   wait_for_file_contains 'Launched' "$first_output"
 
-  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$root' && bash testing/run-all.sh"
+  run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -142,7 +142,7 @@ link_run_all_system_tools() {
     fi
     sleep 0.1
   done
-  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; return 1; }
+  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
@@ -177,7 +177,7 @@ link_run_all_system_tools() {
     fi
     sleep 0.1
   done
-  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; return 1; }
+  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
   run env RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -112,7 +112,7 @@ link_run_all_system_tools() {
   local root="$1"
   local tool_name
 
-  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp mv ps rm sort trort tr; do
+  for tool_name in bash cat dirname find git grep jq ls mkdir mktemp mv ps rm sort tr; do
     link_runtime_tool "$root" "$tool_name"
   done
 }


### PR DESCRIPTION
## Linked Issue

Fixes #447

## What

Improve local `testing/run-all.sh` throughput when multiple Claude worktrees run the full suite at the same time.

This PR lowers the default local bats worker budget from `12` to `8`, adds same-repo cross-worktree coordination for overlapping local suites, hardens token validation/publication so overlap detection is reliable under startup races and stale-token scenarios, and updates the local orchestration tests/docs to match the new behavior.

## Why

The previous local runner chose its worker budget per process, not per machine. With 4–6 agents active in separate worktrees, each local suite could still claim the full default bats fan-out, oversubscribing the box and making the local verification loop slower under contention.

The fix keeps the existing full-suite workflow, but makes local overlap detection work across linked worktrees of the same repo and preserves explicit `BATS_WORKERS=N` overrides when a caller wants to pin the budget manually.

## How

- `testing/run-all.sh`
  - reduce the default local `BATS_WORKERS` budget from `12` to `8`
  - coordinate local suites through a machine-local shared state root
  - derive a repo-scoped key from the normalized absolute git common-dir so the primary checkout and linked worktrees share the same token directory
  - write structured token metadata (pid, repo key, process start, command) instead of trusting filename-only tokens
  - publish tokens atomically via temp-file + rename so overlapping startups do not delete each other’s half-written tokens
  - add a short overlap settle window before counting active suites so near-simultaneous starts still detect each other
  - preserve explicit `BATS_WORKERS` values and bypass local auto-throttling for CI
  - restore EXIT cleanup for already-launched background jobs on early failure paths
- `tests/run-all-orchestration.bats`
  - add real checkout + linked-worktree overlap coverage for the auto-throttle path
  - add explicit-override coverage under real overlap
  - add a stray-token regression so malformed/forged tokens do not self-throttle a lone suite
  - add an early-failure cleanup regression so background jobs are reaped when `run-all.sh` exits before the wait loop
- `testing/verify-ci-workflow-contract.sh`
  - keep the numeric-default contract for `BATS_WORKERS` without requiring CI and local worker counts to be identical
- `testing/README.md`
  - document the local auto-throttling behavior and the `BATS_WORKERS=N` override
  - remove stale wording that implied a fixed 4-shard local layout
  - update the shard reproduction example to match CI’s current 8-shard matrix

## Acceptance criteria verification

1. Lower default local worker budget than `12` when unset  
   - satisfied by `testing/run-all.sh` changing the local default to `8`
2. Shared machine-local path works across separate worktrees of the same repo  
   - satisfied by `testing/run-all.sh` repo-scoped token directory keyed from the normalized absolute git common-dir
3. Overlapping local suites auto-reduce the inferred worker budget  
   - satisfied by `testing/run-all.sh` active-suite counting + `auto_tune_bats_workers()` and verified by `tests/run-all-orchestration.bats` real overlap test
4. Explicit `BATS_WORKERS` override is preserved  
   - satisfied by `testing/run-all.sh` gating auto-throttling on `BATS_WORKERS_FROM_ENV=false` and verified by the explicit-override overlap test in `tests/run-all-orchestration.bats`
5. Orchestration tests cover both auto-throttle and override paths  
   - satisfied by `tests/run-all-orchestration.bats`
6. CI workflow contract still enforces a numeric default without requiring CI/local parity  
   - satisfied by `testing/verify-ci-workflow-contract.sh`
7. README documents local auto-throttling and `BATS_WORKERS=N` override  
   - satisfied by `testing/README.md`
8. Required verification commands pass after the change  
   - satisfied by:
     - `bash testing/run-lint.sh`
     - `bats tests/run-all-orchestration.bats`
     - `bash testing/verify-ci-workflow-contract.sh`
     - plus repeated full `bash testing/run-all.sh` passes on the feature worktree

## Testing

- [x] Loaded plugin locally (`claude-vbw` or `claude --plugin-dir "<path-to-vbw-clone>"`)
- [x] Tested affected commands against a real project (not the VBW repo)
- [x] No errors on plugin load
- [x] Existing commands still work
- [x] Ran QA review (2–4 separate AI sessions acting as devil's advocate on the diff)

Additional local verification from this session:
- `bash testing/run-lint.sh`
- `bats tests/run-all-orchestration.bats`
- `bash testing/verify-ci-workflow-contract.sh`
- `bash testing/run-all.sh`

Measured local wall-clock evidence on this macOS machine:
- before this change: about `149.79s` for the default local full suite
- after reducing the default budget to `8`: about `101.40s`

These numbers are machine-specific evidence from this session, not universal benchmarks.

## QA Review Evidence

- **Rounds completed:** 5 primary rounds + 1 cross-model round
- **Model used:** `qa-investigator` for primary review, `qa-investigator-gpt-54` for cross-model review
- **Fix commits:**
  - `094b348` — `fix(testing): address QA round 1`
  - `d9ff854` — `fix(testing): address QA round 2`
  - `b553ed6` — `fix(testing): address QA round 3`
  - `f21b803` — `fix(testing): address QA round 4`
  - `7743161` — `fix(testing): address QA round 5`
  - `869ad92` — `fix(testing): address cross-model QA round 1`

## Notes

- Coordination is intentionally scoped to the same user / same machine / same repo-worktree family. This PR does not attempt cross-user or cross-host coordination.
- The shared-state approach is designed to fail open if the state directory cannot be used; explicit `BATS_WORKERS=N` remains the escape hatch for callers who want a pinned budget.
- This PR is opened as a draft so the review trail stays attached to the issue-linked implementation branch.