### PR TITLE
fix(tests): stabilize hook-wrapper cache env isolation

### DIFF
--- a/tests/sessionstart-compact-hooks.bats
+++ b/tests/sessionstart-compact-hooks.bats
@@ -400,6 +400,7 @@ MOCK
 
 @test "hook-wrapper: falls back to CLAUDE_PLUGIN_ROOT when cache is empty" {
   cd "$TEST_TEMP_DIR"
+  local claude_dir="$TEST_TEMP_DIR/empty-claude"
   # Set up: no cache, but CLAUDE_PLUGIN_ROOT points to real scripts
   mkdir -p "$TEST_TEMP_DIR/fake-plugin/scripts"
   cp "$SCRIPTS_DIR/hook-wrapper.sh" "$TEST_TEMP_DIR/fake-plugin/scripts/"
@@ -411,24 +412,26 @@ exit 0
 MOCK
   chmod +x "$TEST_TEMP_DIR/fake-plugin/scripts/mock-ok.sh"
 
-  # HOME points to empty dir (no cache), CLAUDE_PLUGIN_ROOT points to fake plugin
-  run bash -c "export HOME='$TEST_TEMP_DIR/empty-home'; export CLAUDE_PLUGIN_ROOT='$TEST_TEMP_DIR/fake-plugin'; bash '$TEST_TEMP_DIR/fake-plugin/scripts/hook-wrapper.sh' mock-ok.sh"
+  # hook-wrapper resolves CLAUDE_CONFIG_DIR before HOME, so set it explicitly
+  # to keep inherited worker env from redirecting cache resolution.
+  run bash -c "export HOME='$TEST_TEMP_DIR/empty-home'; export CLAUDE_CONFIG_DIR='$claude_dir'; export CLAUDE_PLUGIN_ROOT='$TEST_TEMP_DIR/fake-plugin'; bash '$TEST_TEMP_DIR/fake-plugin/scripts/hook-wrapper.sh' mock-ok.sh"
   [ "$status" -eq 0 ]
   [[ "$output" == *"OK from plugin root"* ]]
 }
 
 @test "hook-wrapper: prefers cache over CLAUDE_PLUGIN_ROOT when both exist" {
   cd "$TEST_TEMP_DIR"
+  local claude_dir="$TEST_TEMP_DIR/.claude"
   # Set up cache with a script
-  mkdir -p "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts"
-  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
-  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
-  cat > "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/mock-source.sh" <<'MOCK'
+  mkdir -p "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts"
+  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cat > "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/mock-source.sh" <<'MOCK'
 #!/bin/bash
 echo "FROM_CACHE"
 exit 0
 MOCK
-  chmod +x "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/mock-source.sh"
+  chmod +x "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/mock-source.sh"
 
   # Also set up CLAUDE_PLUGIN_ROOT with a different script
   mkdir -p "$TEST_TEMP_DIR/fake-plugin/scripts"
@@ -440,7 +443,7 @@ MOCK
   chmod +x "$TEST_TEMP_DIR/fake-plugin/scripts/mock-source.sh"
 
   # Cache should win
-  run bash -c "export HOME='$TEST_TEMP_DIR'; export CLAUDE_PLUGIN_ROOT='$TEST_TEMP_DIR/fake-plugin'; bash '$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' mock-source.sh"
+  run bash -c "export HOME='$TEST_TEMP_DIR'; export CLAUDE_CONFIG_DIR='$claude_dir'; export CLAUDE_PLUGIN_ROOT='$TEST_TEMP_DIR/fake-plugin'; bash '$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' mock-source.sh"
   [ "$status" -eq 0 ]
   [[ "$output" == *"FROM_CACHE"* ]]
 }
@@ -465,15 +468,16 @@ MOCK
   # Verify that the hook-wrapper exit-code logic preserves exit 2
   # (This tests the actual hook-wrapper.sh, not the mock)
   cd "$TEST_TEMP_DIR"
+  local claude_dir="$TEST_TEMP_DIR/.claude"
 
   # Create a fake plugin cache with the real hook-wrapper and security-filter
-  mkdir -p "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts"
-  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
-  cp "$SCRIPTS_DIR/security-filter.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
-  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  mkdir -p "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts"
+  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/security-filter.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
 
   INPUT='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
-  run bash -c "export HOME='$TEST_TEMP_DIR'; echo '$INPUT' | bash '$TEST_TEMP_DIR/.claude/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' security-filter.sh"
+  run bash -c "export HOME='$TEST_TEMP_DIR'; export CLAUDE_CONFIG_DIR='$claude_dir'; echo '$INPUT' | bash '$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' security-filter.sh"
   [ "$status" -eq 2 ]
 }
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -18,7 +18,17 @@ setup_temp_dir() {
   export _ORIG_HOME="${HOME:-}"
   export _ORIG_GIT_CONFIG_NOSYSTEM="${GIT_CONFIG_NOSYSTEM:-}"
   export _ORIG_GIT_CONFIG_GLOBAL="${GIT_CONFIG_GLOBAL:-}"
+  if [ "${CLAUDE_CONFIG_DIR+x}" = "x" ]; then
+    export _ORIG_CLAUDE_CONFIG_DIR_WAS_SET=1
+    export _ORIG_CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR}"
+  else
+    export _ORIG_CLAUDE_CONFIG_DIR_WAS_SET=0
+    unset _ORIG_CLAUDE_CONFIG_DIR 2>/dev/null || true
+  fi
   export HOME="$TEST_TEMP_DIR"
+  # Scripts that source resolve-claude-dir.sh prefer CLAUDE_CONFIG_DIR over HOME,
+  # so clear inherited host config unless a test opts back in explicitly.
+  unset CLAUDE_CONFIG_DIR 2>/dev/null || true
   export GIT_CONFIG_NOSYSTEM=1
   export GIT_CONFIG_GLOBAL="$TEST_TEMP_DIR/.gitconfig"
   mkdir -p "$TEST_TEMP_DIR/.vbw-planning"
@@ -28,6 +38,11 @@ setup_temp_dir() {
 teardown_temp_dir() {
   [ -n "${TEST_TEMP_DIR:-}" ] && rm -rf "$TEST_TEMP_DIR"
   HOME="$_ORIG_HOME"
+  if [ "${_ORIG_CLAUDE_CONFIG_DIR_WAS_SET:-0}" = "1" ]; then
+    export CLAUDE_CONFIG_DIR="${_ORIG_CLAUDE_CONFIG_DIR-}"
+  else
+    unset CLAUDE_CONFIG_DIR 2>/dev/null || true
+  fi
   if [ -n "$_ORIG_GIT_CONFIG_NOSYSTEM" ]; then
     GIT_CONFIG_NOSYSTEM="$_ORIG_GIT_CONFIG_NOSYSTEM"
   else
@@ -38,7 +53,7 @@ teardown_temp_dir() {
   else
     unset GIT_CONFIG_GLOBAL
   fi
-  unset VBW_AGENT_PID_LOCK_DIR _ORIG_HOME _ORIG_GIT_CONFIG_NOSYSTEM _ORIG_GIT_CONFIG_GLOBAL
+  unset VBW_AGENT_PID_LOCK_DIR _ORIG_HOME _ORIG_CLAUDE_CONFIG_DIR _ORIG_CLAUDE_CONFIG_DIR_WAS_SET _ORIG_GIT_CONFIG_NOSYSTEM _ORIG_GIT_CONFIG_GLOBAL
 }
 
 # Generate a PID that is guaranteed dead. Spawns a process intended to stay


### PR DESCRIPTION
## Linked Issue

Fixes #459

Related during validation only: observed an unrelated flaky `context-cache` failure and filed #470. That issue is not fixed in this PR and is out of scope for #459.

## What

This PR makes the flaky hook-wrapper cache-precedence tests hermetic against inherited Claude config environment and parallel-worker contamination.

It changes two test files:
- `tests/sessionstart-compact-hooks.bats` — explicitly sets `CLAUDE_CONFIG_DIR` in the real hook-wrapper cache/plugin-root/security-filter cases so those tests always resolve against the test-local Claude cache tree they create.
- `tests/test_helper.bash` — centralizes test-harness isolation by snapshotting, unsetting, and restoring inherited `CLAUDE_CONFIG_DIR` around `setup_temp_dir` / `teardown_temp_dir` so helper-using tests do not accidentally read host Claude cache/config state.

## Why

The root cause was not production `hook-wrapper.sh` behavior. The real problem was that the tests assumed isolating `HOME` was enough, but `scripts/resolve-claude-dir.sh` gives `CLAUDE_CONFIG_DIR` higher precedence than `HOME`.

That let inherited outer-shell config leak into BATS runs:
- for the target flaky case, cache lookup could be redirected away from the test-local cache and fall through to `CLAUDE_PLUGIN_ROOT`
- for adjacent session-start coverage, a hostile outer Claude cache could emit a stderr integrity warning ahead of JSON output and break `jq` assertions

The chosen fix keeps production behavior unchanged and restores the invariant a senior reviewer would want here: tests that exercise Claude-cache resolution must explicitly own the highest-precedence config input, and the shared test harness must not inherit host Claude config by accident.

## How

- `tests/sessionstart-compact-hooks.bats`
  - `401-419`: plugin-root fallback test now pins `CLAUDE_CONFIG_DIR` to an empty test-local Claude dir
  - `422-448`: cache-wins test now pins `CLAUDE_CONFIG_DIR` to the seeded test-local cache dir
  - `467-481`: real-wrapper `security-filter` integration test now uses the same explicit Claude-dir setup so it exercises the intended cached-wrapper path
- `tests/test_helper.bash`
  - `21-31`: `setup_temp_dir` now snapshots whether `CLAUDE_CONFIG_DIR` was originally set, then clears it after isolating `HOME`
  - `41-45`: `teardown_temp_dir` now restores the original `CLAUDE_CONFIG_DIR` state, including the distinction between unset and set-empty

## Acceptance criteria verification

The issue body did not include an explicit numbered acceptance-criteria section, so this PR verifies the derived issue contract directly.

1. **The flaky cache-precedence case is hermetic against inherited env / parallel-worker contamination**
   - Satisfied by `tests/sessionstart-compact-hooks.bats:422-448` and `tests/test_helper.bash:21-45`
   - Verified with polluted-env reruns of the target case and repeated `BATS_WORKERS=4` runs of `tests/sessionstart-compact-hooks.bats`

2. **The fix does not change production `hook-wrapper` / resolver behavior unless required**
   - Satisfied by scope: only `tests/sessionstart-compact-hooks.bats` and `tests/test_helper.bash` changed
   - `scripts/hook-wrapper.sh` and `scripts/resolve-claude-dir.sh` were reviewed but not modified

3. **Nearby hook-wrapper tests still exercise the intended cache vs plugin-root behavior**
   - Satisfied by `tests/sessionstart-compact-hooks.bats:401-419` (plugin-root fallback), `422-448` (cache wins), and `467-481` (real wrapper preserves exit `2`)

4. **No regressions are introduced in touched code**
   - Satisfied by targeted test runs plus clean full-suite verification
   - One unrelated flaky `context-cache` failure was observed once during final verification, passed on immediate retry, and was tracked separately in #470 rather than folded into this PR’s scope

## Testing

- [x] `bats tests/sessionstart-compact-hooks.bats`
- [x] polluted-env repro for `session-start: runs normally when no compaction marker`
- [x] `bats tests/resolve-claude-dir.bats`
- [x] `bats tests/inject-subagent-skills.bats`
- [x] `bash testing/run-all.sh`

## QA summary

- **Primary QA rounds**: 3 rounds with `qa-investigator`
  - Round 1: 0 findings
  - Round 2: 1 low observation fixed in `fix(tests): address QA round 2` (`3c6cd66`)
  - Round 3: 0 findings
- **Cross-model QA rounds**: 1 round with `qa-investigator-gpt-54` (GPT-5.4)
  - Round 1: 0 findings
- **Copilot PR review rounds**: 0 at draft creation time; pending Phase 4.5 after the PR is marked ready
- **False positives**: 0 legitimate findings were dismissed; only non-issues called out by reviewers were documented as benign rationale during clean rounds