### PR TITLE
Fail closed on degraded known-issues status probes

### DIFF
--- a/scripts/phase-detect.sh
+++ b/scripts/phase-detect.sh
@@ -213,8 +213,8 @@ restore_known_issues_from_verification_if_needed() {
 
   known_meta=$(bash "$_SCRIPT_DIR_PD/track-known-issues.sh" status "$phase_dir" 2>/dev/null || true)
   known_status=$(printf '%s\n' "$known_meta" | awk -F= '/^known_issues_status=/{print $2; exit}')
-  case "${known_status:-missing}" in
-    missing|malformed)
+  case "${known_status:-}" in
+    missing)
       bash "$_SCRIPT_DIR_PD/track-known-issues.sh" sync-verification "$phase_dir" "$verification_file" >/dev/null 2>&1 || true
       bash "$_SCRIPT_DIR_PD/track-known-issues.sh" promote-todos "$phase_dir" >/dev/null 2>&1 || true
       ;;

--- a/scripts/qa-result-gate.sh
+++ b/scripts/qa-result-gate.sh
@@ -1235,17 +1235,40 @@ KNOWN_ISSUES_COUNT=0
 if [ -f "$SCRIPT_DIR/track-known-issues.sh" ]; then
   _known_issues_meta=$(bash "$SCRIPT_DIR/track-known-issues.sh" status "$PHASE_DIR" 2>/dev/null || true)
   _known_issues_status=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_status=/{print $2; exit}')
+  _known_issues_count_raw=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_count=/{print $2; exit}')
   case "${_known_issues_status:-}" in
     present|missing|malformed)
-      KNOWN_ISSUES_STATUS="$_known_issues_status"
+      case "${_known_issues_count_raw:-}" in
+        '')
+          if [ "$_known_issues_status" = "present" ]; then
+            KNOWN_ISSUES_STATUS="probe_error"
+            KNOWN_ISSUES_COUNT=0
+          else
+            KNOWN_ISSUES_STATUS="$_known_issues_status"
+            KNOWN_ISSUES_COUNT=0
+          fi
+          ;;
+        *[!0-9]*)
+          KNOWN_ISSUES_STATUS="probe_error"
+          KNOWN_ISSUES_COUNT=0
+          ;;
+        *)
+          if [ "$_known_issues_status" != "present" ] && [ "$_known_issues_count_raw" -gt 0 ] 2>/dev/null; then
+            KNOWN_ISSUES_STATUS="probe_error"
+            KNOWN_ISSUES_COUNT=0
+          else
+            KNOWN_ISSUES_STATUS="$_known_issues_status"
+            KNOWN_ISSUES_COUNT="$_known_issues_count_raw"
+          fi
+          ;;
+      esac
       ;;
     *)
       KNOWN_ISSUES_STATUS="probe_error"
+      KNOWN_ISSUES_COUNT=0
       ;;
   esac
-  KNOWN_ISSUES_COUNT=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_count=/{print $2; exit}')
 fi
-KNOWN_ISSUES_COUNT="${KNOWN_ISSUES_COUNT:-0}"
 
 # Count non-placeholder deviations across SUMMARY.md files in a given directory.
 # Uses the same AWK extraction logic as execute-protocol.md Step 4.

--- a/scripts/qa-result-gate.sh
+++ b/scripts/qa-result-gate.sh
@@ -1270,6 +1270,19 @@ if [ -f "$SCRIPT_DIR/track-known-issues.sh" ]; then
   esac
 fi
 
+if [ "$KNOWN_ISSUES_STATUS" = "probe_error" ]; then
+  _known_issues_registry_json=$(load_known_issue_registry_json "$PHASE_DIR/known-issues.json")
+  _known_issues_registry_count=$(json_object_array_length "${_known_issues_registry_json:-[]}")
+  case "${_known_issues_registry_count:-}" in
+    ''|*[!0-9]*)
+      KNOWN_ISSUES_COUNT=0
+      ;;
+    *)
+      KNOWN_ISSUES_COUNT="$_known_issues_registry_count"
+      ;;
+  esac
+fi
+
 # Count non-placeholder deviations across SUMMARY.md files in a given directory.
 # Uses the same AWK extraction logic as execute-protocol.md Step 4.
 # Arguments: $1 = directory to scan for SUMMARY.md files

--- a/scripts/qa-result-gate.sh
+++ b/scripts/qa-result-gate.sh
@@ -1234,10 +1234,17 @@ KNOWN_ISSUES_STATUS="missing"
 KNOWN_ISSUES_COUNT=0
 if [ -f "$SCRIPT_DIR/track-known-issues.sh" ]; then
   _known_issues_meta=$(bash "$SCRIPT_DIR/track-known-issues.sh" status "$PHASE_DIR" 2>/dev/null || true)
-  KNOWN_ISSUES_STATUS=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_status=/{print $2; exit}')
+  _known_issues_status=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_status=/{print $2; exit}')
+  case "${_known_issues_status:-}" in
+    present|missing|malformed)
+      KNOWN_ISSUES_STATUS="$_known_issues_status"
+      ;;
+    *)
+      KNOWN_ISSUES_STATUS="probe_error"
+      ;;
+  esac
   KNOWN_ISSUES_COUNT=$(printf '%s\n' "${_known_issues_meta:-}" | awk -F= '/^known_issues_count=/{print $2; exit}')
 fi
-KNOWN_ISSUES_STATUS="${KNOWN_ISSUES_STATUS:-missing}"
 KNOWN_ISSUES_COUNT="${KNOWN_ISSUES_COUNT:-0}"
 
 # Count non-placeholder deviations across SUMMARY.md files in a given directory.
@@ -1705,6 +1712,9 @@ case "$RESULT" in
       elif [ "$PLAN_COUNT" -gt 0 ] && [ "$PLANS_VERIFIED_COUNT" -lt "$PLAN_COUNT" ]; then
         echo "qa_gate_plan_coverage=${PLANS_VERIFIED_COUNT}/${PLAN_COUNT}"
         echo "qa_gate_routing=QA_RERUN_REQUIRED"
+      elif [ "$KNOWN_ISSUES_STATUS" = "malformed" ] || [ "$KNOWN_ISSUES_STATUS" = "probe_error" ]; then
+        echo "qa_gate_known_issues_override=true"
+        echo "qa_gate_routing=REMEDIATION_REQUIRED"
       elif [ "$KNOWN_ISSUES_STATUS" = "present" ] && [ "$KNOWN_ISSUES_COUNT" -gt 0 ] 2>/dev/null; then
         # Metadata-only round claims clean, but known issues exist in registry.
         # Apply the same coverage guard as the non-metadata-only known-issues path:
@@ -1728,7 +1738,7 @@ case "$RESULT" in
       # 5b. PASS but incomplete plan coverage → QA skipped some plans
       echo "qa_gate_plan_coverage=${PLANS_VERIFIED_COUNT}/${PLAN_COUNT}"
       echo "qa_gate_routing=QA_RERUN_REQUIRED"
-    elif [ "$KNOWN_ISSUES_STATUS" = "malformed" ]; then
+    elif [ "$KNOWN_ISSUES_STATUS" = "malformed" ] || [ "$KNOWN_ISSUES_STATUS" = "probe_error" ]; then
       echo "qa_gate_known_issues_override=true"
       echo "qa_gate_routing=REMEDIATION_REQUIRED"
     elif [ "$KNOWN_ISSUES_STATUS" = "present" ] && [ "$KNOWN_ISSUES_COUNT" -gt 0 ] 2>/dev/null; then

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2378,6 +2378,63 @@ EOF
   echo "$output" | grep -q "qa_attention_status=failed"
 }
 
+@test "known-issues status probe failure still emits failed QA-attention for later backlog" {
+  echo "# My Project" > .vbw-planning/PROJECT.md
+
+  mkdir -p .vbw-planning/phases/01-unplanned
+
+  mkdir -p .vbw-planning/phases/02-known-issues
+  echo "# Plan" > .vbw-planning/phases/02-known-issues/02-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/02-known-issues/02-SUMMARY.md
+  current_commit="$(git rev-parse HEAD)"
+  printf '%s\n' '---' 'result: PASS' 'writer: write-verification.sh' 'plans_verified:' '  - 02' "verified_at_commit: ${current_commit}" '---' '# Verification' 'Passed.' > .vbw-planning/phases/02-known-issues/02-VERIFICATION.md
+  cat > .vbw-planning/phases/02-known-issues/known-issues.json <<'EOF'
+{
+  "schema_version": 1,
+  "phase": "02",
+  "issues": [
+    {
+      "test": "FIGIRegistryServiceTests",
+      "file": "Tests/FIGIRegistryServiceTests.swift",
+      "error": "compositeFigi missing",
+      "first_seen_in": "02-01-SUMMARY.md",
+      "last_seen_in": "02-VERIFICATION.md",
+      "first_seen_round": 0,
+      "last_seen_round": 0,
+      "times_seen": 2
+    }
+  ]
+}
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_TEMP_DIR/scripts-phase-detect-known-issues-probe-fail"
+  cp -R "$SCRIPTS_DIR" "$shim_dir"
+  cat > "$shim_dir/track-known-issues.sh" <<EOF
+#!/usr/bin/env bash
+cmd="\${1:-}"
+case "\$cmd" in
+  status)
+    exit 23
+    ;;
+  *)
+    exec "$SCRIPTS_DIR/track-known-issues.sh" "\$@"
+    ;;
+esac
+EOF
+  chmod +x "$shim_dir/track-known-issues.sh"
+
+  run_phase_detect "$shim_dir"
+
+  [ "$status" -eq 0 ]
+  [ -f .vbw-planning/phases/02-known-issues/known-issues.json ]
+  echo "$output" | grep -q "next_phase=01"
+  echo "$output" | grep -q "next_phase_state=needs_plan_and_execute"
+  echo "$output" | grep -q "first_qa_attention_phase=02"
+  echo "$output" | grep -q "first_qa_attention_slug=02-known-issues"
+  echo "$output" | grep -q "qa_attention_status=failed"
+}
+
 @test "later active QA remediation outranks earlier mid-execution phase" {
   echo "# My Project" > .vbw-planning/PROJECT.md
 

--- a/tests/phase-detect.bats
+++ b/tests/phase-detect.bats
@@ -2435,6 +2435,64 @@ EOF
   echo "$output" | grep -q "qa_attention_status=failed"
 }
 
+@test "partial known-issues status payload still emits failed QA-attention for later backlog" {
+  echo "# My Project" > .vbw-planning/PROJECT.md
+
+  mkdir -p .vbw-planning/phases/01-unplanned
+
+  mkdir -p .vbw-planning/phases/02-known-issues
+  echo "# Plan" > .vbw-planning/phases/02-known-issues/02-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' '# Summary' 'Done.' > .vbw-planning/phases/02-known-issues/02-SUMMARY.md
+  current_commit="$(git rev-parse HEAD)"
+  printf '%s\n' '---' 'result: PASS' 'writer: write-verification.sh' 'plans_verified:' '  - 02' "verified_at_commit: ${current_commit}" '---' '# Verification' 'Passed.' > .vbw-planning/phases/02-known-issues/02-VERIFICATION.md
+  cat > .vbw-planning/phases/02-known-issues/known-issues.json <<'EOF'
+{
+  "schema_version": 1,
+  "phase": "02",
+  "issues": [
+    {
+      "test": "FIGIRegistryServiceTests",
+      "file": "Tests/FIGIRegistryServiceTests.swift",
+      "error": "compositeFigi missing",
+      "first_seen_in": "02-01-SUMMARY.md",
+      "last_seen_in": "02-VERIFICATION.md",
+      "first_seen_round": 0,
+      "last_seen_round": 0,
+      "times_seen": 2
+    }
+  ]
+}
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_TEMP_DIR/scripts-phase-detect-known-issues-partial-payload"
+  cp -R "$SCRIPTS_DIR" "$shim_dir"
+  cat > "$shim_dir/track-known-issues.sh" <<'EOF'
+#!/usr/bin/env bash
+cmd="${1:-}"
+case "$cmd" in
+  status)
+    printf 'known_issues_status=present\n'
+    exit 0
+    ;;
+  *)
+    exec "$VBW_TEST_TRACK_KNOWN_ISSUES" "$@"
+    ;;
+esac
+EOF
+  chmod +x "$shim_dir/track-known-issues.sh"
+
+  VBW_TEST_TRACK_KNOWN_ISSUES="$SCRIPTS_DIR/track-known-issues.sh" run_phase_detect "$shim_dir"
+
+  [ "$status" -eq 0 ]
+  [ -f .vbw-planning/phases/02-known-issues/known-issues.json ]
+  echo "$output" | grep -q "next_phase=01"
+  echo "$output" | grep -q "next_phase_state=needs_plan_and_execute"
+  echo "$output" | grep -q "first_qa_attention_phase=02"
+  echo "$output" | grep -q "first_qa_attention_slug=02-known-issues"
+  echo "$output" | grep -q "qa_attention_status=failed"
+}
+
 @test "later active QA remediation outranks earlier mid-execution phase" {
   echo "# My Project" > .vbw-planning/PROJECT.md
 

--- a/tests/qa-result-gate.bats
+++ b/tests/qa-result-gate.bats
@@ -3676,7 +3676,7 @@ EOF
   run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"qa_gate_known_issue_count=0"* ]]
+  [[ "$output" == *"qa_gate_known_issue_count=1"* ]]
   [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
   [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
 }
@@ -3723,6 +3723,7 @@ EOF
   VBW_TEST_TRACK_KNOWN_ISSUES="$REPO_ROOT/scripts/track-known-issues.sh" run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
+  [[ "$output" == *"qa_gate_known_issue_count=1"* ]]
   [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
   [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
 }
@@ -3769,6 +3770,7 @@ EOF
   VBW_TEST_TRACK_KNOWN_ISSUES="$REPO_ROOT/scripts/track-known-issues.sh" run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
+  [[ "$output" == *"qa_gate_known_issue_count=1"* ]]
   [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
   [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
 }

--- a/tests/qa-result-gate.bats
+++ b/tests/qa-result-gate.bats
@@ -3681,6 +3681,98 @@ EOF
   [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
 }
 
+@test "PASS with partial known-issues status payload missing count fails closed to remediation" {
+  create_verif "write-verification.sh" "PASS"
+  cat > "$PHASE_DIR/known-issues.json" <<'EOF'
+{
+  "schema_version": 1,
+  "phase": "01",
+  "issues": [
+    {
+      "test": "FIGIRegistryServiceTests",
+      "file": "Tests/FIGIRegistryServiceTests.swift",
+      "error": "compositeFigi missing",
+      "first_seen_in": "01-01-SUMMARY.md",
+      "last_seen_in": "01-VERIFICATION.md",
+      "first_seen_round": 0,
+      "last_seen_round": 0,
+      "times_seen": 2
+    }
+  ]
+}
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_DIR/scripts-known-issues-partial-payload-missing-count"
+  cp -R "$REPO_ROOT/scripts" "$shim_dir"
+  cat > "$shim_dir/track-known-issues.sh" <<'EOF'
+#!/usr/bin/env bash
+cmd="${1:-}"
+case "$cmd" in
+  status)
+    printf 'known_issues_status=present\n'
+    exit 0
+    ;;
+  *)
+    exec "$VBW_TEST_TRACK_KNOWN_ISSUES" "$@"
+    ;;
+esac
+EOF
+  chmod +x "$shim_dir/track-known-issues.sh"
+
+  VBW_TEST_TRACK_KNOWN_ISSUES="$REPO_ROOT/scripts/track-known-issues.sh" run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
+  [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
+}
+
+@test "PASS with partial known-issues status payload non-numeric count fails closed to remediation" {
+  create_verif "write-verification.sh" "PASS"
+  cat > "$PHASE_DIR/known-issues.json" <<'EOF'
+{
+  "schema_version": 1,
+  "phase": "01",
+  "issues": [
+    {
+      "test": "FIGIRegistryServiceTests",
+      "file": "Tests/FIGIRegistryServiceTests.swift",
+      "error": "compositeFigi missing",
+      "first_seen_in": "01-01-SUMMARY.md",
+      "last_seen_in": "01-VERIFICATION.md",
+      "first_seen_round": 0,
+      "last_seen_round": 0,
+      "times_seen": 2
+    }
+  ]
+}
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_DIR/scripts-known-issues-partial-payload-bad-count"
+  cp -R "$REPO_ROOT/scripts" "$shim_dir"
+  cat > "$shim_dir/track-known-issues.sh" <<'EOF'
+#!/usr/bin/env bash
+cmd="${1:-}"
+case "$cmd" in
+  status)
+    printf 'known_issues_status=present\nknown_issues_count=abc\n'
+    exit 0
+    ;;
+  *)
+    exec "$VBW_TEST_TRACK_KNOWN_ISSUES" "$@"
+    ;;
+esac
+EOF
+  chmod +x "$shim_dir/track-known-issues.sh"
+
+  VBW_TEST_TRACK_KNOWN_ISSUES="$REPO_ROOT/scripts/track-known-issues.sh" run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
+  [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
+}
+
 @test "remediation round PASS with malformed known-issues registry fails closed" {
   create_verif "write-verification.sh" "FAIL" "## Must-Have Checks
 | ID | Category | Description | Status | Evidence |

--- a/tests/qa-result-gate.bats
+++ b/tests/qa-result-gate.bats
@@ -3635,6 +3635,52 @@ EOF
   [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
 }
 
+@test "PASS with known-issues status probe failure fails closed to remediation" {
+  create_verif "write-verification.sh" "PASS"
+  cat > "$PHASE_DIR/known-issues.json" <<'EOF'
+{
+  "schema_version": 1,
+  "phase": "01",
+  "issues": [
+    {
+      "test": "FIGIRegistryServiceTests",
+      "file": "Tests/FIGIRegistryServiceTests.swift",
+      "error": "compositeFigi missing",
+      "first_seen_in": "01-01-SUMMARY.md",
+      "last_seen_in": "01-VERIFICATION.md",
+      "first_seen_round": 0,
+      "last_seen_round": 0,
+      "times_seen": 2
+    }
+  ]
+}
+EOF
+
+  local shim_dir
+  shim_dir="$TEST_DIR/scripts-known-issues-probe-fail"
+  cp -R "$REPO_ROOT/scripts" "$shim_dir"
+  cat > "$shim_dir/track-known-issues.sh" <<EOF
+#!/usr/bin/env bash
+cmd="\${1:-}"
+case "\$cmd" in
+  status)
+    exit 23
+    ;;
+  *)
+    exec "$REPO_ROOT/scripts/track-known-issues.sh" "\$@"
+    ;;
+esac
+EOF
+  chmod +x "$shim_dir/track-known-issues.sh"
+
+  run bash "$shim_dir/qa-result-gate.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"qa_gate_known_issue_count=0"* ]]
+  [[ "$output" == *"qa_gate_known_issues_override=true"* ]]
+  [[ "$output" == *"qa_gate_routing=REMEDIATION_REQUIRED"* ]]
+}
+
 @test "remediation round PASS with malformed known-issues registry fails closed" {
   create_verif "write-verification.sh" "FAIL" "## Must-Have Checks
 | ID | Category | Description | Status | Evidence |


### PR DESCRIPTION
## Linked Issue

Fixes #450

## What

This change hardens the known-issues QA-attention path so degraded `track-known-issues.sh status` output can no longer make a real backlog disappear from routing. It updates the direct QA gate in `scripts/qa-result-gate.sh`, keeps `scripts/phase-detect.sh` from treating anything except an explicit `missing` registry as a safe restore trigger, and adds regression coverage at both the gate layer and the end-to-end phase-detect layer.

Files modified:
- `scripts/phase-detect.sh`
- `scripts/qa-result-gate.sh`
- `tests/phase-detect.bats`
- `tests/qa-result-gate.bats`

## Why

Issue #450 was a fail-open contract bug in the known-issues routing path. The original symptom was an intermittent missing `first_qa_attention_phase=02` under the local parallel runner. The root cause fixed here is that a degraded helper probe could be interpreted as “missing/clean” instead of “untrusted,” which let PASS routing bypass a real known-issues backlog. The chosen fix keeps the contract deterministic and fail-closed in the gate instead of weakening the flaky test or special-casing one reproducer.

## How

- `scripts/phase-detect.sh`: narrowed detect-time restore so only an explicit `known_issues_status=missing` triggers a restore; malformed or empty probe output no longer counts as a safe rebuild signal.
- `scripts/qa-result-gate.sh`: hardened status parsing so empty, unknown, and partial `track-known-issues.sh status` payloads become `probe_error` and route to `REMEDIATION_REQUIRED` instead of falling through as clean PASS.
- `tests/phase-detect.bats`: added end-to-end regressions for empty probe output and partial `known_issues_status=present` payloads while preserving the original #450 routing contract.
- `tests/qa-result-gate.bats`: added direct gate regressions for empty probe output, malformed registry state, and partial payloads with missing or non-numeric counts.

## Acceptance criteria verification

The issue does not provide a numbered acceptance checklist, so this PR maps the bug contract into explicit verifiable criteria:

1. A transient or empty `track-known-issues.sh status` probe must not make a real known-issues backlog disappear from QA routing.
   - Satisfied by: `scripts/qa-result-gate.sh` fail-closed parsing of empty/unknown status output and `scripts/phase-detect.sh` preserving QA attention when the gate returns remediation.
   - Verified by: `tests/qa-result-gate.bats` test `PASS with known-issues status probe failure fails closed to remediation` and `tests/phase-detect.bats` test `known-issues status probe failure still emits failed QA-attention for later backlog`.

2. Partial status payloads must also fail closed, including `known_issues_status=present` without a trustworthy numeric count.
   - Satisfied by: `scripts/qa-result-gate.sh` validating both `known_issues_status` and `known_issues_count` before trusting the probe.
   - Verified by: `tests/qa-result-gate.bats` tests `PASS with partial known-issues status payload missing count fails closed to remediation` and `PASS with partial known-issues status payload non-numeric count fails closed to remediation`.

3. The original #450 routing outcome must remain intact.
   - Satisfied by: unchanged phase-detect priority ordering plus fail-closed QA gate behavior.
   - Verified by: `tests/phase-detect.bats` tests `earlier unfinished work still emits failed QA-attention for later stage-less known-issues backlog` and `partial known-issues status payload still emits failed QA-attention for later backlog`.

4. Adjacent known-issues routing must not regress for the sibling #451 path or the older #414 gate path.
   - Satisfied by: preserving `scripts/phase-detect.sh` routing logic outside the known-issues probe contract and only tightening the gate’s trust checks.
   - Verified by: `tests/phase-detect.bats` tests `later active QA remediation backed by known issues outranks earlier unplanned phase` and `qa_status is pending when structured phase PASS fails qa-result-gate`.

5. The full local suite must remain green on the final branch tip.
   - Satisfied by: no behavior changes outside the gate/parser contract and matching regression coverage.
   - Verified by: `bash testing/run-all.sh` on the final synced branch tip (`Lint 1/1`, `Contract 41/41`, `BATS 2947/2947`).

## Testing

- `bash testing/run-all.sh`
- `bats tests/qa-result-gate.bats --filter 'PASS with known-issues status probe failure fails closed to remediation'`
- `bats tests/qa-result-gate.bats --filter 'PASS with partial known-issues status payload missing count fails closed to remediation'`
- `bats tests/qa-result-gate.bats --filter 'PASS with partial known-issues status payload non-numeric count fails closed to remediation'`
- `bats tests/phase-detect.bats --filter 'known-issues status probe failure still emits failed QA-attention for later backlog'`
- `bats tests/phase-detect.bats --filter 'partial known-issues status payload still emits failed QA-attention for later backlog'`
- `bats tests/phase-detect.bats --filter 'earlier unfinished work still emits failed QA-attention for later stage-less known-issues backlog'`

## QA summary

- Primary QA (`qa-investigator`): 3 rounds completed.
  - Round 1: clean — recorded in `fix(phase-detect): address QA round 1` (`4bd7e3e`)
  - Round 2: clean — recorded in `fix(phase-detect): address QA round 2` (`0843231`)
  - Round 3: clean — recorded in `fix(phase-detect): address QA round 3` (`6354f31`)
- Cross-model QA (`qa-investigator-gpt-54` / GPT-5.4): 2 rounds completed.
  - Round 1: 1 legitimate low contract finding (partial `known_issues_status=present` payload could still fail open). Fixed in `fix(phase-detect): address cross-model QA round 1` (`541eee7`).
  - Round 2: clean — recorded in `fix(phase-detect): address cross-model QA round 2` (`dd6cb64`)
- Copilot PR review: 1 round completed on commit `dd6cb64e3af0c2b954b4346bca113c4eae7443f0`.
  - Review result: `COMMENTED` overview-only review from `copilot-pull-request-reviewer[bot]`
  - Inline findings: 0
  - Threads requiring fixes: 0
- GitHub Actions status: all required checks green, including `Linked Issue Check`, `QA Review Evidence`, `Lint`, `Contract Tests`, `Bats Tests`, and `Copilot code review`.