### PR TITLE
test(skills): add Step 5b global path contract

### DIFF
--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -158,6 +158,44 @@ for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
 done
 
 echo ""
+echo "=== skills.md Step 5b Verification ==="
+
+SKILLS_FILE="$COMMANDS_DIR/skills.md"
+if [ ! -f "$SKILLS_FILE" ]; then
+  fail "skills: command file not found"
+else
+  skills_step_5b="$({
+    awk '
+      /^### Step 5b: Choose installation scope$/ { in_block=1; next }
+      in_block && /^### / { exit }
+      in_block { print }
+    ' "$SKILLS_FILE"
+  } || true)"
+
+  if [ -z "$skills_step_5b" ]; then
+    fail "skills: missing Step 5b block"
+  else
+    if grep -Fq -- '- **Global** — "Installed to `<global_skills_dir>/`, available in all projects."' <<< "$skills_step_5b"; then
+      pass "skills: Step 5b Global option uses <global_skills_dir>/ placeholder"
+    else
+      fail "skills: Step 5b Global option missing <global_skills_dir>/ placeholder"
+    fi
+
+    if grep -Fq 'Use the `global_skills_dir` value from the Stack detection Context JSON as the display path.' <<< "$skills_step_5b"; then
+      pass "skills: Step 5b explains global_skills_dir display source"
+    else
+      fail "skills: Step 5b missing global_skills_dir Stack detection Context JSON guidance"
+    fi
+
+    if grep -Fq '~/.agents/skills/' <<< "$skills_step_5b"; then
+      fail "skills: Step 5b still exposes ~/.agents/skills/ display path"
+    else
+      pass "skills: Step 5b does not expose ~/.agents/skills/ display path"
+    fi
+  fi
+fi
+
+echo ""
 echo "=== Milestone Context Verification ==="
 
 # Commands that reference milestone-scoped paths in their Steps section must have


### PR DESCRIPTION
Fixes #436

## What

This change adds explicit contract coverage for the `/vbw:skills` Step 5b Global install-path display in `testing/verify-commands-contract.sh`. The contract now pins the current post-#435 behavior in `commands/skills.md` by asserting that Step 5b displays `&lt;global_skills_dir&gt;/`, explains that the display path comes from the Stack detection Context JSON, and rejects the stale `~/.agents/skills/` display path.

## Why

The root cause behind #436 is not broken runtime behavior in `commands/skills.md`; it is a missing regression guard. Issue #433 fixed the user-facing path, but there was no contract test to prevent a future drift back to the wrong display text. After #435, the correct architecture is the dynamic `global_skills_dir` model backed by `scripts/detect-stack.sh`, so the durable fix is to enforce that invariant in the existing command contract suite rather than hardcoding an outdated literal path into a new one-off test.

## How

- `testing/verify-commands-contract.sh`: added a focused `skills.md` Step 5b verification block that extracts the Step 5b section, asserts the exact Global-option placeholder text, asserts the `global_skills_dir` guidance sentence, and fails if the legacy `~/.agents/skills/` display path reappears.

## Acceptance criteria verification

1. **A contract test asserts that `commands/skills.md` Step 5b Global option contains `~/.claude/skills/` (or the correct path per #435)**
   - Satisfied by the post-#435-correct invariant in `commands/skills.md:86-90`, where Step 5b uses `&lt;global_skills_dir&gt;/`.
   - Enforced by `testing/verify-commands-contract.sh:161-187`, which verifies the Step 5b Global option and the `global_skills_dir` display-source guidance.
2. **A contract test asserts that `commands/skills.md` does NOT contain `~/.agents/skills/` as a display path**
   - Satisfied by `commands/skills.md:86-90`, which contains the dynamic display path rather than `~/.agents/skills/`.
   - Enforced by `testing/verify-commands-contract.sh:190-193`, which fails if the Step 5b block exposes `~/.agents/skills/`.
3. **All existing tests pass**
   - Verified by `bash testing/verify-commands-contract.sh`.
   - Verified by `bash testing/run-all.sh` with final results: lint `1/1`, contract `41/41`, BATS `2940/2940`.

## Testing

- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/run-all.sh`
- [x] Verified the new guard reports the Step 5b checks as passing
- [x] Confirmed the contract remains registered through the existing `commands-contract` entry in `testing/list-contract-tests.sh:18`

## QA summary

| Phase | Rounds | Model | Findings |
|-------|--------|-------|----------|
| Primary QA | 3 | Claude | 0 legitimate findings |
| Cross-model QA | 1 | GPT-5.4 | 0 legitimate findings |
| Copilot PR review | 1 | Copilot | Fresh review on head `b00400c` was `COMMENTED` with 0 unresolved inline threads |

- Primary QA commits: `8578901`, `d8a1f4d`, `523f231`
- Cross-model QA commit: `b00400c`
- Copilot review result: review `4127448843` on commit `b00400c5d6014cccf61f88484544a3186f47e4a6`, no unresolved Copilot-authored threads
- False positives: none confirmed against this branch state
