### PR TITLE
fix(state-updater): harden temp file operations against parallel BATS flakiness

### DIFF
--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -381,7 +381,7 @@ esac
 
 # Update execution-state as best-effort only (never gates STATE/ROADMAP updates)
 if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ]; then
-  TEMP_FILE="${STATE_FILE}.tmp"
+  TEMP_FILE="${STATE_FILE}.tmp.$$.${RANDOM:-0}"
   jq --arg phase "$PHASE" --arg plan "$PLAN" --arg status "$STATUS" --arg summary_id "$SUMMARY_ID" '
     def as_num: (try tonumber catch null);
     if (.plans | type) == "array" then
@@ -398,7 +398,7 @@ if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ]; then
     else
       .
     end
-  ' "$STATE_FILE" > "$TEMP_FILE" 2>/dev/null && mv "$TEMP_FILE" "$STATE_FILE" 2>/dev/null || rm -f "$TEMP_FILE" 2>/dev/null
+  ' "$STATE_FILE" > "$TEMP_FILE" 2>/dev/null && [ -s "$TEMP_FILE" ] && mv "$TEMP_FILE" "$STATE_FILE" 2>/dev/null || rm -f "$TEMP_FILE" 2>/dev/null
 fi
 
 update_state_md "$(dirname "$FILE_PATH")"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -80,10 +80,10 @@ update_state_md() {
     pct=0
   fi
 
-  local tmp="${state_md}.tmp.$$"
+  local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
   sed "s/^Plans: .*/Plans: ${summary_count}\/${plan_count}/" "$state_md" | \
     sed "s/^Progress: .*/Progress: ${pct}%/" > "$tmp" 2>/dev/null && \
-    mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 }
 
 slug_to_name() {
@@ -142,7 +142,7 @@ update_roadmap() {
   fi
 
   # Start with a working copy
-  local tmp="${roadmap}.tmp.$$"
+  local tmp="${roadmap}.tmp.$$.${RANDOM:-0}"
   cp "$roadmap" "$tmp" 2>/dev/null || return 0
 
   # Update extended progress table row (| num - name | done | status | date |)
@@ -153,9 +153,9 @@ update_roadmap() {
     existing_name=$(grep -E "^\| *${phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
   fi
   if [ -n "$existing_name" ]; then
-    local tmp_ext="${roadmap}.tmp_ext.$$"
+    local tmp_ext="${roadmap}.tmp_ext.$$.${RANDOM:-0}"
     sed "s/^| *${phase_num} - .*/| ${phase_num} - ${existing_name} | ${summary_count}\/${plan_count} | ${status} | ${date_str} |/" "$tmp" > "$tmp_ext" 2>/dev/null && \
-      mv "$tmp_ext" "$tmp" 2>/dev/null || rm -f "$tmp_ext" 2>/dev/null
+      [ -s "$tmp_ext" ] && mv "$tmp_ext" "$tmp" 2>/dev/null || rm -f "$tmp_ext" 2>/dev/null
   fi
 
   # Update simple progress table format (| 01 | ● Done |)
@@ -170,19 +170,19 @@ update_roadmap() {
       planned)       simple_status="○ Planned" ;;
       *)             simple_status="$status" ;;
     esac
-    local tmp_simple="${roadmap}.tmp_s.$$"
+    local tmp_simple="${roadmap}.tmp_s.$$.${RANDOM:-0}"
     sed "s/^| *0*${phase_num} *|.*/| ${padded_num} | ${simple_status} |/" "$tmp" > "$tmp_simple" 2>/dev/null && \
-      mv "$tmp_simple" "$tmp" 2>/dev/null || rm -f "$tmp_simple" 2>/dev/null
+      [ -s "$tmp_simple" ] && mv "$tmp_simple" "$tmp" 2>/dev/null || rm -f "$tmp_simple" 2>/dev/null
   fi
 
   # Check/uncheck checkbox based on status
-  local tmp2="${roadmap}.tmp2.$$"
+  local tmp2="${roadmap}.tmp2.$$.${RANDOM:-0}"
   if [ "$status" = "complete" ]; then
     sed "s/^- \[ \] Phase ${phase_num}:/- [x] Phase ${phase_num}:/" "$tmp" > "$tmp2" 2>/dev/null && \
-      mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
+      [ -s "$tmp2" ] && mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
   elif [ "$status" = "uat issues" ]; then
     sed "s/^- \[[xX]\] Phase ${phase_num}:/- [ ] Phase ${phase_num}:/" "$tmp" > "$tmp2" 2>/dev/null && \
-      mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
+      [ -s "$tmp2" ] && mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
   fi
 
   mv "$tmp" "$roadmap" 2>/dev/null || rm -f "$tmp" 2>/dev/null
@@ -212,15 +212,15 @@ update_model_profile() {
   # Check if Model Profile line already exists
   if grep -q "^- \*\*Model Profile:\*\*" "$state_md" 2>/dev/null; then
     # Update existing line
-    local tmp="${state_md}.tmp.$$"
+    local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
     sed "s/^- \*\*Model Profile:\*\*.*/- **Model Profile:** ${model_profile}/" "$state_md" > "$tmp" 2>/dev/null && \
-      mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   else
     # Insert after Test Coverage line
-    local tmp="${state_md}.tmp.$$"
+    local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
     sed "/^- \*\*Test Coverage:\*\*/a\\
 - **Model Profile:** ${model_profile}" "$state_md" > "$tmp" 2>/dev/null && \
-      mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   fi
 }
 
@@ -282,16 +282,16 @@ advance_phase() {
 
   [ "$total" -eq 0 ] && return 0
 
-  local tmp="${state_md}.tmp.$$"
+  local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
   if [ "$all_done" = true ]; then
     sed "s/^Status: .*/Status: complete/" "$state_md" > "$tmp" 2>/dev/null && \
-      mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   elif [ -n "$next_num" ]; then
     local next_status="ready"
     [ "$next_has_uat" = true ] && next_status="needs_remediation"
     sed "s/^Phase: .*/Phase: ${next_num} of ${total} (${next_name})/" "$state_md" | \
       sed "s/^Status: .*/Status: ${next_status}/" > "$tmp" 2>/dev/null && \
-      mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   fi
 }
 
@@ -305,9 +305,9 @@ if echo "$FILE_PATH" | grep -qE 'phases/[^/]+/([0-9]+(-[0-9]+)?-PLAN|PLAN)\.md$'
   # Status: ready → active when a plan is written
   _sm="$(planning_root_from_phase_dir "$(dirname "$FILE_PATH")")/STATE.md"
   if [ -f "$_sm" ] && grep -q '^Status: ready' "$_sm" 2>/dev/null; then
-    _tmp="${_sm}.tmp.$$"
+    _tmp="${_sm}.tmp.$$.${RANDOM:-0}"
     sed 's/^Status: ready/Status: active/' "$_sm" > "$_tmp" 2>/dev/null && \
-      mv "$_tmp" "$_sm" 2>/dev/null || rm -f "$_tmp" 2>/dev/null
+      [ -s "$_tmp" ] && mv "$_tmp" "$_sm" 2>/dev/null || rm -f "$_tmp" 2>/dev/null
   fi
 fi
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -224,11 +224,25 @@ SUMMARY
   run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
   [ "$status" -eq 0 ]
 
-  grep -q '^Plans: 1/1$' .vbw-planning/STATE.md
-  grep -q '^Progress: 100%$' .vbw-planning/STATE.md
-  grep -q '^Phase: 2 of 2 (Core)$' .vbw-planning/STATE.md
-  grep -q '^- \[x\] Phase 1: Setup$' .vbw-planning/ROADMAP.md
-  grep -Eq '^\| 1 - Setup \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+  run grep -q '^Plans: 1/1$' .vbw-planning/STATE.md
+  if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
+  [ "$status" -eq 0 ]
+
+  run grep -q '^Progress: 100%$' .vbw-planning/STATE.md
+  if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
+  [ "$status" -eq 0 ]
+
+  run grep -q '^Phase: 2 of 2 (Core)$' .vbw-planning/STATE.md
+  if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
+  [ "$status" -eq 0 ]
+
+  run grep -q '^- \[x\] Phase 1: Setup$' .vbw-planning/ROADMAP.md
+  if [ "$status" -ne 0 ]; then echo "ROADMAP.md contents:" >&2; cat .vbw-planning/ROADMAP.md >&2; fi
+  [ "$status" -eq 0 ]
+
+  run grep -Eq '^\| 1 - Setup \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+  if [ "$status" -ne 0 ]; then echo "ROADMAP.md contents:" >&2; cat .vbw-planning/ROADMAP.md >&2; fi
+  [ "$status" -eq 0 ]
 }
 
 @test "advance_phase sets needs_remediation when next phase has UAT issues" {


### PR DESCRIPTION
Fixes #443

## What

Hardens all temp file operations in `scripts/state-updater.sh` against parallel BATS execution collisions, and adds diagnostic output to the flaky test in `tests/state-updater.bats`.

**Files modified:**
- `scripts/state-updater.sh`: All 11 sed/jq→mv temp file pipelines hardened with `$$.${RANDOM:-0}` suffix and `[ -s ]` non-empty guard
- `tests/state-updater.bats`: 5 `grep` assertions in the flaky test wrapped with `run` + diagnostic dump on failure

## Why

The test "summary trigger supports legacy SUMMARY.md naming" fails intermittently during parallel BATS execution (`testing/run-all.sh` with 8+ workers) but passes in isolation. Root cause: `sed` writes to a shared `.tmp` path, and under parallel load, concurrent test processes can collide on that filename. The `2>/dev/null` on `mv` silently swallows the resulting error, leaving STATE.md with stale values. The subsequent `grep` assertion then fails.

The fix addresses the root cause (temp file collisions) rather than just the symptom (flaky assertion). Using `$$` (PID) + `${RANDOM}` ensures unique temp paths even under parallel execution, and the `[ -s ]` guard prevents `mv` of empty/corrupt files.

## How

- **`scripts/state-updater.sh`**: Changed all temp file paths from `.tmp` or `.tmp.$$` to `.tmp.$$.${RANDOM:-0}` for collision resistance across parallel processes. Added `[ -s "$tmp" ] &&` guard before every `mv` to prevent replacing good state with empty/corrupt files. Applied consistently across `update_state_md`, `update_roadmap`, `update_model_profile`, `advance_phase`, PLAN trigger, and `.execution-state.json` update.
- **`tests/state-updater.bats`**: Wrapped each bare `grep -q` with `run grep -q ... ; if [ "$status" -ne 0 ]; then cat file >&2; fi; [ "$status" -eq 0 ]` so that if the test does fail again, the actual file contents are captured in BATS output for diagnosis.

## Acceptance Criteria Verification

1. **Test includes diagnostic output on failure** — satisfied by `run` + conditional `cat` pattern in `state-updater.bats` lines 227-244
2. **Root cause mitigated** — satisfied by `$$.${RANDOM:-0}` suffix + `[ -s ]` guard on all 11 temp file operations in `state-updater.sh`
3. **All existing tests pass** — 2894 BATS tests passed, 0 failed; 40 contract checks passed; lint clean
4. **No new flaky behavior introduced** — changes are scoped to temp file naming and test diagnostics only

## Testing

- [x] Loaded plugin locally with `claude --plugin-dir .`
- [x] `bash testing/run-all.sh` — 2894 passed, 0 failed, exit 0
- [x] Targeted test passes: `bats tests/state-updater.bats -f 'summary trigger supports legacy SUMMARY.md naming'`
- [x] No load errors, existing commands still work

## QA Summary

- **Primary QA**: 3 rounds (Claude), all clean — 0 findings across all rounds
- **Cross-model QA**: 2 rounds (GPT-5.4). Round 1: 1 medium contract finding (`.execution-state.json` temp file path not hardened) — fixed in commit `2ad5e7b`. Round 2: clean
- **Copilot PR review**: pending
- **Total findings**: 1 (medium, fixed). 0 false positives.