### PR TITLE
fix(phase-detect): harden flaky QA routing under parallel load

### DIFF
--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -46,8 +46,51 @@ else
   verification_is_stale() { return 0; }
 fi
 
+list_child_dirs_sorted_fallback() {
+  local dirs=("$@")
+  local sorted=()
+  local candidate candidate_name candidate_prefix candidate_num
+  local existing existing_name existing_prefix existing_num
+  local insert_at idx
+
+  [ ${#dirs[@]} -gt 0 ] || return 0
+
+  for candidate in "${dirs[@]}"; do
+    candidate_name="${candidate##*/}"
+    candidate_prefix="${candidate_name%%[^0-9]*}"
+    if [ -z "$candidate_prefix" ]; then
+      sorted+=("$candidate")
+      continue
+    fi
+
+    candidate_num=$((10#$candidate_prefix))
+    insert_at=${#sorted[@]}
+
+    for idx in "${!sorted[@]}"; do
+      existing="${sorted[$idx]}"
+      existing_name="${existing##*/}"
+      existing_prefix="${existing_name%%[^0-9]*}"
+      if [ -z "$existing_prefix" ]; then
+        continue
+      fi
+
+      existing_num=$((10#$existing_prefix))
+      if [ "$candidate_num" -lt "$existing_num" ] || { [ "$candidate_num" -eq "$existing_num" ] && [[ "$candidate" < "$existing" ]]; }; then
+        insert_at=$idx
+        break
+      fi
+    done
+
+    sorted=("${sorted[@]:0:$insert_at}" "$candidate" "${sorted[@]:$insert_at}")
+  done
+
+  printf '%s\n' "${sorted[@]}"
+}
+
 list_child_dirs_sorted() {
   local parent="$1"
+  local sorted_output=""
+
   [ -d "$parent" ] || return 0
 
   # Collect via bash glob (avoids find pipeline under parallel fd contention).
@@ -57,9 +100,23 @@ list_child_dirs_sorted() {
   for d in "$parent"/*/; do
     [ -d "$d" ] && dirs+=("${d%/}")
   done
-  [ ${#dirs[@]} -gt 0 ] || return 0
-  printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || \
-    printf '%s\n' "${dirs[@]}" | awk -F/ '{n=$NF; gsub(/[^0-9].*/,"",n); if (n == "") n=0; print (n+0)"\t"$0}' | sort -n -k1,1 -k2,2 | cut -f2-
+  case ${#dirs[@]} in
+    0) return 0 ;;
+    1)
+      printf '%s\n' "${dirs[0]}"
+      return 0
+      ;;
+  esac
+
+  sorted_output=$(printf '%s\n' "${dirs[@]}" | sort -V 2>/dev/null || true)
+  if [ -n "$sorted_output" ]; then
+    printf '%s\n' "$sorted_output"
+    return 0
+  fi
+
+  # Fail closed to a deterministic non-empty fallback rather than silently
+  # returning no phase dirs when sort helper execution degrades under load.
+  list_child_dirs_sorted_fallback "${dirs[@]}"
 }
 
 phase_relative_path() {
@@ -963,36 +1020,30 @@ fi
 # phases into QA remediation.
 if [ "$NEXT_PHASE_STATE" = "all_done" ] && [ -n "$FIRST_QA_ATTENTION_PHASE" ]; then
   _QA_ATT_DIR="$PHASES_DIR/$FIRST_QA_ATTENTION_SLUG/"
-  _QA_ATT_UAT="$(current_uat "$_QA_ATT_DIR")"
-  _QA_ATT_UAT_STATUS=""
-  if [ -f "$_QA_ATT_UAT" ]; then
-    _QA_ATT_UAT_STATUS=$(extract_status_value "$_QA_ATT_UAT")
-  fi
+  case "$QA_ATTENTION_STATUS" in
+    failed|verify)
+      NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
+      NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
+      if [ -d "$_QA_ATT_DIR" ]; then
+        NEXT_PHASE_PLANS=$(count_phase_plans "$_QA_ATT_DIR")
+        NEXT_PHASE_SUMMARIES=$(count_complete_summaries "$_QA_ATT_DIR")
+      fi
+      NEXT_PHASE_STATE="needs_qa_remediation"
+      if [ "$QA_ATTENTION_STATUS" = "failed" ]; then
+        QA_STATUS="failed"
+      else
+        QA_STATUS="remediating"
+      fi
+      ;;
+    pending)
+      _QA_ATT_UAT="$(current_uat "$_QA_ATT_DIR")"
+      _QA_ATT_UAT_STATUS=""
+      if [ -f "$_QA_ATT_UAT" ]; then
+        _QA_ATT_UAT_STATUS=$(extract_status_value "$_QA_ATT_UAT")
+      fi
 
-  case "$_QA_ATT_UAT_STATUS" in
-    complete|passed)
-      case "$QA_ATTENTION_STATUS" in
-        failed)
-          NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
-          NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
-          if [ -d "$_QA_ATT_DIR" ]; then
-            NEXT_PHASE_PLANS=$(count_phase_plans "$_QA_ATT_DIR")
-            NEXT_PHASE_SUMMARIES=$(count_complete_summaries "$_QA_ATT_DIR")
-          fi
-          NEXT_PHASE_STATE="needs_qa_remediation"
-          QA_STATUS="failed"
-          ;;
-        verify)
-          NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
-          NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
-          if [ -d "$_QA_ATT_DIR" ]; then
-            NEXT_PHASE_PLANS=$(count_phase_plans "$_QA_ATT_DIR")
-            NEXT_PHASE_SUMMARIES=$(count_complete_summaries "$_QA_ATT_DIR")
-          fi
-          NEXT_PHASE_STATE="needs_qa_remediation"
-          QA_STATUS="remediating"
-          ;;
-        pending)
+      case "$_QA_ATT_UAT_STATUS" in
+        complete|passed)
           NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
           NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
           if [ -d "$_QA_ATT_DIR" ]; then
@@ -1001,30 +1052,6 @@ if [ "$NEXT_PHASE_STATE" = "all_done" ] && [ -n "$FIRST_QA_ATTENTION_PHASE" ]; t
           fi
           NEXT_PHASE_STATE="needs_verification"
           QA_STATUS="pending"
-          ;;
-      esac
-      ;;
-    "")
-      case "$QA_ATTENTION_STATUS" in
-        failed)
-          NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
-          NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
-          if [ -d "$_QA_ATT_DIR" ]; then
-            NEXT_PHASE_PLANS=$(count_phase_plans "$_QA_ATT_DIR")
-            NEXT_PHASE_SUMMARIES=$(count_complete_summaries "$_QA_ATT_DIR")
-          fi
-          NEXT_PHASE_STATE="needs_qa_remediation"
-          QA_STATUS="failed"
-          ;;
-        verify)
-          NEXT_PHASE="$FIRST_QA_ATTENTION_PHASE"
-          NEXT_PHASE_SLUG="$FIRST_QA_ATTENTION_SLUG"
-          if [ -d "$_QA_ATT_DIR" ]; then
-            NEXT_PHASE_PLANS=$(count_phase_plans "$_QA_ATT_DIR")
-            NEXT_PHASE_SUMMARIES=$(count_complete_summaries "$_QA_ATT_DIR")
-          fi
-          NEXT_PHASE_STATE="needs_qa_remediation"
-          QA_STATUS="remediating"
           ;;
       esac
       ;;

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2668,7 +2668,11 @@ exit 23
 EOF
   chmod +x "$fake_sort_dir/sort"
 
-  run env PATH="$fake_sort_dir:$PATH" bash "$SCRIPTS_DIR/phase-detect.sh"
+  local original_path
+  original_path="$PATH"
+  PATH="$fake_sort_dir:$PATH"
+  run_phase_detect
+  PATH="$original_path"
 
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "phase_detect_complete=true"

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2629,6 +2629,86 @@ EOF
   echo "$output" | grep -q "qa_attention_status=failed"
 }
 
+@test "all_done routes to QA remediation when phase sorting helper fails" {
+  mkdir -p .vbw-planning/phases/01-test
+  echo "# Plan" > .vbw-planning/phases/01-test/01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/01-test/01-SUMMARY.md
+  echo "# My Project" > .vbw-planning/PROJECT.md
+
+  printf '%s\n' '---' 'result: FAIL' '---' '# Verification' 'Failed.' > .vbw-planning/phases/01-test/01-VERIFICATION.md
+
+  cat > .vbw-planning/phases/01-test/01-UAT.md <<'EOF'
+---
+phase: 01
+status: complete
+---
+All tests passed.
+EOF
+
+  local fake_sort_dir
+  fake_sort_dir="$TEST_TEMP_DIR/fake-sort"
+  mkdir -p "$fake_sort_dir"
+  cat > "$fake_sort_dir/sort" <<'EOF'
+#!/usr/bin/env bash
+exit 23
+EOF
+  chmod +x "$fake_sort_dir/sort"
+
+  run env PATH="$fake_sort_dir:$PATH" bash "$SCRIPTS_DIR/phase-detect.sh"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "phase_detect_complete=true"
+  echo "$output" | grep -q "next_phase=01"
+  echo "$output" | grep -q "next_phase_slug=01-test"
+  echo "$output" | grep -q "next_phase_state=needs_qa_remediation"
+  echo "$output" | grep -q "first_qa_attention_phase=01"
+  echo "$output" | grep -q "qa_attention_status=failed"
+}
+
+@test "all_done routes to QA remediation when failed QA attention sees degraded UAT reread" {
+  mkdir -p .vbw-planning/phases/01-test
+  echo "# Plan" > .vbw-planning/phases/01-test/01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/01-test/01-SUMMARY.md
+  echo "# My Project" > .vbw-planning/PROJECT.md
+
+  printf '%s\n' '---' 'result: FAIL' '---' '# Verification' 'Failed.' > .vbw-planning/phases/01-test/01-VERIFICATION.md
+
+  cat > .vbw-planning/phases/01-test/01-UAT.md <<'EOF'
+---
+phase: 01
+status: complete
+---
+All tests passed.
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_TEMP_DIR/scripts-phase-detect-uat-reread-degraded"
+  cp -R "$SCRIPTS_DIR" "$shim_dir"
+  cat >> "$shim_dir/uat-utils.sh" <<'EOF'
+
+extract_status_value() {
+  local file="${1:-}"
+  case "$file" in
+    *-UAT.md)
+      printf '%s\n' 'in_progress'
+      ;;
+    *)
+      printf '%s\n' ''
+      ;;
+  esac
+}
+EOF
+
+  run_phase_detect "$shim_dir"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "next_phase=01"
+  echo "$output" | grep -q "next_phase_slug=01-test"
+  echo "$output" | grep -q "next_phase_state=needs_qa_remediation"
+  echo "$output" | grep -q "first_qa_attention_phase=01"
+  echo "$output" | grep -q "qa_attention_status=failed"
+}
+
 @test "terminal UAT QA-attention restore rebuilds missing registry before routing" {
   mkdir -p .vbw-planning/phases/01-test
   echo "# Plan" > .vbw-planning/phases/01-test/01-PLAN.md

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2631,15 +2631,29 @@ EOF
 
 @test "all_done routes to QA remediation when phase sorting helper fails" {
   mkdir -p .vbw-planning/phases/01-test
+  mkdir -p .vbw-planning/phases/02-clean
   echo "# Plan" > .vbw-planning/phases/01-test/01-PLAN.md
+  echo "# Plan" > .vbw-planning/phases/02-clean/02-PLAN.md
   printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/01-test/01-SUMMARY.md
+  printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/02-clean/02-SUMMARY.md
   echo "# My Project" > .vbw-planning/PROJECT.md
 
+  current_commit="$(git rev-parse HEAD)"
+
   printf '%s\n' '---' 'result: FAIL' '---' '# Verification' 'Failed.' > .vbw-planning/phases/01-test/01-VERIFICATION.md
+  printf '%s\n' '---' 'result: PASS' 'writer: write-verification.sh' 'plans_verified:' '  - 02' "verified_at_commit: ${current_commit}" '---' '# Verification' 'Passed.' > .vbw-planning/phases/02-clean/02-VERIFICATION.md
 
   cat > .vbw-planning/phases/01-test/01-UAT.md <<'EOF'
 ---
 phase: 01
+status: complete
+---
+All tests passed.
+EOF
+
+  cat > .vbw-planning/phases/02-clean/02-UAT.md <<'EOF'
+---
+phase: 02
 status: complete
 ---
 All tests passed.
@@ -2658,6 +2672,7 @@ EOF
 
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "phase_detect_complete=true"
+  echo "$output" | grep -q "phase_count=2"
   echo "$output" | grep -q "next_phase=01"
   echo "$output" | grep -q "next_phase_slug=01-test"
   echo "$output" | grep -q "next_phase_state=needs_qa_remediation"


### PR DESCRIPTION
Fixes #434

## What

This PR hardens `scripts/phase-detect.sh` against the failure mode behind issue #434, where the `all_done routes to QA remediation when authoritative QA failed despite terminal UAT` path could intermittently lose `next_phase=01` under parallel local BATS load. It adds a shell-only fallback for phase directory enumeration, makes the `all_done` QA-attention fallback fail closed when QA attention is already `failed|verify`, and adds targeted regressions in `tests/phase-detect.bats` for both degradation paths.

## Why

The bug was not best fixed by serializing `tests/phase-detect.bats` or reducing worker count. The more durable root cause was that `phase-detect.sh` could still produce complete-but-wrong output when helper execution degraded under local parallel load: phase enumeration could collapse to an empty result, and the `all_done` QA-attention branch could depend on a second successful UAT reread even after authoritative QA had already established remediation work. This PR restores deterministic routing at the script layer.

## How

- `scripts/phase-detect.sh` — adds `list_child_dirs_sorted_fallback()` and keeps 0/1-directory cases entirely in bash so helper sort degradation cannot silently erase the phase list.
- `scripts/phase-detect.sh` — changes the `all_done` QA-attention override so `QA_ATTENTION_STATUS=failed|verify` immediately retargets to `needs_qa_remediation`; only `pending` still rereads terminal UAT state.
- `tests/phase-detect.bats` — adds focused regressions for failed sort-helper execution and degraded UAT reread while preserving neighboring stale-QA / QA-attention contracts.

## Acceptance criteria verification

1. Terminal UAT plus authoritative QA failed retargets to the phase with `next_phase=NN` and `next_phase_state=needs_qa_remediation`.
   - Satisfied by `scripts/phase-detect.sh:1023-1037`
   - Covered by `tests/phase-detect.bats:2608-2629`
2. Child directory enumeration does not silently degrade to an empty phase list when helper sort execution fails.
   - Satisfied by `scripts/phase-detect.sh:49-119`
   - Covered by `tests/phase-detect.bats:2632-2667`
3. The `all_done` QA-attention fallback fails closed for `QA_ATTENTION_STATUS=failed|verify` without requiring a second successful UAT reread.
   - Satisfied by `scripts/phase-detect.sh:1023-1037`
   - Covered by `tests/phase-detect.bats:2668-2709`
4. Targeted regressions exist for sort-helper degradation and degraded UAT reread.
   - Satisfied by `tests/phase-detect.bats:2632-2709`
5. Neighboring stale-QA / QA-attention cases still pass distinctly.
   - Verified by existing tests at `tests/phase-detect.bats:872`, `2567`, `2788`, and `2848`
6. The fix does not serialize `phase-detect.bats` or otherwise reduce parallel BATS execution as the solution.
   - Satisfied by the scoped diff: only `scripts/phase-detect.sh` and `tests/phase-detect.bats` changed
7. `bash testing/run-all.sh` passes.
   - Verified locally after the latest `origin/main` merge: lint `1/1`, contract checks `41/41`, BATS `2942 passed / 0 failed`

## Testing

- [x] `bats tests/phase-detect.bats --filter "all_done routes to QA remediation when authoritative QA failed despite terminal UAT"`
- [x] `bats tests/phase-detect.bats --filter "all_done routes to QA remediation when phase sorting helper fails"`
- [x] `bats tests/phase-detect.bats --filter "all_done routes to QA remediation when failed QA attention sees degraded UAT reread"`
- [x] `bats tests/phase-detect.bats --filter "first_qa_attention targets stale QA even when terminal UAT exists"`
- [x] `bats tests/phase-detect.bats --filter "phase-detect treats git freshness probe failure as pending QA when terminal UAT exists"`
- [x] `bats tests/phase-detect.bats`
- [x] `bash testing/run-all.sh`

## QA summary

- Primary QA rounds completed: 3 (`qa-investigator`) — 0 legitimate findings, 0 false positives
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54`, GPT-5.4) — 0 legitimate findings, 0 false positives
- Copilot PR review rounds completed: 0 — pending after draft PR creation / ready-for-review transition