### PR TITLE
fix(testing): eliminate statusline SIGPIPE flake (#448)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,5 +29,5 @@
 
 ## Known onboarding quirks / errors encountered
 - `bash testing/run-all.sh` currently fails in a fresh environment if `bats` is missing, even when lint and contract checks pass. Workaround: install `bats-core` before relying on full CI-parity local verification, or at minimum run the relevant non-bats checks explicitly.
-- `bash testing/verify-statusline-qa-lifecycle.sh` currently exits with status `141` after printing passing output because `run_statusline_l1()` pipes `vbw-statusline.sh` into `head -1`, which can trigger an expected SIGPIPE. Workaround: treat exit `141` as this known standalone-test quirk, or run the check via `testing/run-all.sh` and inspect the emitted output.
+- `bash testing/verify-statusline-qa-lifecycle.sh` should now exit cleanly. If it fails, treat it as a real regression rather than an expected SIGPIPE quirk.
 - Keep `.github/copilot-instructions.md` tracked in git. Do not add it back to `.gitignore`.

--- a/testing/verify-statusline-qa-lifecycle.sh
+++ b/testing/verify-statusline-qa-lifecycle.sh
@@ -138,7 +138,18 @@ cleanup_statusline_cache() {
 
 run_statusline_l1() {
   local dir="$1"
-  (cd "$dir" && CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 bash "$ROOT/scripts/vbw-statusline.sh" <<< '{}' | head -1 | perl -pe 's/\e\[[0-9;]*m//g; s/\e\]8;;.*?\a//g; s/\e\]8;;\a//g')
+  local raw_output sanitized_output first_line
+
+  # Avoid an early-closing reader (for example `head -1`) under `pipefail`.
+  # As documented in verify-plan-filename-convention.sh, that pattern can
+  # SIGPIPE the upstream writer and fail the contract even when assertions pass.
+  if ! raw_output=$(cd "$dir" && CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 bash "$ROOT/scripts/vbw-statusline.sh" <<< '{}'); then
+    raw_output=""
+  fi
+
+  sanitized_output=$(printf '%s\n' "$raw_output" | perl -pe 's/\e\[[0-9;]*m//g; s/\e\]8;;.*?\a//g; s/\e\]8;;\a//g')
+  first_line=${sanitized_output%%$'\n'*}
+  printf '%s\n' "$first_line"
 }
 
 # Test 9: No VERIFICATION.md, no UAT → QA: --


### PR DESCRIPTION
Fixes #448

## What

This change removes the flaky `SIGPIPE` path from `testing/verify-statusline-qa-lifecycle.sh` by buffering the full `vbw-statusline.sh` output before extracting line 1, and updates `.github/copilot-instructions.md` so contributors no longer treat exit `141` as expected behavior. The runtime statusline implementation in `scripts/vbw-statusline.sh` is unchanged; only the contract helper and its repo guidance were touched.

## Why

Issue #448 identified a shell-level race, not a statusline runtime bug. `run_statusline_l1()` piped live statusline output into `head -1` under `set -euo pipefail`, so the downstream reader could close early and SIGPIPE the upstream writer. The correct architectural fix is to remove the early-closing reader from the helper instead of teaching `testing/run-all.sh` or CI to ignore exit `141`.

## How

- `testing/verify-statusline-qa-lifecycle.sh` — rewrites `run_statusline_l1()` to capture full stdout, sanitize ANSI / hyperlink escape sequences after buffering, and extract the first rendered line locally without `head -1`; adds an inline note documenting why the helper avoids early-closing readers under `pipefail`.
- `.github/copilot-instructions.md` — replaces the stale “exit 141 is an expected quirk” note with current guidance that the contract should now exit cleanly and failures should be treated as real regressions.

## Acceptance criteria verification

1. `bash testing/verify-statusline-qa-lifecycle.sh` exits 0 on 10 consecutive runs
   - Satisfied by `testing/verify-statusline-qa-lifecycle.sh:139-152`, which removes the `| head -1` race from `run_statusline_l1()`.
   - Verified locally with 10 consecutive standalone runs from the issue worktree; each run ended with `TOTAL: 48 passed, 0 failed` and exit `0`.
2. `bash testing/run-all.sh` shows 39/39 contracts consistently
   - The current registry contains 41 contract checks, so the modern equivalent is `41/41`.
   - `testing/list-contract-tests.sh:30` still includes `statusline-qa-lifecycle`, and the full suite now reports `PASS: statusline-qa-lifecycle` plus `Contract checks: 41/41 passed`.

## Testing

- [x] Targeted contract check: `bash testing/verify-statusline-qa-lifecycle.sh` ran 10 consecutive times with exit `0`
- [x] Full local verification: `bash testing/run-all.sh`
- [x] Lint clean via `testing/run-all.sh`
- [x] Contract suite clean via `testing/run-all.sh`
- [x] BATS clean via `testing/run-all.sh`

Observed local results on branch `fix-448-statusline-sigpipe`:
- `Lint checks: 1/1 passed`
- `Contract checks: 41/41 passed`
- `BATS: 2920 passed, 0 failed`

## QA summary

- Primary QA (`qa-investigator`): 3 rounds completed
  - Round 1: 0 findings
  - Round 2: 0 findings
  - Round 3: 0 findings
  - False positives noted: issue text still says `39/39`, but the current registry size is `41/41`
- Cross-model QA (`qa-investigator-gpt-54`, GPT-5.4): 1 round completed
  - Round 1: 0 findings
  - False positives noted: same `39/39` wording drift, not a branch defect
- Copilot PR review: pending

Evidence commits on this branch:
- `9bbb6ca` — implementation
- `4293925` — QA round 1 evidence
- `8eb03b1` — QA round 2 evidence
- `dc44309` — QA round 3 evidence
- `651cd8d` — cross-model QA round 1 evidence
