### PR TITLE
fix(init): align CLAUDE_CONFIG_DIR prose with resolve-claude-dir.sh semantics

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -57,7 +57,7 @@ Skills:
 
 **CRITICAL: Complete ENTIRE step (including writing settings.json) BEFORE Step 1. Use AskUserQuestion for prompts. Wait for answers. Write settings.json. Only then proceed.**
 
-**Resolve config directory:** Try in order: env var `CLAUDE_CONFIG_DIR` (if set and directory exists), `~/.config/claude-code` (if exists), otherwise `~/.claude`. Store result as `CLAUDE_DIR`. Use it for all config paths in this command.
+**Resolve config directory:** Try in order: env var `CLAUDE_CONFIG_DIR` (if set, even if directory does not yet exist), `~/.config/claude-code` (if exists), otherwise `~/.claude`. Store result as `CLAUDE_DIR`. Use it for all config paths in this command.
 
 Read `CLAUDE_DIR/settings.json` (create `{}` if missing).
 


### PR DESCRIPTION
Fixes #444

## What

Updated `commands/init.md` line 60 to change the CLAUDE_CONFIG_DIR description from "if set and directory exists" to "if set, even if directory does not yet exist".

## Why

The prose in init.md Step 0 incorrectly stated that CLAUDE_CONFIG_DIR requires both the env var to be set AND the directory to exist. The canonical resolver (`scripts/resolve-claude-dir.sh`) only checks `[ -n "${CLAUDE_CONFIG_DIR:-}" ]` — no directory existence check. This mismatch could cause an LLM consumer to skip CLAUDE_CONFIG_DIR when the directory doesn't exist yet, contradicting the intended behavior where the env var always wins when set.

## How

- **`commands/init.md`** (line 60): Changed `"env var CLAUDE_CONFIG_DIR (if set and directory exists)"` → `"env var CLAUDE_CONFIG_DIR (if set, even if directory does not yet exist)"`. This matches both the script semantics and the comment on line 8 of `resolve-claude-dir.sh`.

## Acceptance criteria verification

1. **init.md Step 0 prose matches resolve-claude-dir.sh semantics — no "directory exists" gate**: Satisfied — line 60 now says "if set, even if directory does not yet exist", matching the `[ -n "${CLAUDE_CONFIG_DIR:-}" ]` guard in the script.
2. **All existing tests pass**: Satisfied — `bash testing/run-all.sh` exits 0 (2894 BATS tests, 40/40 contract checks, lint clean).

## Testing

- [x] `bash testing/run-all.sh` passes (2894 tests, 0 failures)
- [x] No contract tests reference the changed prose

## QA summary

- **Primary QA**: 3 rounds (Claude), 0 findings across all rounds
- **Cross-model QA**: 1 round (GPT-5.4), 0 findings
- **Copilot PR review**: pending
- **False positives**: none