### PR TITLE
fix(report): consolidate diagnostic helpers into /vbw:report (#458)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,11 +49,5 @@ npm-debug.log*
 a_non_prod_files/
 .vbw-worktrees/
 
-# Local Debugging
-diag-session-key.md
-diag-emulate-marketplace.sh
-diag-parse-session.sh
-diag-parse-key.sh
-diag-session-key.sh
 package.json
 package-lock.json

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -10,6 +10,14 @@
 
 set -u
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Source debug-log helper (provides collect_debug_log_diagnostics)
+# shellcheck source=lib/report-debug-log.sh
+if [ -f "$SCRIPT_DIR/lib/report-debug-log.sh" ]; then
+  . "$SCRIPT_DIR/lib/report-debug-log.sh"
+fi
+
 PLUGIN_ROOT="${1:-}"
 PROJECT_DIR="${2:-$(pwd)}"
 
@@ -163,6 +171,110 @@ collect() {
     tail -10 "$PROJECT_DIR/.vbw-planning/.hook-debug.log" 2>/dev/null || echo "(read error)"
   else
     echo "(no .hook-debug.log found)"
+  fi
+  echo ""
+
+  # --- Debug Log Summary ---
+  if type collect_debug_log_diagnostics &>/dev/null; then
+    collect_debug_log_diagnostics
+  else
+    echo "--- Debug Log Summary ---"
+    echo "(helper not available)"
+    echo ""
+  fi
+
+  # --- Session Artifacts ---
+  echo "--- Session Artifacts ---"
+  local claude_dir="${CLAUDE_CONFIG_DIR:-${HOME:-/tmp}/.claude}"
+  local session_id="${CLAUDE_SESSION_ID:-}"
+  local session_key="${session_id:-default}"
+  local session_link="/tmp/.vbw-plugin-root-link-${session_key}"
+
+  echo "session_id: ${session_id:-(unset)}"
+  echo "session_link: $session_link"
+  if [ -L "$session_link" ]; then
+    echo "session_link_exists: YES -> $(readlink "$session_link" 2>/dev/null)"
+  else
+    echo "session_link_exists: NO"
+  fi
+
+  # Hook resolution source
+  local hook_cache hook_cpr hook_tmp=""
+  hook_cache=$(ls -1 "$claude_dir"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | sort -V 2>/dev/null | tail -1 || true)
+  hook_cpr="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}"
+  for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do
+    [ -f "$f" ] 2>/dev/null && hook_tmp="$f" && break
+  done 2>/dev/null
+  if [ -f "${hook_cache:-}" ]; then
+    echo "hook_resolution: CACHE"
+  elif [ -f "${hook_cpr:-}" ]; then
+    echo "hook_resolution: PLUGIN_ROOT"
+  elif [ -n "$hook_tmp" ]; then
+    echo "hook_resolution: TMP_LINK"
+  else
+    echo "hook_resolution: NONE"
+  fi
+
+  # Config cache / update cache presence
+  if [ -n "$PLUGIN_ROOT" ] && [ -f "$PLUGIN_ROOT/VERSION" ] && [ -f "$PLUGIN_ROOT/scripts/lib/vbw-cache-key.sh" ]; then
+    local _diag_ver _diag_uid _diag_config_cache _diag_update_cache
+    # shellcheck source=lib/vbw-cache-key.sh
+    . "$PLUGIN_ROOT/scripts/lib/vbw-cache-key.sh"
+    _diag_ver=$(cat "$PLUGIN_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]')
+    _diag_uid=$(id -u)
+    _diag_config_cache=$(vbw_cache_prefix "${_diag_ver:-0}" "$_diag_uid" "${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}")-config.env
+    _diag_update_cache="/tmp/vbw-update-check-${_diag_uid}-$(vbw_hash_path "$PLUGIN_ROOT")"
+    echo "config_cache_exists: $([ -f "$_diag_config_cache" ] && echo "YES" || echo "NO")"
+    echo "update_cache_exists: $([ -f "$_diag_update_cache" ] && echo "YES" || echo "NO")"
+  else
+    echo "config_cache_exists: (unavailable)"
+    echo "update_cache_exists: (unavailable)"
+  fi
+
+  # Welcome marker
+  echo "welcome_marker: $([ -f "$claude_dir/.vbw-welcomed" ] && echo "YES" || echo "NO")"
+
+  # Cache entry summary
+  local cache_dir="${claude_dir}/plugins/cache/vbw-marketplace/vbw"
+  if [ -d "$cache_dir" ]; then
+    local entry_count
+    entry_count=$(ls -d "$cache_dir"/*/ 2>/dev/null | wc -l | tr -d ' ')
+    echo "cache_entries: $entry_count"
+    for d in "$cache_dir"/*/; do
+      [ -d "$d" ] 2>/dev/null && echo "  $(basename "$d")$([ -L "${d%/}" ] && echo " (symlink)" || echo "")"
+    done 2>/dev/null
+  else
+    echo "cache_entries: (cache dir not found)"
+  fi
+  echo ""
+
+  # --- Marketplace Status ---
+  echo "--- Marketplace Status ---"
+  local mp_cache_root="${claude_dir}/plugins/cache/vbw-marketplace/vbw"
+  local mp_local_link="${mp_cache_root}/local"
+  local mp_installed="${claude_dir}/plugins/installed_plugins.json"
+
+  echo "cache_root: $mp_cache_root"
+  echo "cache_root_exists: $([ -d "$mp_cache_root" ] && echo "YES" || echo "NO")"
+
+  if [ -L "$mp_local_link" ]; then
+    echo "local_link: SYMLINK -> $(readlink "$mp_local_link" 2>/dev/null)"
+  elif [ -d "$mp_local_link" ]; then
+    echo "local_link: REAL_DIR"
+  else
+    echo "local_link: NOT_PRESENT"
+  fi
+
+  if [ -f "$mp_installed" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      local vbw_reg
+      vbw_reg=$(jq -r '.plugins // {} | keys[] | select(test("vbw";"i"))' "$mp_installed" 2>/dev/null | head -1)
+      echo "registry_entry: ${vbw_reg:-(not found)}"
+    else
+      echo "registry_entry: (jq unavailable — cannot parse)"
+    fi
+  else
+    echo "registry_entry: (installed_plugins.json not found)"
   fi
   echo ""
 

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -277,9 +277,26 @@ collect() {
 
   if [ -f "$mp_installed" ]; then
     if command -v jq >/dev/null 2>&1; then
-      local vbw_reg
-      vbw_reg=$(jq -r '.plugins // {} | keys[] | select(test("vbw";"i"))' "$mp_installed" 2>/dev/null | head -1)
-      echo "registry_entry: ${vbw_reg:-(not found)}"
+      local vbw_reg vbw_reg_fallback
+      vbw_reg=$(jq -r '
+        .plugins // {}
+        | if has("vbw@vbw-marketplace") then
+            "vbw@vbw-marketplace"
+          else
+            empty
+          end
+      ' "$mp_installed" 2>/dev/null)
+      if [ -n "$vbw_reg" ]; then
+        echo "registry_entry: $vbw_reg"
+      else
+        vbw_reg_fallback=$(jq -r '
+          .plugins // {}
+          | keys
+          | map(select(test("^vbw@")))
+          | if length > 0 then join(", ") else empty end
+        ' "$mp_installed" 2>/dev/null)
+        echo "registry_entry: ${vbw_reg_fallback:-(not found)}"
+      fi
     else
       echo "registry_entry: (jq unavailable — cannot parse)"
     fi

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -241,7 +241,8 @@ collect() {
     entry_count=$(ls -d "$cache_dir"/*/ 2>/dev/null | wc -l | tr -d ' ')
     echo "cache_entries: $entry_count"
     for d in "$cache_dir"/*/; do
-      [ -d "$d" ] 2>/dev/null && echo "  $(basename "$d")$([ -L "${d%/}" ] && echo " (symlink)" || echo "")"
+      [ -d "$d" ] 2>/dev/null || continue
+      echo "  $(basename "$d")$([ -L "${d%/}" ] && echo " (symlink)" || echo "")"
     done 2>/dev/null
   else
     echo "cache_entries: (cache dir not found)"

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -200,7 +200,7 @@ collect() {
 
   # Hook resolution source
   local hook_cache hook_cpr hook_tmp=""
-  hook_cache=$(ls -1 "$claude_dir"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | sort -V 2>/dev/null | tail -1 || true)
+  hook_cache=$(ls -1 "$claude_dir"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1 || true)
   hook_cpr="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}"
   for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do
     [ -f "$f" ] 2>/dev/null && hook_tmp="$f" && break

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -222,8 +222,17 @@ collect() {
     . "$PLUGIN_ROOT/scripts/lib/vbw-cache-key.sh"
     _diag_ver=$(cat "$PLUGIN_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]')
     _diag_uid=$(id -u)
-    _diag_config_cache=$(vbw_cache_prefix "${_diag_ver:-0}" "$_diag_uid" "${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}")-config.env
-    _diag_update_cache="/tmp/vbw-update-check-${_diag_uid}-$(vbw_hash_path "$PLUGIN_ROOT")"
+    local _diag_config_root _diag_scripts_dir
+    if [ -n "${VBW_CONFIG_ROOT:-}" ]; then
+      _diag_config_root=$(cd "${VBW_CONFIG_ROOT}" 2>/dev/null && pwd -P)
+    else
+      _diag_config_root=$(cd "${PROJECT_DIR}" 2>/dev/null && pwd -P)
+    fi
+    [ -n "${_diag_config_root:-}" ] || _diag_config_root="${VBW_CONFIG_ROOT:-$PROJECT_DIR}"
+    _diag_scripts_dir=$(cd "$PLUGIN_ROOT/scripts" 2>/dev/null && pwd -P)
+    [ -n "${_diag_scripts_dir:-}" ] || _diag_scripts_dir="$PLUGIN_ROOT/scripts"
+    _diag_config_cache=$(vbw_cache_prefix "${_diag_ver:-0}" "$_diag_uid" "$_diag_config_root")-config.env
+    _diag_update_cache="/tmp/vbw-update-check-${_diag_uid}-$(vbw_hash_path "$_diag_scripts_dir")"
     echo "config_cache_exists: $([ -f "$_diag_config_cache" ] && echo "YES" || echo "NO")"
     echo "update_cache_exists: $([ -f "$_diag_update_cache" ] && echo "YES" || echo "NO")"
   else

--- a/scripts/lib/report-debug-log.sh
+++ b/scripts/lib/report-debug-log.sh
@@ -26,7 +26,8 @@ collect_debug_log_diagnostics() {
 
   # Plugin loading evidence
   local plugin_lines
-  plugin_lines=$(grep -cE 'Loading hooks from plugin:|Registered .* hooks from|Loaded plugin|Loading plugin' "$debug_log" 2>/dev/null || echo "0")
+  plugin_lines=$(grep -cE 'Loading hooks from plugin:|Registered .* hooks from|Loaded plugin|Loading plugin' "$debug_log" 2>/dev/null || true)
+  : "${plugin_lines:=0}"
   echo "plugin_loading_lines: $plugin_lines"
   if [ "$plugin_lines" -gt 0 ]; then
     grep -E 'Loading hooks from plugin:|Registered .* hooks from|Loaded plugin|Loading plugin' "$debug_log" 2>/dev/null | head -5 | while IFS= read -r line; do
@@ -36,9 +37,12 @@ collect_debug_log_diagnostics() {
 
   # Hook lookup/match counts
   local hook_lookups hook_successes hook_errors
-  hook_lookups=$(grep -c 'Getting matching hook commands' "$debug_log" 2>/dev/null || echo "0")
-  hook_successes=$(grep -c 'Hook .* success:' "$debug_log" 2>/dev/null || echo "0")
-  hook_errors=$(grep -ciE 'hook.*(error|fail|timeout|reject|denied|block|stderr)' "$debug_log" 2>/dev/null || echo "0")
+  hook_lookups=$(grep -c 'Getting matching hook commands' "$debug_log" 2>/dev/null || true)
+  : "${hook_lookups:=0}"
+  hook_successes=$(grep -c 'Hook .* success:' "$debug_log" 2>/dev/null || true)
+  : "${hook_successes:=0}"
+  hook_errors=$(grep -ciE 'hook.*(error|fail|timeout|reject|denied|block|stderr)' "$debug_log" 2>/dev/null || true)
+  : "${hook_errors:=0}"
   echo "hook_lookups: $hook_lookups"
   echo "hook_successes: $hook_successes"
   echo "hook_error_lines: $hook_errors"

--- a/scripts/lib/report-debug-log.sh
+++ b/scripts/lib/report-debug-log.sh
@@ -19,9 +19,9 @@ collect_debug_log_diagnostics() {
     return 0
   fi
 
-  local real_name
-  real_name=$(readlink "$debug_log" 2>/dev/null || basename "$debug_log")
-  echo "debug_log: $(basename "$real_name")"
+  local real_path
+  real_path=$(readlink "$debug_log" 2>/dev/null || echo "$debug_log")
+  echo "debug_log: $real_path"
   echo "debug_log_lines: $(wc -l < "$debug_log" 2>/dev/null | tr -d ' ')"
 
   # Plugin loading evidence

--- a/scripts/lib/report-debug-log.sh
+++ b/scripts/lib/report-debug-log.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# scripts/lib/report-debug-log.sh — Parse Claude Code debug log for hook evidence
+# Sourced by collect-diagnostics.sh. Expects redact() to be applied by the caller.
+#
+# Usage: collect_debug_log_diagnostics
+# Reads ~/.claude/debug/latest (or CLAUDE_CONFIG_DIR override).
+# Emits a compact summary: plugin loading, hook counts, hook errors, log path.
+# Always succeeds (never exits non-zero).
+
+collect_debug_log_diagnostics() {
+  local claude_dir="${CLAUDE_CONFIG_DIR:-${HOME:-/tmp}/.claude}"
+  local debug_log="${claude_dir}/debug/latest"
+
+  echo "--- Debug Log Summary ---"
+
+  if [ ! -f "$debug_log" ]; then
+    echo "debug_log: not found (${debug_log})"
+    echo ""
+    return 0
+  fi
+
+  local real_name
+  real_name=$(readlink "$debug_log" 2>/dev/null || basename "$debug_log")
+  echo "debug_log: $(basename "$real_name")"
+  echo "debug_log_lines: $(wc -l < "$debug_log" 2>/dev/null | tr -d ' ')"
+
+  # Plugin loading evidence
+  local plugin_lines
+  plugin_lines=$(grep -cE 'Loading hooks from plugin:|Registered .* hooks from|Loaded plugin|Loading plugin' "$debug_log" 2>/dev/null || echo "0")
+  echo "plugin_loading_lines: $plugin_lines"
+  if [ "$plugin_lines" -gt 0 ]; then
+    grep -E 'Loading hooks from plugin:|Registered .* hooks from|Loaded plugin|Loading plugin' "$debug_log" 2>/dev/null | head -5 | while IFS= read -r line; do
+      echo "  $line"
+    done
+  fi
+
+  # Hook lookup/match counts
+  local hook_lookups hook_successes hook_errors
+  hook_lookups=$(grep -c 'Getting matching hook commands' "$debug_log" 2>/dev/null || echo "0")
+  hook_successes=$(grep -c 'Hook .* success:' "$debug_log" 2>/dev/null || echo "0")
+  hook_errors=$(grep -ciE 'hook.*(error|fail|timeout|reject|denied|block|stderr)' "$debug_log" 2>/dev/null || echo "0")
+  echo "hook_lookups: $hook_lookups"
+  echo "hook_successes: $hook_successes"
+  echo "hook_error_lines: $hook_errors"
+
+  # Show hook errors if any (limited to 10)
+  if [ "$hook_errors" -gt 0 ]; then
+    grep -iE 'hook.*(error|fail|timeout|reject|denied|block|stderr)' "$debug_log" 2>/dev/null | head -10 | while IFS= read -r line; do
+      echo "  [ERROR] $line"
+    done
+  fi
+
+  echo ""
+}

--- a/scripts/lib/report-debug-log.sh
+++ b/scripts/lib/report-debug-log.sh
@@ -19,10 +19,26 @@ collect_debug_log_diagnostics() {
     return 0
   fi
 
-  local real_path
-  real_path=$(readlink "$debug_log" 2>/dev/null || echo "$debug_log")
+  local real_path link_target debug_dir resolved_debug_dir debug_log_lines
+  real_path="$debug_log"
+  link_target=$(readlink "$debug_log" 2>/dev/null || true)
+  if [ -n "$link_target" ]; then
+    if [[ "$link_target" = /* ]]; then
+      real_path="$link_target"
+    else
+      debug_dir=$(dirname "$debug_log")
+      resolved_debug_dir=$(cd -P "$debug_dir" 2>/dev/null && pwd -P)
+      if [ -n "$resolved_debug_dir" ]; then
+        real_path="${resolved_debug_dir}/${link_target}"
+      else
+        real_path="${debug_dir}/${link_target}"
+      fi
+    fi
+  fi
   echo "debug_log: $real_path"
-  echo "debug_log_lines: $(wc -l < "$debug_log" 2>/dev/null | tr -d ' ')"
+  debug_log_lines=$(wc -l < "$debug_log" 2>/dev/null | tr -d ' ')
+  : "${debug_log_lines:=0}"
+  echo "debug_log_lines: $debug_log_lines"
 
   # Plugin loading evidence
   local plugin_lines

--- a/testing/verify-plugin-root-resolution.sh
+++ b/testing/verify-plugin-root-resolution.sh
@@ -309,7 +309,7 @@ fi
 # Check 11: targeted command preambles use CLAUDE_SESSION_ID:-default session key
 # todo.md and list-todos.md intentionally have no shell preamble (fix for #201) — skip from preamble checks
 TARGET_COMMANDS=(
-  config.md debug.md diag-session-key.md discuss.md fix.md help.md init.md map.md qa.md
+  config.md debug.md discuss.md fix.md help.md init.md map.md qa.md
   report.md research.md resume.md skills.md status.md update.md verify.md vibe.md whats-new.md
 )
 for rel in "${TARGET_COMMANDS[@]}"; do

--- a/tests/collect-diagnostics.bats
+++ b/tests/collect-diagnostics.bats
@@ -83,6 +83,7 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"hook_lookups: 2"* ]]
   [[ "$output" == *"hook_successes: 2"* ]]
+  [[ "$output" == *"hook_error_lines: 0"* ]]
   [[ "$output" == *"plugin_loading_lines:"* ]]
 }
 
@@ -118,6 +119,12 @@ EOF
 @test "collect-diagnostics: shows welcome_marker status" {
   run_collector
   [[ "$output" == *"welcome_marker:"* ]]
+}
+
+@test "collect-diagnostics: shows config_cache and update_cache status" {
+  run_collector
+  [[ "$output" == *"config_cache_exists:"* ]]
+  [[ "$output" == *"update_cache_exists:"* ]]
 }
 
 # --- New section: Marketplace Status ---

--- a/tests/collect-diagnostics.bats
+++ b/tests/collect-diagnostics.bats
@@ -44,7 +44,8 @@ run_collector() {
 
 @test "collect-diagnostics: redacts home directory paths" {
   run_collector
-  [[ "$output" != *"$HOME"* ]] || [[ "$HOME" == "$TEST_TEMP_DIR" ]]
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"$TEST_TEMP_DIR"* ]]
 }
 
 @test "collect-diagnostics: redacts API key patterns" {

--- a/tests/collect-diagnostics.bats
+++ b/tests/collect-diagnostics.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  export CLAUDE_CONFIG_DIR="$TEST_TEMP_DIR/.claude"
+  mkdir -p "$CLAUDE_CONFIG_DIR/debug"
+  mkdir -p "$CLAUDE_CONFIG_DIR/plugins/cache/vbw-marketplace/vbw"
+}
+
+teardown() {
+  unset CLAUDE_CONFIG_DIR
+  unset CLAUDE_SESSION_ID
+  unset CLAUDE_PLUGIN_ROOT
+  teardown_temp_dir
+}
+
+run_collector() {
+  run bash "$SCRIPTS_DIR/collect-diagnostics.sh" "$PROJECT_ROOT" "$TEST_TEMP_DIR"
+}
+
+# --- Invariant: always exits 0 ---
+
+@test "collect-diagnostics: exits 0 with no project artifacts" {
+  rm -rf "$TEST_TEMP_DIR/.vbw-planning"
+  run_collector
+  [ "$status" -eq 0 ]
+}
+
+@test "collect-diagnostics: exits 0 with full project artifacts" {
+  mkdir -p "$TEST_TEMP_DIR/.vbw-planning/.events"
+  mkdir -p "$TEST_TEMP_DIR/.vbw-planning/.metrics"
+  echo '{"ts":"2025-01-01"}' > "$TEST_TEMP_DIR/.vbw-planning/.session-log.jsonl"
+  echo '{"event":"test"}' > "$TEST_TEMP_DIR/.vbw-planning/.events/event-log.jsonl"
+  echo '{"metric":"test"}' > "$TEST_TEMP_DIR/.vbw-planning/.metrics/run-metrics.jsonl"
+  echo '{"profile":"balanced"}' > "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  printf '# STATE\nphase: 01\n' > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  run_collector
+  [ "$status" -eq 0 ]
+}
+
+# --- Redaction ---
+
+@test "collect-diagnostics: redacts home directory paths" {
+  run_collector
+  [[ "$output" != *"$HOME"* ]] || [[ "$HOME" == "$TEST_TEMP_DIR" ]]
+}
+
+@test "collect-diagnostics: redacts API key patterns" {
+  mkdir -p "$TEST_TEMP_DIR/.vbw-planning"
+  echo '{"api_key":"sk-abcdefghij1234567890abcdefghij"}' > "$TEST_TEMP_DIR/.vbw-planning/config.json"
+  run_collector
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"sk-abcdefghij1234567890abcdefghij"* ]]
+}
+
+# --- New section: Debug Log Summary ---
+
+@test "collect-diagnostics: includes Debug Log Summary section" {
+  run_collector
+  [[ "$output" == *"--- Debug Log Summary ---"* ]]
+}
+
+@test "collect-diagnostics: debug log summary shows not found when no debug log" {
+  run_collector
+  [[ "$output" == *"debug_log: not found"* ]]
+}
+
+@test "collect-diagnostics: debug log summary parses hook counts from fixture" {
+  # Create a fake debug log
+  cat > "$CLAUDE_CONFIG_DIR/debug/test-session.txt" <<'EOF'
+[DEBUG] Getting matching hook commands for PreToolUse with query: Bash
+[DEBUG] Matched 2 unique hooks for PreToolUse
+[DEBUG] Hook vbw-hook success: {"result":"ok"}
+[DEBUG] Getting matching hook commands for PostToolUse with query: Bash
+[DEBUG] Hook vbw-hook2 success: {"result":"ok"}
+[DEBUG] Loading hooks from plugin: /path/to/vbw
+[DEBUG] Registered 21 hooks from vbw
+EOF
+  ln -sf "$CLAUDE_CONFIG_DIR/debug/test-session.txt" "$CLAUDE_CONFIG_DIR/debug/latest"
+  run_collector
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hook_lookups: 2"* ]]
+  [[ "$output" == *"hook_successes: 2"* ]]
+  [[ "$output" == *"plugin_loading_lines:"* ]]
+}
+
+# --- New section: Session Artifacts ---
+
+@test "collect-diagnostics: includes Session Artifacts section" {
+  run_collector
+  [[ "$output" == *"--- Session Artifacts ---"* ]]
+}
+
+@test "collect-diagnostics: shows session_id unset when not set" {
+  unset CLAUDE_SESSION_ID 2>/dev/null || true
+  run_collector
+  [[ "$output" == *"session_id: (unset)"* ]]
+}
+
+@test "collect-diagnostics: shows session_id when set" {
+  export CLAUDE_SESSION_ID="test-session-123"
+  run_collector
+  [[ "$output" == *"session_id: test-session-123"* ]]
+}
+
+@test "collect-diagnostics: shows session link existence" {
+  run_collector
+  [[ "$output" == *"session_link_exists:"* ]]
+}
+
+@test "collect-diagnostics: shows hook_resolution" {
+  run_collector
+  [[ "$output" == *"hook_resolution:"* ]]
+}
+
+@test "collect-diagnostics: shows welcome_marker status" {
+  run_collector
+  [[ "$output" == *"welcome_marker:"* ]]
+}
+
+# --- New section: Marketplace Status ---
+
+@test "collect-diagnostics: includes Marketplace Status section" {
+  run_collector
+  [[ "$output" == *"--- Marketplace Status ---"* ]]
+}
+
+@test "collect-diagnostics: shows cache_root_exists" {
+  run_collector
+  [[ "$output" == *"cache_root_exists:"* ]]
+}
+
+@test "collect-diagnostics: shows local_link status" {
+  run_collector
+  [[ "$output" == *"local_link:"* ]]
+}
+
+@test "collect-diagnostics: detects marketplace registry with jq" {
+  if ! command -v jq >/dev/null 2>&1; then
+    skip "jq not available"
+  fi
+  echo '{"plugins":{"vbw@vbw-marketplace":[{"scope":"user"}]}}' > "$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json"
+  run_collector
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"registry_entry: vbw@vbw-marketplace"* ]]
+}
+
+# --- Graceful degradation ---
+
+@test "collect-diagnostics: degrades gracefully with missing optional files" {
+  rm -rf "$TEST_TEMP_DIR/.vbw-planning"
+  rm -rf "$CLAUDE_CONFIG_DIR/debug"
+  run_collector
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Debug Log Summary"* ]]
+  [[ "$output" == *"Session Artifacts"* ]]
+  [[ "$output" == *"Marketplace Status"* ]]
+  [[ "$output" == *"Doctor Checks"* ]]
+}

--- a/tests/collect-diagnostics.bats
+++ b/tests/collect-diagnostics.bats
@@ -158,6 +158,16 @@ EOF
   [[ "$output" == *"registry_entry: vbw@vbw-marketplace"* ]]
 }
 
+@test "collect-diagnostics: falls back to vbw-prefixed registry entries when exact key is absent" {
+  if ! command -v jq >/dev/null 2>&1; then
+    skip "jq not available"
+  fi
+  echo '{"plugins":{"vbw@alt-marketplace":[{"scope":"user"}],"other-plugin":[{"scope":"user"}]}}' > "$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json"
+  run_collector
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"registry_entry: vbw@alt-marketplace"* ]]
+}
+
 # --- Graceful degradation ---
 
 @test "collect-diagnostics: degrades gracefully with missing optional files" {

--- a/tests/collect-diagnostics.bats
+++ b/tests/collect-diagnostics.bats
@@ -85,6 +85,9 @@ EOF
   [[ "$output" == *"hook_successes: 2"* ]]
   [[ "$output" == *"hook_error_lines: 0"* ]]
   [[ "$output" == *"plugin_loading_lines:"* ]]
+  # debug_log should show a path, not just a filename
+  [[ "$output" == *"debug_log: "* ]]
+  [[ "$output" != *"debug_log: test-session.txt"* ]]  # must be a path, not bare filename
 }
 
 # --- New section: Session Artifacts ---


### PR DESCRIPTION
Fixes #458

## What

Consolidates the useful read-only diagnostics from legacy untracked helper scripts (`diag-parse-session.sh`, `diag-session-key.sh`, `diag-emulate-marketplace.sh`) into the tracked `collect-diagnostics.sh` pipeline, making `/vbw:report` the single supported diagnostic reporting command. Adds a new tracked helper `scripts/lib/report-debug-log.sh` for Claude Code debug-log parsing, and retires the obsolete `.gitignore` local-debug entries and `diag-session-key.md` command reference.

## Why

Multiple untracked diagnostic scripts existed alongside `/vbw:report`, creating confusion about which tool to use. The untracked scripts were `.gitignore`-listed, so they couldn't be tested or maintained. Consolidating into the tracked collector means all diagnostic evidence flows through one canonical, tested, redacted path.

## How

- **`scripts/lib/report-debug-log.sh`** (NEW): Tracked helper with `collect_debug_log_diagnostics()` that parses `~/.claude/debug/latest` for plugin loading evidence, hook lookup/success/error counts, and debug-log path. Always returns 0.
- **`scripts/collect-diagnostics.sh`**: Sources the new helper; adds three new diagnostic sections before Doctor Checks:
  - *Debug Log Summary*: plugin loading lines, hook counts, error lines, log path
  - *Session Artifacts*: session ID, session-link path/existence/target, hook resolution source, config/update cache presence, welcome marker, cache entry summary
  - *Marketplace Status*: cache root, local symlink state/target, installed-plugin registry status via `jq`
- **`.gitignore`**: Removed the "Local Debugging" block (5 entries for retired diagnostic scripts)
- **`testing/verify-plugin-root-resolution.sh`**: Removed `diag-session-key.md` from `TARGET_COMMANDS` array
- **`tests/collect-diagnostics.bats`** (NEW): 19 behavior tests covering exit 0, redaction, all three new sections with fixtures, graceful degradation

## Acceptance criteria verification

1. **Debug Log Summary section**: Satisfied — `scripts/lib/report-debug-log.sh` provides `collect_debug_log_diagnostics()` sourced at `collect-diagnostics.sh:17-20`, emitting debug_log path, debug_log_lines, plugin_loading_lines (capped at 5), hook_lookups, hook_successes, hook_error_lines (capped at 10).
2. **Session Artifacts section**: Satisfied — `collect-diagnostics.sh:186-249` emits session_id, session_link, session_link_exists, session_link_target, hook_resolution, config_cache_exists, update_cache_exists, welcome_marker, and cache_entries.
3. **Marketplace Status section**: Satisfied — `collect-diagnostics.sh:252-279` uses shell+jq for registry parsing, no python3.
4. **Preserves invariants**: Satisfied — exits 0, all output through `redact()`, all file access guarded with `[ -f ]`/`[ -d ]`, no writes.
5. **No side effects**: Satisfied — no phase-detect.sh references, no state mutations.
6. **report.md contracts survive**: Satisfied — report.md unchanged (zero diff from main).
7. **.gitignore cleanup**: Satisfied — all 5 retired entries removed.
8. **verify-plugin-root-resolution.sh cleanup**: Satisfied — `diag-session-key.md` removed from TARGET_COMMANDS.
9. **BATS tests**: Satisfied — 19 tests in `tests/collect-diagnostics.bats` covering all specified areas.
10. **run-all.sh passes**: Satisfied — 41/41 contract checks, 2939/2939 BATS passed.

## Testing

- `bash testing/run-all.sh`: 41/41 contract, 2939/2939 BATS, 0 failed
- New `tests/collect-diagnostics.bats`: 19 tests covering exit status, redaction, fixture-based section parsing, graceful degradation
- Contract checks: `verify-report-template-contract.sh`, `verify-report-diag-handoff.sh`, `verify-plugin-root-resolution.sh` all pass

## QA summary

- **Primary QA (Claude)**: 3 rounds. Round 1: 3 low findings (glob-no-match guard, hook_error_lines test gap, config/update cache test gap) — all fixed. Rounds 2-3: clean.
- **Cross-model QA (GPT-5.4)**: 1 round. 1 medium finding (debug_log emitting basename instead of full path) + 1 low finding (test gap for path assertion) — both fixed. F-01 "hook-match count" claim classified as false positive (`hook_successes` IS the match count).
- **Copilot PR review**: pending