### PR TITLE
fix(run-all): harden command contracts against local drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,6 @@ claude --plugin-dir /absolute/path/to/vibe-better-with-claude-code-vbw
 All `/vbw:*` commands will load from your local copy. Restart Claude Code to pick up changes after editing VBW files.
 
 > **Important:** `--plugin-dir` loads whatever is on disk in your VBW clone, which means whatever branch is currently checked out. Make sure you're on the branch with your changes before launching Claude Code — if you're on `main`, you'll be testing the unchanged version.
-
 > **Known limitation:** Plugin hooks (the 21 event handlers in `hooks.json`) resolve scripts from the marketplace cache via the symlink. This means hooks will run (unlike before the symlink existed), but they execute from your local clone — changes to hook scripts take effect immediately without a cache refresh. The git pre-push hook is a separate mechanism — see [Version Management](#version-management).
 
 ## Project Structure
@@ -86,7 +85,7 @@ All `/vbw:*` commands will load from your local copy. Restart Claude Code to pic
 ```text
 .claude-plugin/    Plugin manifest (plugin.json)
 agents/            7 agent definitions with native tool permissions
-commands/          24 slash commands (22 user-visible, 2 hidden protocol files)
+commands/          25 slash commands (23 user-visible, 2 hidden protocol files)
 config/            Default settings and stack-to-skill mappings
 hooks/             Plugin hooks (hooks.json)
 scripts/           Hook handler scripts

--- a/scripts/verify-vibe.sh
+++ b/scripts/verify-vibe.sh
@@ -13,13 +13,20 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 VIBE="$ROOT/commands/vibe.md"
 PROTOCOL="$ROOT/references/execute-protocol.md"
-COMMANDS_DIR="$ROOT/commands"
 README="$ROOT/README.md"
 CLAUDE_MD="$ROOT/CLAUDE.md"
 HELP="$ROOT/commands/help.md"
 SUGGEST="$ROOT/scripts/suggest-next.sh"
 MKT_ROOT="$ROOT/marketplace.json"
 MKT_PLUGIN="$ROOT/.claude-plugin/marketplace.json"
+
+tracked_repo_file_exists() {
+  git -C "$ROOT" ls-files --error-unmatch "$1" >/dev/null 2>&1
+}
+
+tracked_markdown_count() {
+  git -C "$ROOT" ls-files -- "$@" | wc -l | tr -d ' '
+}
 
 # Counters
 TOTAL_PASS=0
@@ -134,7 +141,7 @@ group_start "GROUP 3: Execution Protocol (REQ-16, REQ-17)"
 
 # REQ-16: execute-protocol.md in references/ (not commands/)
 check "REQ-16" "execute-protocol.md exists in references/" test -f "$PROTOCOL"
-check_absent "REQ-16" "execute-protocol.md NOT in commands/" test -f "$COMMANDS_DIR/execute-protocol.md"
+check_absent "REQ-16" "execute-protocol.md NOT in commands/" tracked_repo_file_exists "commands/execute-protocol.md"
 
 # REQ-16: No command frontmatter (no name: line)
 check_absent "REQ-16" "execute-protocol.md has no name: frontmatter" grep -q "^name:" "$PROTOCOL"
@@ -157,12 +164,11 @@ group_start "GROUP 4: Command Surface (REQ-18 to REQ-20)"
 # REQ-18: 9 absorbed commands do NOT exist
 ABSORBED=(implement plan execute assumptions add-phase insert-phase remove-phase archive audit)
 for cmd in "${ABSORBED[@]}"; do
-  check_absent "REQ-18" "commands/${cmd}.md does not exist" test -f "$COMMANDS_DIR/${cmd}.md"
+  check_absent "REQ-18" "commands/${cmd}.md does not exist" tracked_repo_file_exists "commands/${cmd}.md"
 done
 
-# REQ-18: Exact file count
-# shellcheck disable=SC2010
-CMD_COUNT=$(ls "$COMMANDS_DIR" | grep -c '\.md$')
+# REQ-18: Exact tracked file count (ignore ignored/untracked local command artifacts)
+CMD_COUNT=$(tracked_markdown_count 'commands/*.md')
 check "REQ-18" "commands/ has exactly 25 .md files (found $CMD_COUNT)" test "$CMD_COUNT" -eq 25
 
 # REQ-20: No stale "29 commands" in key files

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -15,6 +15,20 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMMANDS_DIR="$ROOT/commands"
 
+tracked_command_markdown_files() {
+  local rel
+  git -C "$ROOT" ls-files -- 'commands/*.md' 'internal/*.md' | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+TRACKED_COMMAND_MARKDOWN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_COMMAND_MARKDOWN_FILES+=("$file")
+done < <(tracked_command_markdown_files)
+
 PASS=0
 FAIL=0
 
@@ -53,8 +67,7 @@ echo "=== AskUserQuestion maxItems Contract Verification ==="
 echo ""
 echo "--- Check 1: No >4 option lists ---"
 
-for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   # Count lines with >4 options in either format (outside code fences):
@@ -124,8 +137,7 @@ done
 echo ""
 echo "--- Check 2: Numbered-list workarounds include guard language ---"
 
-for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   body=$(extract_body "$file")

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -21,11 +21,27 @@ tracked_command_markdown_files() {
   done
 }
 
+tracked_active_scan_files() {
+  local rel
+  git -C "$ROOT" ls-files -- scripts references agents templates \
+    | awk -F/ '($1 == "scripts" || $1 == "references" || $1 == "agents" || $1 == "templates") && NF <= 3 && ($NF ~ /\.sh$/ || $NF ~ /\.md$/) { print }' \
+    | while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      printf '%s\n' "$ROOT/$rel"
+    done
+}
+
 TRACKED_COMMAND_MARKDOWN_FILES=()
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   TRACKED_COMMAND_MARKDOWN_FILES+=("$file")
 done < <(tracked_command_markdown_files)
+
+TRACKED_ACTIVE_SCAN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_ACTIVE_SCAN_FILES+=("$file")
+done < <(tracked_active_scan_files)
 
 PASS=0
 FAIL=0
@@ -199,24 +215,22 @@ echo "=== Stale ACTIVE Reference Verification (scripts + references) ==="
 
 # Scan scripts and references for any runtime usage of .vbw-planning/ACTIVE
 # (session-start.sh is allowed — it only deletes the stale file)
-for scan_dir in "$ROOT/scripts" "$ROOT/references" "$ROOT/agents" "$ROOT/templates"; do
-  [ -d "$scan_dir" ] || continue
-  dir_label="$(basename "$scan_dir")"
-  while IFS= read -r -d '' scan_file; do
-    scan_base="$(basename "$scan_file")"
+for scan_file in "${TRACKED_ACTIVE_SCAN_FILES[@]}"; do
+  rel_scan_file="${scan_file#$ROOT/}"
+  dir_label="${rel_scan_file%%/*}"
+  scan_base="$(basename "$scan_file")"
 
-    # session-start.sh is allowed to reference ACTIVE (rm -f cleanup migration)
-    if [[ "$scan_base" == "session-start.sh" ]]; then
-      pass "$dir_label/$scan_base: ACTIVE reference allowed (cleanup migration)"
-      continue
-    fi
+  # session-start.sh is allowed to reference ACTIVE (rm -f cleanup migration)
+  if [[ "$scan_base" == "session-start.sh" ]]; then
+    pass "$dir_label/$scan_base: ACTIVE reference allowed (cleanup migration)"
+    continue
+  fi
 
-    if grep -qi '\.vbw-planning/ACTIVE' "$scan_file" 2>/dev/null; then
-      fail "$dir_label/$scan_base: references .vbw-planning/ACTIVE — milestone indirection was removed"
-    else
-      pass "$dir_label/$scan_base: no stale ACTIVE file references"
-    fi
-  done < <(find "$scan_dir" -maxdepth 2 -type f \( -name '*.sh' -o -name '*.md' \) -print0 2>/dev/null)
+  if grep -qi '\.vbw-planning/ACTIVE' "$scan_file" 2>/dev/null; then
+    fail "$dir_label/$scan_base: references .vbw-planning/ACTIVE — milestone indirection was removed"
+  else
+    pass "$dir_label/$scan_base: no stale ACTIVE file references"
+  fi
 done
 
 echo ""

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -13,6 +13,20 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMMANDS_DIR="$ROOT/commands"
 
+tracked_command_markdown_files() {
+  local rel
+  git -C "$ROOT" ls-files -- 'commands/*.md' 'internal/*.md' | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+TRACKED_COMMAND_MARKDOWN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_COMMAND_MARKDOWN_FILES+=("$file")
+done < <(tracked_command_markdown_files)
+
 PASS=0
 FAIL=0
 
@@ -103,8 +117,7 @@ check_allowed_tool_match() {
 echo "=== Command Contract Verification ==="
 
 # Scan both commands/ (consumer-facing) and internal/ (maintainer-only)
-for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   if [ "$(head -1 "$file" 2>/dev/null || true)" != "---" ]; then
@@ -165,8 +178,7 @@ echo "=== Milestone Context Verification ==="
 # 1. The ACTIVE milestone shell interpolation in their Context section, OR
 # 2. Bash in allowed-tools (so the agent can read ACTIVE at runtime)
 # Without either, the agent has no way to discover the active milestone slug.
-for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   # Extract body after frontmatter, excluding Context section (which contains the fix itself)
@@ -650,8 +662,7 @@ echo "=== Allowed-Tools Consistency Verification ==="
 # tools in their allowed-tools frontmatter. Keep these checks exact-pattern and
 # low-noise: match real tool-call syntax or explicit tool names, not generic
 # prose about "skills" or "search".
-for file in "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   FRONTMATTER="$(extract_frontmatter "$file")"
@@ -726,7 +737,7 @@ while IFS= read -r ref; do
   else
     fail "reference missing target: $ref -> $rel"
   fi
-done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "$COMMANDS_DIR"/*.md "$ROOT/internal"/*.md 2>/dev/null | sort -u)
+done < <(grep -RhoE '\$\{CLAUDE_PLUGIN_ROOT\}/[A-Za-z0-9._/*{}-]+' "${TRACKED_COMMAND_MARKDOWN_FILES[@]}" 2>/dev/null | sort -u)
 
 # ── UAT Remediation step 4 must use TodoWrite (not generic "task list") ──
 echo ""

--- a/testing/verify-no-inline-exec-spans.sh
+++ b/testing/verify-no-inline-exec-spans.sh
@@ -17,6 +17,34 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+tracked_markdown_files() {
+  local rel
+  git -C "$ROOT" ls-files -- 'commands/*.md' 'references/*.md' 'internal/*.md' | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+tracked_command_markdown_files() {
+  local rel
+  git -C "$ROOT" ls-files -- 'commands/*.md' | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+TRACKED_MARKDOWN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_MARKDOWN_FILES+=("$file")
+done < <(tracked_markdown_files)
+
+TRACKED_COMMAND_MARKDOWN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_COMMAND_MARKDOWN_FILES+=("$file")
+done < <(tracked_command_markdown_files)
+
 PASS=0
 FAIL=0
 WARN=0
@@ -51,54 +79,49 @@ is_known_unfixed() {
 
 echo "=== Inline Execution Span Verification (Issue #157) ==="
 
-# Scan all command, reference, and internal files
-for dir in "$ROOT/commands" "$ROOT/references" "$ROOT/internal"; do
-  [ -d "$dir" ] || continue
-  dir_label="$(basename "$dir")"
+# Scan all tracked command, reference, and internal files
+for file in "${TRACKED_MARKDOWN_FILES[@]}"; do
+  rel_file="${file#$ROOT/}"
+  dir_label="${rel_file%%/*}"
+  base="$(basename "$file" .md)"
 
-  for file in "$dir"/*.md; do
-    [ -f "$file" ] || continue
-    base="$(basename "$file" .md)"
+  # Use awk to find `!`<command> execution spans NOT inside fenced code blocks.
+  # Pattern: backtick-bang-backtick immediately followed by a command (echo, cat, ls, etc.)
+  # Excludes documentation mentions like "fenced `!` blocks" (no command follows).
+  # Fenced blocks start/end with ``` at line start.
+  inline_hits=$(awk '
+    BEGIN { in_fence = 0 }
+    /^```/ {
+      in_fence = !in_fence
+      next
+    }
+    !in_fence && /`!`[a-zA-Z$]/ {
+      print NR": "$0
+    }
+  ' "$file")
 
-    # Use awk to find `!`<command> execution spans NOT inside fenced code blocks.
-    # Pattern: backtick-bang-backtick immediately followed by a command (echo, cat, ls, etc.)
-    # Excludes documentation mentions like "fenced `!` blocks" (no command follows).
-    # Fenced blocks start/end with ``` at line start.
-    inline_hits=$(awk '
-      BEGIN { in_fence = 0 }
-      /^```/ {
-        in_fence = !in_fence
-        next
-      }
-      !in_fence && /`!`[a-zA-Z$]/ {
-        print NR": "$0
-      }
-    ' "$file")
-
-    if [ -n "$inline_hits" ]; then
-      hit_count=$(printf '%s\n' "$inline_hits" | wc -l | tr -d ' ')
-      if is_known_unfixed "$base"; then
-        warn "$dir_label/$base: $hit_count inline \`!\` span(s) — known unfixed (#157)"
-      else
-        fail "$dir_label/$base: $hit_count inline \`!\` span(s) found (dead syntax — CC does not execute inline spans)"
-        printf '%s\n' "$inline_hits" | head -5 | sed 's/^/     /'
-        if [ "$hit_count" -gt 5 ]; then
-          echo "     ... and $((hit_count - 5)) more"
-        fi
-      fi
+  if [ -n "$inline_hits" ]; then
+    hit_count=$(printf '%s\n' "$inline_hits" | wc -l | tr -d ' ')
+    if is_known_unfixed "$base"; then
+      warn "$dir_label/$base: $hit_count inline \`!\` span(s) — known unfixed (#157)"
     else
-      pass "$dir_label/$base: no inline \`!\` spans"
+      fail "$dir_label/$base: $hit_count inline \`!\` span(s) found (dead syntax — CC does not execute inline spans)"
+      printf '%s\n' "$inline_hits" | head -5 | sed 's/^/     /'
+      if [ "$hit_count" -gt 5 ]; then
+        echo "     ... and $((hit_count - 5)) more"
+      fi
     fi
-  done
+  else
+    pass "$dir_label/$base: no inline \`!\` spans"
+  fi
 done
 
 echo ""
 echo "=== Fenced Precompute Block Integrity ==="
 
-# Verify that command files with fenced !` blocks have them intact.
+# Verify that tracked command files with fenced !` blocks have them intact.
 # These are the blocks that CC template processor actually executes.
-for file in "$ROOT/commands"/*.md; do
-  [ -f "$file" ] || continue
+for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
   base="$(basename "$file" .md)"
 
   fenced_exec_count=$(awk '

--- a/testing/verify-plugin-root-resolution.sh
+++ b/testing/verify-plugin-root-resolution.sh
@@ -37,6 +37,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMMANDS_DIR="$ROOT/commands"
 REFERENCES_DIR="$ROOT/references"
+EXECUTE_PROTOCOL="$REFERENCES_DIR/execute-protocol.md"
 
 PASS=0
 FAIL=0
@@ -55,6 +56,29 @@ is_tracked_repo_file() {
   local abs="$1"
   git -C "$ROOT" ls-files --error-unmatch "${abs#$ROOT/}" >/dev/null 2>&1
 }
+
+tracked_files_for_pattern() {
+  local rel
+  git -C "$ROOT" ls-files -- "$@" | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+TRACKED_COMMAND_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_COMMAND_FILES+=("$file")
+done < <(tracked_files_for_pattern 'commands/*.md')
+
+TRACKED_REFERENCE_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_REFERENCE_FILES+=("$file")
+done < <(tracked_files_for_pattern 'references/*.md')
+
+TRACKED_COMMAND_REFERENCE_FILES=("${TRACKED_COMMAND_FILES[@]}" "${TRACKED_REFERENCE_FILES[@]}")
+TRACKED_COMMAND_EXECUTE_PROTOCOL_FILES=("${TRACKED_COMMAND_FILES[@]}" "$EXECUTE_PROTOCOL")
 
 echo "=== Plugin Root Inline Resolution Verification ==="
 
@@ -185,11 +209,10 @@ echo "=== Runtime Resolver Safety Verification ==="
 PASS=0
 FAIL=0
 
-EXECUTE_PROTOCOL="$REFERENCES_DIR/execute-protocol.md"
 PHASE_DETECTION="$REFERENCES_DIR/phase-detection.md"
 
 # Check 1: No direct $(cat /tmp/.vbw-plugin-root) execution path
-if grep -R -n '\$(cat /tmp/.vbw-plugin-root)' "$COMMANDS_DIR" "$REFERENCES_DIR" >/tmp/.vbw-plugin-runtime-grep 2>/dev/null; then
+if grep -n '\$(cat /tmp/.vbw-plugin-root)' "${TRACKED_COMMAND_REFERENCE_FILES[@]}" >/tmp/.vbw-plugin-runtime-grep 2>/dev/null; then
   fail "runtime docs contain direct \$(cat /tmp/.vbw-plugin-root) execution path"
   while IFS= read -r line; do echo "      $line"; done </tmp/.vbw-plugin-runtime-grep
 else
@@ -197,7 +220,7 @@ else
 fi
 
 # Check 2: No legacy cat /tmp/.vbw-plugin-root reader pattern (eliminated)
-if grep -R -n 'cat /tmp/.vbw-plugin-root' "$COMMANDS_DIR" | grep -v 'vbw-plugin-root-link-' >/tmp/.vbw-plugin-legacy-cat 2>/dev/null; then
+if grep -n 'cat /tmp/.vbw-plugin-root' "${TRACKED_COMMAND_FILES[@]}" 2>/dev/null | grep -v 'vbw-plugin-root-link-' >/tmp/.vbw-plugin-legacy-cat; then
   fail "commands still use legacy cat /tmp/.vbw-plugin-root reader"
   while IFS= read -r line; do echo "      $line"; done </tmp/.vbw-plugin-legacy-cat
 else
@@ -205,7 +228,7 @@ else
 fi
 
 # Check 3: No legacy temp file write (printf to /tmp/.vbw-plugin-root)
-if grep -R -n "printf.*> /tmp/.vbw-plugin-root" "$COMMANDS_DIR" >/tmp/.vbw-plugin-legacy-write 2>/dev/null; then
+if grep -n "printf.*> /tmp/.vbw-plugin-root" "${TRACKED_COMMAND_FILES[@]}" >/tmp/.vbw-plugin-legacy-write 2>/dev/null; then
   fail "commands still write to legacy /tmp/.vbw-plugin-root temp file"
   while IFS= read -r line; do echo "      $line"; done </tmp/.vbw-plugin-legacy-write
 else
@@ -213,7 +236,7 @@ else
 fi
 
 # Check 4: Canonical no-space link path exists in resolver preambles
-canonical_count=$(grep -R -c 'LINK="/tmp/.vbw-plugin-root-link-' "$COMMANDS_DIR" "$REFERENCES_DIR" 2>/dev/null | awk -F: '{s+=$NF} END{print s+0}')
+canonical_count=$(grep -c 'LINK="/tmp/.vbw-plugin-root-link-' "${TRACKED_COMMAND_REFERENCE_FILES[@]}" 2>/dev/null | awk -F: '{s+=$NF} END{print s+0}')
 if [ "$canonical_count" -ge 1 ]; then
   pass "resolver preambles emit canonical no-space link path"
 else
@@ -236,7 +259,7 @@ for file in "$COMMANDS_DIR"/*.md; do
 done
 
 # Check 6: Deterministic reader pattern uses CLAUDE_SESSION_ID
-reader_without_session=$(grep -R -n 'echo /tmp/.vbw-plugin-root-link-' "$COMMANDS_DIR" | grep -v 'CLAUDE_SESSION_ID' || true)
+reader_without_session=$(grep -n 'echo /tmp/.vbw-plugin-root-link-' "${TRACKED_COMMAND_FILES[@]}" 2>/dev/null | grep -v 'CLAUDE_SESSION_ID' || true)
 if [ -z "$reader_without_session" ]; then
   pass "all readers use CLAUDE_SESSION_ID for session isolation"
 else
@@ -325,7 +348,7 @@ for rel in "${TARGET_COMMANDS[@]}"; do
 done
 
 # Check 12: no SHA1 session key derivation in commands (reverted pattern)
-sha1_session_count=$({ grep -R -c 'SESSION_BASE.*shasum\|shasum.*SESSION' "$COMMANDS_DIR" 2>/dev/null || true; } | awk -F: '{s+=$NF} END{print s+0}')
+sha1_session_count=$({ grep -c 'SESSION_BASE.*shasum\|shasum.*SESSION' "${TRACKED_COMMAND_FILES[@]}" 2>/dev/null || true; } | awk -F: '{s+=$NF} END{print s+0}')
 if [ "$sha1_session_count" -eq 0 ]; then
   pass "no SHA1 session key derivation in commands"
 else
@@ -539,7 +562,7 @@ else
 fi
 
 # Check 17: no command preamble or execute doc retains the old shell-expanded symlink glob fallback
-old_glob_uses=$(grep -R -n '/tmp/.vbw-plugin-root-link-\*/scripts/hook-wrapper.sh' "$COMMANDS_DIR" "$EXECUTE_PROTOCOL" 2>/dev/null || true)
+old_glob_uses=$(grep -n '/tmp/.vbw-plugin-root-link-\*/scripts/hook-wrapper.sh' "${TRACKED_COMMAND_EXECUTE_PROTOCOL_FILES[@]}" 2>/dev/null || true)
 if [ -z "$old_glob_uses" ]; then
   pass "command preambles and execute-protocol no longer use shell-expanded symlink globs"
 else

--- a/testing/verify-skill-activation.sh
+++ b/testing/verify-skill-activation.sh
@@ -13,6 +13,20 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+tracked_command_reference_files() {
+  local rel
+  git -C "$ROOT" ls-files -- 'commands/*.md' 'references/*.md' | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+TRACKED_COMMAND_REFERENCE_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  TRACKED_COMMAND_REFERENCE_FILES+=("$file")
+done < <(tracked_command_reference_files)
+
 COMMAND_SKILL_CONTRACT_FILES=(
   "$ROOT/commands/vibe.md"
   "$ROOT/commands/research.md"
@@ -619,7 +633,7 @@ done
 # --- maxTurns conditional omission: all commands that spawn agents ---
 
 # Every command that references maxTurns: ${...} must also have "omit" or "do NOT include"
-_MAX_TURNS_COMMANDS=$(grep -rl 'maxTurns.*\${' "$ROOT/commands/" "$ROOT/references/" 2>/dev/null || true)
+_MAX_TURNS_COMMANDS=$(grep -l 'maxTurns.*\${' "${TRACKED_COMMAND_REFERENCE_FILES[@]}" 2>/dev/null || true)
 _MT_FAIL=0
 for _cmd_file in $_MAX_TURNS_COMMANDS; do
   _cmd_name=$(basename "$_cmd_file")
@@ -886,7 +900,7 @@ echo ""
 echo "=== Subagent Type Verification ==="
 
 # Count subagent_type occurrences across commands and references
-_SAT_TOTAL=$(grep -r 'subagent_type.*vbw:' "$ROOT/commands/" "$ROOT/references/" 2>/dev/null | wc -l | tr -d ' ')
+_SAT_TOTAL=$(grep -h 'subagent_type.*vbw:' "${TRACKED_COMMAND_REFERENCE_FILES[@]}" 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$_SAT_TOTAL" -ge 16 ]; then
   pass "subagent_type: ${_SAT_TOTAL} spawn points specify subagent_type (>= 16 expected)"


### PR DESCRIPTION
Fixes #453

## What

This PR hardens the `run-all` contract checks so they use the tracked Git inventory instead of raw working-tree directory contents when validating command markdown files. That prevents ignored or untracked local command artifacts from poisoning otherwise healthy local verification runs.

Files changed:
- `scripts/verify-vibe.sh` — move command-surface absence/count checks onto tracked Git inventory.
- `testing/verify-plugin-root-resolution.sh` — constrain command/reference scans and the old-glob check to tracked files.
- `testing/verify-commands-contract.sh` — use tracked file inventories for command scans and stale-ACTIVE verification; also preserve the new `skills.md` Step 5b contract added on `main` during overlap resolution.
- `testing/verify-askuserquestion-contract.sh` — use tracked command/internal markdown inventory.
- `testing/verify-no-inline-exec-spans.sh` — use tracked command/reference/internal markdown inventory.
- `testing/verify-skill-activation.sh` — use tracked command/reference inventory for the remaining grep-based command/reference checks.
- `CONTRIBUTING.md` — sync tracked command-count prose to the live `25 total / 23 user-visible / 2 hidden` inventory.

## Why

The bug was local-checkout contamination, not broken committed `main`. Several contract scripts treated whatever happened to be on disk under `commands/` as part of the repo contract, so ignored or untracked scratch files could make `bash testing/run-all.sh` fail spuriously.

The architectural fix is to make Git-tracked files the source of truth for these contract checks. That removes the contamination vector for the reported failures and closes the same bug class in adjacent contract scripts that feed `run-all`.

## How

- `scripts/verify-vibe.sh`: added tracked-file helpers and switched the command-absence/count checks from raw filesystem probes to `git ls-files`-backed lookups.
- `testing/verify-plugin-root-resolution.sh`: added tracked command/reference arrays and moved the runtime and behavioral grep checks onto those arrays instead of raw directory recursion.
- `testing/verify-commands-contract.sh`: added tracked command and tracked scan inventories, replaced raw command/internal loops, replaced the stale-ACTIVE `find` walk with a tracked-file scan, merged `main`’s new `skills.md` Step 5b verification block, and kept the merge result hermetic.
- `testing/verify-askuserquestion-contract.sh`: replaced raw command/internal loops with tracked markdown arrays.
- `testing/verify-no-inline-exec-spans.sh`: replaced raw command/reference/internal loops with tracked markdown arrays and kept the commands-only fenced-block verification scoped to tracked command files.
- `testing/verify-skill-activation.sh`: replaced the remaining raw command/reference recursive greps used for `maxTurns` and `subagent_type` contract checks with tracked-file arrays.
- `CONTRIBUTING.md`: updated the project-structure command count to match the tracked tree.

## Acceptance criteria verification

1. `scripts/verify-vibe.sh` uses the tracked Git inventory for command-surface verification instead of raw `commands/` filesystem counts.
   - Satisfied by `scripts/verify-vibe.sh` lines 23-27, 144, 167, and 171-172.
2. `testing/verify-plugin-root-resolution.sh` does not report `found old shell-expanded symlink glob fallback` solely because an ignored or untracked local command file exists in `commands/`.
   - Satisfied by `testing/verify-plugin-root-resolution.sh` lines 60-81, 215-239, and 565.
3. `testing/verify-commands-contract.sh` and `testing/verify-askuserquestion-contract.sh` ignore ignored/untracked local command markdown files and operate on tracked repo files only.
   - Satisfied by `testing/verify-commands-contract.sh` lines 16-44, 136, 235, 256, 717, and 792.
   - Satisfied by `testing/verify-askuserquestion-contract.sh` lines 18-30, 70, and 140.
4. The tracked command inventory remains `25` total command markdown files, and tracked command-count prose matches that inventory.
   - Satisfied by `CONTRIBUTING.md` line 88 and `README.md` line 1046; tracked inventory remains 25 files.
5. `bash testing/run-all.sh` exits `0` on the issue branch after the fix.
   - Satisfied by the final local `bash testing/run-all.sh` run on this branch: lint `1/1`, contract `41/41`, BATS `2942/2942`.
6. A temporary local contamination repro no longer causes the targeted contract scripts to fail.
   - Satisfied by local repros with temporary untracked `commands/diag-session-key.md`, `commands/implement.md`, and `commands/temp-inline.md`; the targeted scripts and final `run-all` stayed green.

## Testing

- [x] `bash scripts/verify-vibe.sh`
- [x] `bash testing/verify-plugin-root-resolution.sh`
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/verify-askuserquestion-contract.sh`
- [x] `bash testing/verify-no-inline-exec-spans.sh`
- [x] `bash testing/verify-skill-activation.sh`
- [x] `bash testing/run-all.sh`
- [x] Local contamination repro with temporary untracked `commands/diag-session-key.md` and `commands/implement.md`
- [x] Local contamination repro with temporary untracked `commands/temp-inline.md`

## QA summary

- Primary QA rounds completed: 4 via `qa-investigator`
  - Round 1: clean
  - Round 2: fixed 1 low-severity contract finding in `testing/verify-commands-contract.sh`
  - Round 3: fixed 1 medium-severity contract finding in `testing/verify-no-inline-exec-spans.sh` and swept the same bug class in `testing/verify-skill-activation.sh`
  - Round 4: clean
- Cross-model QA rounds completed: 1 via `qa-investigator-gpt-54` (GPT-5.4), clean
- Copilot PR review rounds completed: 1 clean round (`COMMENTED`, 0 inline comments, 0 unresolved threads)
- Findings fixed vs false positives:
  - Primary QA: 2 legitimate findings fixed, 0 false positives
  - Cross-model QA: 0 findings
  - Copilot review: 0 findings
- CI/CD status: all required GitHub Actions checks are green on the current head
