### PR TITLE
fix(debug-target): add configurable debug target and root CLAUDE symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules/
 .github/hooks
 .github/references
 .github/scripts
-CLAUDE.md
 
 # OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules/
 .github/hooks
 .github/references
 .github/scripts
-AGENTS.md
 CLAUDE.md
 
 # OS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Example local file content:
 Resolution order:
 1. `VBW_DEBUG_TARGET_REPO` env var (one-off override, absolute path only)
 2. `./.claude/vbw-debug-target.txt` in the VBW repo clone (preferred persistent local config, absolute path only)
-3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback, absolute path only)
+3. `<claude-config-dir>/vbw/debug-target.txt` (user-global fallback, absolute path only; `<claude-config-dir>` is resolved by `scripts/resolve-claude-dir.sh`: `CLAUDE_CONFIG_DIR` if set, else `$HOME/.config/claude-code` when that directory exists, else `$HOME/.claude`)
 4. If none are configured, **ask the user for the target repo path** — do not guess.
 
 Use the shared resolver when debugging:
@@ -46,7 +46,9 @@ CLAUDE_PROJECT_DIR=$(bash scripts/resolve-debug-target.sh claude-project-dir)
 
 If the resolver exits non-zero, stop guessing and ask the user to configure a debug target.
 
-### Claude Code Log Locations (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}`)
+### Claude Code Log Locations (canonical Claude config root)
+
+In the paths below, `<claude-config-dir>` means the same Claude config root resolved by `scripts/resolve-claude-dir.sh`: `CLAUDE_CONFIG_DIR` if set, else `$HOME/.config/claude-code` when that directory exists, else `$HOME/.claude`.
 
 After resolving the target repo, derive the encoded Claude project path by replacing `/` with `-` in the absolute target-repo path. For an absolute path, the result begins with `-`.
 
@@ -61,20 +63,21 @@ When debugging, search these directories for evidence of what actually happened:
 | Path | Contents | Use When |
 | ------ | ---------- | ---------- |
 | `<target-repo>/.vbw-planning/` | Project state (phases, milestones, config, `STATE.md`) | Ground the investigation in actual workflow state |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/*.jsonl` | Session transcripts | Replaying what the LLM said/did in a session |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/{session-id}/subagents/agent-*.jsonl` | Subagent transcripts | Checking what VBW agent team members did |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/{session-id}/tool-results/` | Tool output snapshots | Seeing exact tool outputs from a session |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/debug/{session-id}.txt` | Debug logs (`[DEBUG]`/`[WARN]`) | Startup issues, plugin loading, hook execution failures |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/sessions/{pid}.json` | Active session metadata | Mapping a PID to a session ID |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/session-env/{session-id}/` | Hook-exported env vars | Verifying `CLAUDE_SESSION_ID` and other env vars |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/tasks/{session-id}/` | Task/subagent lock files | Checking for stuck or concurrent task issues |
-| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` | User-level Claude Code settings and hooks | Verifying hook definitions, permissions, MCP config |
+| `<claude-config-dir>/projects/{encoded-path}/*.jsonl` | Session transcripts | Replaying what the LLM said/did in a session |
+| `<claude-config-dir>/projects/{encoded-path}/{session-id}/subagents/agent-*.jsonl` | Subagent transcripts | Checking what VBW agent team members did |
+| `<claude-config-dir>/projects/{encoded-path}/{session-id}/tool-results/` | Tool output snapshots | Seeing exact tool outputs from a session |
+| `<claude-config-dir>/debug/{session-id}.txt` | Debug logs (`[DEBUG]`/`[WARN]`) | Startup issues, plugin loading, hook execution failures |
+| `<claude-config-dir>/sessions/{pid}.json` | Active session metadata | Mapping a PID to a session ID |
+| `<claude-config-dir>/session-env/{session-id}/` | Hook-exported env vars | Verifying `CLAUDE_SESSION_ID` and other env vars |
+| `<claude-config-dir>/tasks/{session-id}/` | Task/subagent lock files | Checking for stuck or concurrent task issues |
+| `<claude-config-dir>/settings.json` | User-level Claude Code settings and hooks | Verifying hook definitions, permissions, MCP config |
 
 ### Common search patterns
 
 ```bash
 TARGET_REPO=$(bash scripts/resolve-debug-target.sh repo)
 CLAUDE_PROJECT_DIR=$(bash scripts/resolve-debug-target.sh claude-project-dir)
+CLAUDE_CONFIG_ROOT="$(dirname "$(dirname "$CLAUDE_PROJECT_DIR")")"
 
 # Find sessions for the configured target repo
 ls "$CLAUDE_PROJECT_DIR"/*.jsonl
@@ -83,7 +86,7 @@ ls "$CLAUDE_PROJECT_DIR"/*.jsonl
 grep -l 'vbw' "$CLAUDE_PROJECT_DIR"/*.jsonl
 
 # Find hook errors in debug logs
-grep -l 'hook.*error\|hook.*fail' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/debug"/*.txt
+grep -l 'hook.*error\|hook.*fail' "$CLAUDE_CONFIG_ROOT"/debug/*.txt
 
 # Search for a specific tool invocation across sessions
 grep -rl 'bootstrap-state\|state-updater' "$CLAUDE_PROJECT_DIR"/*.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Preferred setup in the VBW repo clone:
 ```
 
 The first non-empty, non-comment line must be the absolute path to the contributor's primary VBW consumer/test repo.
+Relative paths are rejected so the resolver produces the same result regardless of the caller's current working directory.
 
 Example local file content:
 
@@ -29,9 +30,9 @@ Example local file content:
 ```
 
 Resolution order:
-1. `VBW_DEBUG_TARGET_REPO` env var (one-off override)
-2. `./.claude/vbw-debug-target.txt` in the VBW repo clone (preferred persistent local config)
-3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback)
+1. `VBW_DEBUG_TARGET_REPO` env var (one-off override, absolute path only)
+2. `./.claude/vbw-debug-target.txt` in the VBW repo clone (preferred persistent local config, absolute path only)
+3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback, absolute path only)
 4. If none are configured, **ask the user for the target repo path** — do not guess.
 
 Use the shared resolver when debugging:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,10 @@ ls "$CLAUDE_PROJECT_DIR"/*.jsonl
 grep -l 'vbw' "$CLAUDE_PROJECT_DIR"/*.jsonl
 
 # Find hook errors in debug logs
-grep -l 'hook.*error\|hook.*fail' "$CLAUDE_CONFIG_ROOT"/debug/*.txt
+grep -El 'hook.*error|hook.*fail' "$CLAUDE_CONFIG_ROOT"/debug/*.txt
 
 # Search for a specific tool invocation across sessions
-grep -rl 'bootstrap-state\|state-updater' "$CLAUDE_PROJECT_DIR"/*.jsonl
+grep -Erl 'bootstrap-state|state-updater' "$CLAUDE_PROJECT_DIR"/*.jsonl
 
 # Check what a subagent did in a specific session
 cat "$CLAUDE_PROJECT_DIR"/<session-id>/subagents/agent-*.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,267 @@
+# VBW Instructions
+
+A Claude Code plugin adding structured development workflows (plan → execute → verify) via 7 specialized agent teams. Zero external dependencies beyond `jq` and `git`. All logic is bash scripts + markdown.
+
+## Communication Style
+
+- **No AI fluff.** Skip phrases like "Thanks for the thoughtful feedback!", "Happy to help!", "I appreciate...", etc.
+- **No soliciting opinions.** Don't end responses with "Would you like me to...", "Let me know if...", "What do you think?", etc.
+- **Direct and terse.** State facts, provide options when relevant, then stop.
+
+## Debugging VBW Behavior
+
+When the user reports VBW misbehavior — pasting Claude Code session output, describing incorrect command behavior, or showing unexpected file state — first resolve the contributor's **local debug target repo** instead of guessing a maintainer-specific path.
+
+### Local debug target configuration (private, not committed)
+
+Preferred setup in the VBW repo clone:
+
+```text
+.claude/vbw-debug-target.txt
+```
+
+The first non-empty, non-comment line must be the absolute path to the contributor's primary VBW consumer/test repo.
+
+Example local file content:
+
+```text
+/absolute/path/to/your-test-repo
+```
+
+Resolution order:
+1. `VBW_DEBUG_TARGET_REPO` env var (one-off override)
+2. `./.claude/vbw-debug-target.txt` in the VBW repo clone (preferred persistent local config)
+3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback)
+4. If none are configured, **ask the user for the target repo path** — do not guess.
+
+Use the shared resolver when debugging:
+
+```bash
+TARGET_REPO=$(bash scripts/resolve-debug-target.sh repo)
+TARGET_PLANNING=$(bash scripts/resolve-debug-target.sh planning-dir)
+ENCODED_PATH=$(bash scripts/resolve-debug-target.sh encoded-path)
+CLAUDE_PROJECT_DIR=$(bash scripts/resolve-debug-target.sh claude-project-dir)
+```
+
+If the resolver exits non-zero, stop guessing and ask the user to configure a debug target.
+
+### Claude Code Log Locations (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}`)
+
+After resolving the target repo, derive the encoded Claude project path by replacing `/` with `-` in the absolute target-repo path. For an absolute path, the result begins with `-`.
+
+Example rule:
+
+```text
+/absolute/path/to/project  ->  -absolute-path-to-project
+```
+
+When debugging, search these directories for evidence of what actually happened:
+
+| Path | Contents | Use When |
+| ------ | ---------- | ---------- |
+| `<target-repo>/.vbw-planning/` | Project state (phases, milestones, config, `STATE.md`) | Ground the investigation in actual workflow state |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/*.jsonl` | Session transcripts | Replaying what the LLM said/did in a session |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/{session-id}/subagents/agent-*.jsonl` | Subagent transcripts | Checking what VBW agent team members did |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/{encoded-path}/{session-id}/tool-results/` | Tool output snapshots | Seeing exact tool outputs from a session |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/debug/{session-id}.txt` | Debug logs (`[DEBUG]`/`[WARN]`) | Startup issues, plugin loading, hook execution failures |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/sessions/{pid}.json` | Active session metadata | Mapping a PID to a session ID |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/session-env/{session-id}/` | Hook-exported env vars | Verifying `CLAUDE_SESSION_ID` and other env vars |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/tasks/{session-id}/` | Task/subagent lock files | Checking for stuck or concurrent task issues |
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` | User-level Claude Code settings and hooks | Verifying hook definitions, permissions, MCP config |
+
+### Common search patterns
+
+```bash
+TARGET_REPO=$(bash scripts/resolve-debug-target.sh repo)
+CLAUDE_PROJECT_DIR=$(bash scripts/resolve-debug-target.sh claude-project-dir)
+
+# Find sessions for the configured target repo
+ls "$CLAUDE_PROJECT_DIR"/*.jsonl
+
+# Search session transcripts for a VBW hook or command
+grep -l 'vbw' "$CLAUDE_PROJECT_DIR"/*.jsonl
+
+# Find hook errors in debug logs
+grep -l 'hook.*error\|hook.*fail' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/debug"/*.txt
+
+# Search for a specific tool invocation across sessions
+grep -rl 'bootstrap-state\|state-updater' "$CLAUDE_PROJECT_DIR"/*.jsonl
+
+# Check what a subagent did in a specific session
+cat "$CLAUDE_PROJECT_DIR"/<session-id>/subagents/agent-*.jsonl
+```
+
+## Conventions
+
+- **Naming**: Commands are kebab-case `.md`, agents are `vbw-{role}.md`, scripts are kebab-case `.sh`, phase dirs are `{NN}-{slug}/`
+- **Commits**: `{type}({scope}): {description}` — one atomic commit per task, stage files explicitly (never `git add .`)
+- **JSON parsing**: Always use `jq`, never grep/sed on JSON
+- **No dependencies**: No package.json, npm, or build step. Everything is bash + markdown
+- **YAML frontmatter**: `description` field must be single-line. Use `.prettierignore` for formatting exclusions (no `prettier-ignore` comments)
+- **Plugin isolation**: VBW files live in `.vbw-planning/`, GSD files in `.planning/` — never cross-reference between them
+- **Token reduction**: When the LLM needs context to make decisions, prefer pre-extracting data via bash scripts (injected in command template expansions) over instructing the LLM to read files at runtime. Scripts produce compact, deterministic output and avoid burning tokens on file reads the agent doesn't need to reason about. Apply this principle whenever adding context to commands.
+- **Claude Code template expansion semantics**: Standalone one-line `` !`command` `` directives and fenced `` !`command` `` blocks execute. Embedded `` !`command` `` spans inside prose, paths, or larger strings do **not** execute — Claude passes them through literally. Never build runtime paths or sentence fragments with embedded `!` spans; precompute the value in a fenced block or helper script and reference the resolved output instead.
+- **Root-cause fixes only (non-negotiable)**: Every fix must address the underlying root cause. Masking/symptom-only fixes are not allowed. If a temporary mitigation is added, it must be accompanied by a root-cause fix in the same work item (or the task is incomplete).
+- **No Python in terminal**: Never run `python3` or `python` via the terminal. Use the available Python execution tool instead.
+- **LSP-first code navigation**: Any agent with LSP in its `tools` list must prefer LSP for semantic code navigation (definitions, references, symbols, call hierarchy) and reserve Search/Grep/Glob for literal strings, filenames, non-code assets, or LSP failure cases. See `references/lsp-first-policy.md` for the canonical policy.
+
+## Architecture
+
+- **Commands** (`commands/*.md`): 24 slash commands with YAML frontmatter. Command `name` values are explicitly prefixed (e.g. `name: vbw:init`) so slash commands appear as `/vbw:*`. The frontmatter `description` must be single-line (multi-line breaks plugin discovery).
+- **Agents** (`agents/vbw-{role}.md`): 7 agents (Scout, Architect, Lead, Dev, QA, Debugger, Docs) with platform-enforced tool permissions via YAML `tools`/`disallowedTools`. Scout and QA are read-only (`permissionMode: plan`).
+- **Hooks** (`hooks/hooks.json`): 21 handlers across 11 event types (SessionStart, Stop, PreToolUse, PostToolUse, SubagentStart, SubagentStop, Notification, PreCompact, TaskCompleted, TeammateIdle, UserPromptSubmit). All route through `scripts/hook-wrapper.sh` which resolves from plugin cache via `ls | sort -V | tail -1` with a `CLAUDE_PLUGIN_ROOT` fallback for `--plugin-dir` installs, logs failures, and always exits 0 — no hook can break a session.
+- **Scripts** (`scripts/*.sh`): bash scripts for hook handlers, context compilation, state management, bootstrap, metrics, diagnostics, and codebase mapping. Target bash (not POSIX sh). Use `set -euo pipefail` for critical scripts, `set -u` minimum otherwise.
+- **References** (`references/*.md`): protocol docs loaded on-demand by commands (for example `execute-protocol.md` and `verification-protocol.md`).
+- **Templates** (`templates/*.md`): artifact templates (CONTEXT, PLAN, PROJECT, REQUIREMENTS, ROADMAP, SUMMARY, UAT, VERIFICATION, etc.).
+- **Config** (`config/`): `defaults.json` (settings), `model-profiles.json` (3 presets: quality/balanced/budget), `stack-mappings.json` (tech detection → skill suggestions), `token-budgets.json` (context budgets), `rollout-stages.json` (feature rollout), `destructive-commands.txt` (guarded commands list), `schemas/` (message schemas).
+
+## Key Patterns
+
+### Plugin root resolution
+
+Two resolution cascades exist — one for hooks (DXP-01) and one for commands. They share the same steps but differ in priority order by design.
+
+**Hook cascade (DXP-01)** — cache-first because hooks fire automatically in production (marketplace) deployments. Always exits 0 (no hook can break a session):
+1. Versioned cache glob (`ls … sort -V … tail -1`)
+2. `CLAUDE_PLUGIN_ROOT` env var
+3. `/tmp/.vbw-plugin-root-link-*` symlink glob
+4. `ps axww` + `grep -oE -- "--plugin-dir [^ ]+"` extraction
+5. Graceful no-op (`exit 0`)
+
+**Command cascade** — `CLAUDE_PLUGIN_ROOT` first because an explicit env var should take priority when the user invokes a command. Exits 1 on failure so the user knows the plugin is misconfigured:
+1. `CLAUDE_PLUGIN_ROOT` env var
+2. `cache/local` symlink
+3. Versioned cache dir (`find … sort … tail -1`)
+4. Generic cache dir fallback
+5. `/tmp/.vbw-plugin-root-link-*` symlink glob
+6. `ps axww` + `grep -oE -- "--plugin-dir [^ ]+"` extraction
+7. Fail guard (`exit 1`)
+
+After resolution, commands create a session symlink at `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}` pointing to the resolved root, so subsequent template expansions and hooks can find it.
+
+Inside scripts, `CLAUDE_PLUGIN_ROOT` is available and used normally.
+
+### Context compilation
+`scripts/compile-context.sh` produces role-specific `.context-{role}.md` files so each agent loads only relevant context (Lead gets requirements, Dev gets phase goal + conventions, QA gets verification targets).
+
+### State management
+Runtime state lives in `.vbw-planning/` (created per-project by `/vbw:init`): `STATE.md`, `ROADMAP.md`, `PROJECT.md`, `REQUIREMENTS.md`, `config.json`, `phases/{NN}-{slug}/` with PLAN.md and SUMMARY.md per plan.
+
+### Model routing
+`scripts/resolve-agent-model.sh` reads `config.json` profile + overrides against `config/model-profiles.json`. The resolved model string is passed as an explicit `model:` parameter to Task tool invocations (session `/model` doesn't propagate to subagents).
+
+## Testing
+
+Run all checks (tests + lint): `bash testing/run-all.sh`
+
+Run `testing/run-all.sh` directly — do not pipe it through `| tail`, `| tail -20`, `| tail -40`, `| tee`, or similar wrappers, especially from concurrent worktrees. `tail` pipelines buffer until EOF, hide live progress, and can make a healthy long-running suite look hung while also obscuring the real exit status.
+
+### Zero-tolerance test failure policy (non-negotiable)
+
+Every test and lint failure must be investigated and resolved before committing — **no exceptions**. Never dismiss a failure as "not from my changes" or "pre-existing." If a test fails after your change, one of two things is true:
+1. **The test is correct** and your change (or a recent change) broke real behavior — fix the code.
+2. **The test is outdated** and no longer matches the intended behavior — update the test to match the new behavior.
+
+Either way, you own the fix. Do not leave failures for the user to resolve manually. Do not push code with known test or lint failures.
+
+### Three-tier testing model
+
+This project is markdown consumed by LLMs plus bash scripts. No single testing methodology fits both. Use the right tier for each artifact type:
+
+#### Tier 1 — Behavior tests (BATS) → bash scripts
+
+For scripts that produce observable outputs. Write tests that assert what a script *does* (outputs, exit codes, side effects, file state) rather than *how* it does it internally.
+
+#### Tier 2 — Contract tests (`verify-*.sh`) → markdown, JSON, YAML structure
+
+For structural invariants that can be validated mechanically. These confirm required structure exists but cannot validate that LLM-consumed prose is *correct*.
+
+#### Tier 3 — Smoke tests → integrated system
+
+The real test of a markdown instruction file is whether the LLM does the right thing when it reads it. Smoke-test slash commands in a separate sandbox repo, not the plugin repo itself.
+
+### Lint checks
+
+`run-all.sh` includes lint checks that mirror CI:
+- **Shell syntax** (`bash -n`) on all `.sh` files in `scripts/` and `testing/`
+- **ShellCheck** (`shellcheck -S warning`) on all `.sh` files in `scripts/` and `hooks/`
+
+### Individual checks
+
+- `bash testing/verify-bash-scripts-contract.sh` — validates script conventions
+- `bash testing/verify-commands-contract.sh` — validates command frontmatter
+- `bash testing/verify-hook-event-name.sh` — validates hook event names match platform spec
+- `bash testing/verify-plugin-root-resolution.sh` — validates the plugin-root resolution cascade in commands and references
+- `bash testing/verify-lsp-first-policy.sh` — validates the repo-wide LSP-first rule
+- `bash scripts/verify-init-todo.sh` — verifies init workflow
+- `bash scripts/verify-claude-bootstrap.sh` — verifies bootstrap script
+- `bash scripts/bump-version.sh --verify` — verifies version consistency
+
+## Git Workflow
+
+Direct push access to `swt-labs/vibe-better-with-claude-code-vbw`. Single `origin` remote.
+
+- **`origin`**: fetch and push target for all branches.
+- **`dev` branch**: permanent local integration branch for combined testing before PRs. Tracks `origin/dev`. Never delete this branch.
+
+### Branch Cleanup
+
+- **`fetch.prune`** is enabled — stale remote tracking refs are removed on every fetch.
+- **`git merged`**: custom alias that finds local branches fully merged into `origin/main` and removes them locally. Also prunes worktrees in `../<repo-name>-worktrees/` whose branches have been merged or whose PRs have been merged/closed. Safe to run anytime — skips `main` and `dev`.
+- **`git cleanup`**: fetches, prunes, and deletes local branches whose remote tracking branch is gone.
+- After a PR is merged, run `git merged` to clean up local branches and their worktrees.
+
+### Worktrees
+
+The issue-fix workflow uses git worktrees for parallel-safe issue work.
+
+- **Location**: `../<repo-name>-worktrees/<branch-name>/` (sibling directory, outside the repo)
+- **Creation**: `git worktree add -b` creates branch + worktree atomically
+- **Cleanup**: the workflow never removes worktrees automatically; use `git merged` after merge
+- **Manual removal**: `git worktree remove <path>` or `git worktree prune`
+
+### Branch Protection
+
+- `main` requires PRs to merge.
+- Do not commit directly to `main`.
+- After creating a feature branch from `origin/main`, set its upstream to `origin/<branch>` on first push.
+
+## Version Management
+
+Version is synchronized across 4 files (`VERSION`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `marketplace.json`). The author bumps versions manually via `bash scripts/bump-version.sh`. Contributors should not bump versions themselves.
+
+### Push workflow
+
+- The pre-push hook only checks that version files are **consistent** (all 4 match).
+- Contributors should not modify version files or `CHANGELOG.md` in their branches.
+- Verify consistency locally with `bash scripts/bump-version.sh --verify`.
+- Avoid `git push --no-verify` except for emergencies.
+
+## Local Dev Toggle (`claude-code-router`)
+
+This repo can be run locally via `claude-code-router` (CCR) with a toggle between local dev and prod marketplace modes:
+
+- **Local Dev mode**: CCR config sets `CLAUDE_PATH` to `~/.claude-code-router/bin/claude-with-vbw`, a wrapper that injects `--plugin-dir /absolute/path/to/vibe-better-with-claude-code-vbw` into every `claude` invocation. Commands, agents, and hook definitions load from the local repo.
+- **Prod mode**: CCR config sets `CLAUDE_PATH` to `claude` (bare). Plugins resolve from the marketplace cache at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/vbw-marketplace/vbw/*/`.
+- **Toggle**: Edit `~/.claude-code-router/config.json` and set `CLAUDE_PATH` to one of the above. Optionally `rm -rf "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/commands/vbw"` before relaunching to clear stale command cache.
+
+## Contributing
+
+See `CONTRIBUTING.md` for full guidelines. Key points:
+- Push branches to `origin`. PRs target `main`.
+- Load locally with `claude --plugin-dir .` or `claude --plugin-dir /absolute/path/to/vibe-better-with-claude-code-vbw`.
+- Run `bash scripts/install-hooks.sh` for the pre-push hook.
+- Version bumps are done by the author — the pre-push hook only checks version file consistency.
+- Good candidates: bug fixes in hooks/scripts, new commands fitting the lifecycle model, stack-to-skill mappings, template improvements.
+- Not welcome without discussion: core lifecycle rewrites, features requiring dependencies.
+- Update consumer-facing docs (`docs/`, `README.md`) whenever a change alters behavior, adds a feature, or modifies a workflow.
+
+### Required Fix Workflow (Issue → Branch → Draft PR → Automated QA)
+
+When asked to fix a bug or implement an issue-driven change, use the tracked issue as the contract, create a worktree branch, implement the root-cause fix with tests, run `bash testing/run-all.sh`, and iterate through QA review rounds before opening or finalizing the PR.
+
+### PR and Issue Templates
+
+- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): requires What/Why/How sections plus a testing checklist.
+- **Bug reports** (`.github/ISSUE_TEMPLATE/bug_report.md`): must include the `/vbw:*` command that triggered it, reproduction steps, and environment.
+- **Feature requests** (`.github/ISSUE_TEMPLATE/feature_request.md`): must describe the problem, proposed solution, and alternatives considered.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,40 @@ All `/vbw:*` commands will load from your local copy. Restart Claude Code to pic
 > **Important:** `--plugin-dir` loads whatever is on disk in your VBW clone, which means whatever branch is currently checked out. Make sure you're on the branch with your changes before launching Claude Code — if you're on `main`, you'll be testing the unchanged version.
 > **Known limitation:** Plugin hooks (the 21 event handlers in `hooks.json`) resolve scripts from the marketplace cache via the symlink. This means hooks will run (unlike before the symlink existed), but they execute from your local clone — changes to hook scripts take effect immediately without a cache refresh. The git pre-push hook is a separate mechanism — see [Version Management](#version-management).
 
+### Set your local debug target repo
+
+VBW debugging docs use a **private local pointer file** instead of hard-coding a maintainer's consumer repo path.
+
+Create this file in your VBW clone:
+
+```text
+.claude/vbw-debug-target.txt
+```
+
+Put the absolute path to your primary VBW consumer/test repo on the first non-empty line:
+
+```text
+/absolute/path/to/your-test-repo
+```
+
+This file stays private because `.claude/` is gitignored in this repo.
+
+Resolution order for debug-target lookup:
+
+1. `VBW_DEBUG_TARGET_REPO` env var (one-off override)
+2. `./.claude/vbw-debug-target.txt` in the VBW clone (preferred persistent local config)
+3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback)
+
+Useful checks:
+
+```bash
+bash scripts/resolve-debug-target.sh repo
+bash scripts/resolve-debug-target.sh planning-dir
+bash scripts/resolve-debug-target.sh claude-project-dir
+```
+
+If the resolver exits non-zero, configure one of the sources above before debugging VBW behavior.
+
 ## Project Structure
 
 ```text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,11 @@ This file stays private because `.claude/` is gitignored in this repo.
 
 Resolution order for debug-target lookup:
 
-1. `VBW_DEBUG_TARGET_REPO` env var (one-off override)
-2. `./.claude/vbw-debug-target.txt` in the VBW clone (preferred persistent local config)
-3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback)
+1. `VBW_DEBUG_TARGET_REPO` env var (one-off override, absolute path only)
+2. `./.claude/vbw-debug-target.txt` in the VBW clone (preferred persistent local config, absolute path only)
+3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback, absolute path only)
+
+Relative paths are rejected so the resolver behaves the same no matter which directory calls it.
 
 Useful checks:
 
@@ -113,6 +115,8 @@ bash scripts/resolve-debug-target.sh claude-project-dir
 ```
 
 If the resolver exits non-zero, configure one of the sources above before debugging VBW behavior.
+
+Root instructions in this repo have one canonical source: `AGENTS.md`. The tracked root `CLAUDE.md` is a symlink to `AGENTS.md` for Claude Code compatibility.
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Resolution order for debug-target lookup:
 
 1. `VBW_DEBUG_TARGET_REPO` env var (one-off override, absolute path only)
 2. `./.claude/vbw-debug-target.txt` in the VBW clone (preferred persistent local config, absolute path only)
-3. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt` (user-global fallback, absolute path only)
+3. `<claude-config-dir>/vbw/debug-target.txt` (user-global fallback, absolute path only; `<claude-config-dir>` is resolved by `scripts/resolve-claude-dir.sh`: `CLAUDE_CONFIG_DIR` if set, else `$HOME/.config/claude-code` when that directory exists, else `$HOME/.claude`)
 
 Relative paths are rejected so the resolver behaves the same no matter which directory calls it.
 

--- a/scripts/resolve-debug-target.sh
+++ b/scripts/resolve-debug-target.sh
@@ -4,7 +4,9 @@
 # Resolution order:
 #   1. VBW_DEBUG_TARGET_REPO env var (one-off override)
 #   2. <plugin-root>/.claude/vbw-debug-target.txt (preferred local config)
-#   3. ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt (user-global fallback)
+#   3. ${CLAUDE_DIR}/vbw/debug-target.txt (user-global fallback; CLAUDE_DIR is
+#      resolved by resolve-claude-dir.sh using CLAUDE_CONFIG_DIR when set and
+#      the canonical Claude config-directory defaults otherwise)
 #
 # File format: first non-empty, non-comment line is the absolute path to the
 # contributor's primary VBW consumer/test repo.
@@ -95,10 +97,11 @@ PLUGIN_ROOT="$(cd "$PLUGIN_ROOT" && pwd -P)"
 
 read_target_file() {
   local file_path="$1"
+  local line=""
 
   [ -f "$file_path" ] || return 1
 
-  awk '
+  line="$({ awk '
     /^[[:space:]]*#/ { next }
     /^[[:space:]]*$/ { next }
     {
@@ -107,7 +110,15 @@ read_target_file() {
       print
       exit
     }
-  ' "$file_path"
+  ' "$file_path"; } )"
+
+  if [ -z "$line" ]; then
+    echo "Configured VBW debug target file is empty or has only comments: $file_path" >&2
+    echo "Expected the first non-empty, non-comment line to be an absolute path to the contributor's primary VBW consumer/test repo." >&2
+    return 2
+  fi
+
+  printf '%s\n' "$line"
 }
 
 LOCAL_FILE="$PLUGIN_ROOT/.claude/vbw-debug-target.txt"
@@ -118,14 +129,28 @@ TARGET_SOURCE=""
 if [ "${VBW_DEBUG_TARGET_REPO+x}" = "x" ]; then
   TARGET_REPO="$(trim_value "$VBW_DEBUG_TARGET_REPO")"
   TARGET_SOURCE="VBW_DEBUG_TARGET_REPO"
-elif TARGET_REPO="$(read_target_file "$LOCAL_FILE" 2>/dev/null || true)" && [ -n "$TARGET_REPO" ]; then
-  TARGET_SOURCE="$LOCAL_FILE"
-elif TARGET_REPO="$(read_target_file "$GLOBAL_FILE" 2>/dev/null || true)" && [ -n "$TARGET_REPO" ]; then
-  TARGET_SOURCE="$GLOBAL_FILE"
 else
-  echo "No VBW debug target repo configured." >&2
-  echo "Set VBW_DEBUG_TARGET_REPO, create $LOCAL_FILE, or create $GLOBAL_FILE." >&2
-  exit 1
+  if TARGET_REPO="$(read_target_file "$LOCAL_FILE")"; then
+    TARGET_SOURCE="$LOCAL_FILE"
+  else
+    READ_RC=$?
+    if [ "$READ_RC" -eq 2 ]; then
+      exit 1
+    fi
+
+    if TARGET_REPO="$(read_target_file "$GLOBAL_FILE")"; then
+      TARGET_SOURCE="$GLOBAL_FILE"
+    else
+      READ_RC=$?
+      if [ "$READ_RC" -eq 2 ]; then
+        exit 1
+      fi
+
+      echo "No VBW debug target repo configured." >&2
+      echo "Set VBW_DEBUG_TARGET_REPO, create $LOCAL_FILE, or create $GLOBAL_FILE." >&2
+      exit 1
+    fi
+  fi
 fi
 
 validate_target_repo "$TARGET_REPO" "$TARGET_SOURCE"

--- a/scripts/resolve-debug-target.sh
+++ b/scripts/resolve-debug-target.sh
@@ -25,11 +25,43 @@ if [ $# -gt 0 ]; then
   shift
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 
 usage() {
   echo "Usage: resolve-debug-target.sh [repo|planning-dir|encoded-path|claude-project-dir|source|all] [--plugin-root PATH]" >&2
+}
+
+trim_value() {
+  local value="$1"
+
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  printf '%s' "$value"
+}
+
+validate_target_repo() {
+  local target_repo="$1"
+  local target_source="$2"
+
+  if [ -z "$target_repo" ]; then
+    echo "Configured VBW debug target repo from $target_source is empty." >&2
+    exit 1
+  fi
+
+  case "$target_repo" in
+    /*) ;;
+    *)
+      echo "Configured VBW debug target repo from $target_source must be an absolute path: $target_repo" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ ! -d "$target_repo" ]; then
+    echo "Configured VBW debug target repo from $target_source does not exist or is not a directory: $target_repo" >&2
+    exit 1
+  fi
 }
 
 while [ $# -gt 0 ]; do
@@ -51,6 +83,13 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ ! -d "$PLUGIN_ROOT" ]; then
+  echo "Error: --plugin-root directory not found: $PLUGIN_ROOT" >&2
+  exit 1
+fi
+
+PLUGIN_ROOT="$(cd "$PLUGIN_ROOT" && pwd -P)"
+
 # shellcheck source=resolve-claude-dir.sh
 . "$SCRIPT_DIR/resolve-claude-dir.sh"
 
@@ -63,6 +102,7 @@ read_target_file() {
     /^[[:space:]]*#/ { next }
     /^[[:space:]]*$/ { next }
     {
+      sub(/^[[:space:]]+/, "", $0)
       sub(/[[:space:]]+$/, "", $0)
       print
       exit
@@ -75,8 +115,8 @@ GLOBAL_FILE="$CLAUDE_DIR/vbw/debug-target.txt"
 TARGET_REPO=""
 TARGET_SOURCE=""
 
-if [ -n "${VBW_DEBUG_TARGET_REPO:-}" ]; then
-  TARGET_REPO="$VBW_DEBUG_TARGET_REPO"
+if [ "${VBW_DEBUG_TARGET_REPO+x}" = "x" ]; then
+  TARGET_REPO="$(trim_value "$VBW_DEBUG_TARGET_REPO")"
   TARGET_SOURCE="VBW_DEBUG_TARGET_REPO"
 elif TARGET_REPO="$(read_target_file "$LOCAL_FILE" 2>/dev/null || true)" && [ -n "$TARGET_REPO" ]; then
   TARGET_SOURCE="$LOCAL_FILE"
@@ -88,10 +128,7 @@ else
   exit 1
 fi
 
-if [ ! -d "$TARGET_REPO" ]; then
-  echo "Configured VBW debug target repo does not exist or is not a directory: $TARGET_REPO" >&2
-  exit 1
-fi
+validate_target_repo "$TARGET_REPO" "$TARGET_SOURCE"
 
 TARGET_REPO="$(cd "$TARGET_REPO" && pwd -P)"
 ENCODED_PATH="${TARGET_REPO//\//-}"

--- a/scripts/resolve-debug-target.sh
+++ b/scripts/resolve-debug-target.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# resolve-debug-target.sh — Resolve the contributor-local VBW debug target repo.
+#
+# Resolution order:
+#   1. VBW_DEBUG_TARGET_REPO env var (one-off override)
+#   2. <plugin-root>/.claude/vbw-debug-target.txt (preferred local config)
+#   3. ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt (user-global fallback)
+#
+# File format: first non-empty, non-comment line is the absolute path to the
+# contributor's primary VBW consumer/test repo.
+#
+# Usage:
+#   resolve-debug-target.sh [repo|planning-dir|encoded-path|claude-project-dir|source|all] [--plugin-root PATH]
+#
+# Notes:
+# - --plugin-root exists so tests and diagnostics can point at an explicit repo root
+#   without relying on the script's installed location.
+# - The resolved target must exist as a directory. The script does not require
+#   .vbw-planning/ to exist because some debug flows may need to inspect pre-init repos.
+
+set -euo pipefail
+
+FIELD="${1:-repo}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+usage() {
+  echo "Usage: resolve-debug-target.sh [repo|planning-dir|encoded-path|claude-project-dir|source|all] [--plugin-root PATH]" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plugin-root)
+      if [ $# -lt 2 ]; then
+        echo "Error: --plugin-root requires a path" >&2
+        usage
+        exit 1
+      fi
+      PLUGIN_ROOT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown option '$1'" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# shellcheck source=resolve-claude-dir.sh
+. "$SCRIPT_DIR/resolve-claude-dir.sh"
+
+read_target_file() {
+  local file_path="$1"
+
+  [ -f "$file_path" ] || return 1
+
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    {
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$file_path"
+}
+
+LOCAL_FILE="$PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+GLOBAL_FILE="$CLAUDE_DIR/vbw/debug-target.txt"
+TARGET_REPO=""
+TARGET_SOURCE=""
+
+if [ -n "${VBW_DEBUG_TARGET_REPO:-}" ]; then
+  TARGET_REPO="$VBW_DEBUG_TARGET_REPO"
+  TARGET_SOURCE="VBW_DEBUG_TARGET_REPO"
+elif TARGET_REPO="$(read_target_file "$LOCAL_FILE" 2>/dev/null || true)" && [ -n "$TARGET_REPO" ]; then
+  TARGET_SOURCE="$LOCAL_FILE"
+elif TARGET_REPO="$(read_target_file "$GLOBAL_FILE" 2>/dev/null || true)" && [ -n "$TARGET_REPO" ]; then
+  TARGET_SOURCE="$GLOBAL_FILE"
+else
+  echo "No VBW debug target repo configured." >&2
+  echo "Set VBW_DEBUG_TARGET_REPO, create $LOCAL_FILE, or create $GLOBAL_FILE." >&2
+  exit 1
+fi
+
+if [ ! -d "$TARGET_REPO" ]; then
+  echo "Configured VBW debug target repo does not exist or is not a directory: $TARGET_REPO" >&2
+  exit 1
+fi
+
+TARGET_REPO="$(cd "$TARGET_REPO" && pwd -P)"
+ENCODED_PATH="${TARGET_REPO//\//-}"
+PLANNING_DIR="$TARGET_REPO/.vbw-planning"
+CLAUDE_PROJECT_DIR="$CLAUDE_DIR/projects/$ENCODED_PATH"
+
+case "$FIELD" in
+  repo)
+    printf '%s\n' "$TARGET_REPO"
+    ;;
+  planning-dir)
+    printf '%s\n' "$PLANNING_DIR"
+    ;;
+  encoded-path)
+    printf '%s\n' "$ENCODED_PATH"
+    ;;
+  claude-project-dir)
+    printf '%s\n' "$CLAUDE_PROJECT_DIR"
+    ;;
+  source)
+    printf '%s\n' "$TARGET_SOURCE"
+    ;;
+  all)
+    printf 'repo=%s\n' "$TARGET_REPO"
+    printf 'planning_dir=%s\n' "$PLANNING_DIR"
+    printf 'encoded_path=%s\n' "$ENCODED_PATH"
+    printf 'claude_project_dir=%s\n' "$CLAUDE_PROJECT_DIR"
+    printf 'source=%s\n' "$TARGET_SOURCE"
+    ;;
+  *)
+    echo "Error: unknown field '$FIELD'" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -48,6 +48,7 @@ printf '%s\t%s\n' \
   report-diag-handoff          testing/verify-report-diag-handoff.sh \
   discussion-engine-contract   testing/verify-discussion-engine-contract.sh \
   debug-session-contract       testing/verify-debug-session-contract.sh \
+  debug-target-docs            testing/verify-debug-target-docs.sh \
   askuserquestion-contract     testing/verify-askuserquestion-contract.sh \
   research-storage-contract    testing/verify-research-storage-contract.sh \
   config-defaults-sync         testing/verify-config-defaults-sync.sh \

--- a/testing/verify-debug-target-docs.sh
+++ b/testing/verify-debug-target-docs.sh
@@ -45,6 +45,12 @@ else
   fail "AGENTS.md missing resolve-debug-target.sh guidance"
 fi
 
+if grep -q 'resolve-claude-dir.sh' "$AGENTS_MD" 2>/dev/null; then
+  pass "AGENTS.md references canonical Claude config resolution"
+else
+  fail "AGENTS.md missing canonical Claude config resolution guidance"
+fi
+
 if grep -E '(/Users/[^/[:space:]]+|~/repos/[^[:space:]]+|projects/-Users-[^/[:space:]]+)' "$AGENTS_MD" >/dev/null 2>&1; then
   fail "AGENTS.md still contains maintainer-specific debug target paths"
 else
@@ -55,6 +61,24 @@ if grep -q 'vbw-debug-target.txt' "$CONTRIB" 2>/dev/null; then
   pass "CONTRIBUTING.md documents local debug target setup"
 else
   fail "CONTRIBUTING.md missing local debug target setup"
+fi
+
+if grep -q 'resolve-claude-dir.sh' "$CONTRIB" 2>/dev/null; then
+  pass "CONTRIBUTING.md references canonical Claude config resolution"
+else
+  fail "CONTRIBUTING.md missing canonical Claude config resolution guidance"
+fi
+
+if grep -Fq '${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt' "$AGENTS_MD" 2>/dev/null; then
+  fail "AGENTS.md still documents the stale debug-target global fallback path"
+else
+  pass "AGENTS.md documents the canonical debug-target global fallback path"
+fi
+
+if grep -Fq '${CLAUDE_CONFIG_DIR:-$HOME/.claude}/vbw/debug-target.txt' "$CONTRIB" 2>/dev/null; then
+  fail "CONTRIBUTING.md still documents the stale debug-target global fallback path"
+else
+  pass "CONTRIBUTING.md documents the canonical debug-target global fallback path"
 fi
 
 if git -C "$ROOT" check-ignore --no-index -q -- AGENTS.md; then

--- a/testing/verify-debug-target-docs.sh
+++ b/testing/verify-debug-target-docs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+AGENTS_MD="$ROOT/AGENTS.md"
+CONTRIB="$ROOT/CONTRIBUTING.md"
+IGNORE="$ROOT/.gitignore"
+
+echo "=== Debug Target Docs Contract Verification ==="
+
+if [ -f "$AGENTS_MD" ]; then
+  pass "AGENTS.md exists"
+else
+  fail "AGENTS.md missing"
+fi
+
+if grep -q 'vbw-debug-target.txt' "$AGENTS_MD" 2>/dev/null; then
+  pass "AGENTS.md documents the local debug target file"
+else
+  fail "AGENTS.md missing vbw-debug-target.txt guidance"
+fi
+
+if grep -q 'resolve-debug-target.sh' "$AGENTS_MD" 2>/dev/null; then
+  pass "AGENTS.md references resolve-debug-target.sh"
+else
+  fail "AGENTS.md missing resolve-debug-target.sh guidance"
+fi
+
+if grep -E '/Users/dpearson|ios-options-wheel-tracker|-Users-dpearson-' "$AGENTS_MD" >/dev/null 2>&1; then
+  fail "AGENTS.md still contains maintainer-specific debug target paths"
+else
+  pass "AGENTS.md contains no maintainer-specific debug target paths"
+fi
+
+if grep -q 'vbw-debug-target.txt' "$CONTRIB" 2>/dev/null; then
+  pass "CONTRIBUTING.md documents local debug target setup"
+else
+  fail "CONTRIBUTING.md missing local debug target setup"
+fi
+
+if grep -q '^AGENTS\.md$' "$IGNORE" 2>/dev/null; then
+  fail ".gitignore still ignores AGENTS.md"
+else
+  pass ".gitignore allows AGENTS.md to be tracked"
+fi
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/testing/verify-debug-target-docs.sh
+++ b/testing/verify-debug-target-docs.sh
@@ -45,7 +45,7 @@ else
   fail "AGENTS.md missing resolve-debug-target.sh guidance"
 fi
 
-if grep -E '/Users/dpearson|ios-options-wheel-tracker|-Users-dpearson-' "$AGENTS_MD" >/dev/null 2>&1; then
+if grep -E '(/Users/[^/[:space:]]+|~/repos/[^[:space:]]+|projects/-Users-[^/[:space:]]+)' "$AGENTS_MD" >/dev/null 2>&1; then
   fail "AGENTS.md still contains maintainer-specific debug target paths"
 else
   pass "AGENTS.md contains no maintainer-specific debug target paths"

--- a/testing/verify-debug-target-docs.sh
+++ b/testing/verify-debug-target-docs.sh
@@ -81,6 +81,13 @@ else
   pass "CONTRIBUTING.md documents the canonical debug-target global fallback path"
 fi
 
+if grep -Fq "grep -El 'hook.*error|hook.*fail'" "$AGENTS_MD" 2>/dev/null \
+  && grep -Fq "grep -Erl 'bootstrap-state|state-updater'" "$AGENTS_MD" 2>/dev/null; then
+  pass "AGENTS.md uses portable grep -E examples for debug-log searches"
+else
+  fail "AGENTS.md debug-log search examples are missing portable grep -E usage"
+fi
+
 if git -C "$ROOT" check-ignore --no-index -q -- AGENTS.md; then
   fail ".gitignore still ignores AGENTS.md"
 else

--- a/testing/verify-debug-target-docs.sh
+++ b/testing/verify-debug-target-docs.sh
@@ -16,8 +16,8 @@ fail() {
 }
 
 AGENTS_MD="$ROOT/AGENTS.md"
+CLAUDE_MD="$ROOT/CLAUDE.md"
 CONTRIB="$ROOT/CONTRIBUTING.md"
-IGNORE="$ROOT/.gitignore"
 
 echo "=== Debug Target Docs Contract Verification ==="
 
@@ -25,6 +25,12 @@ if [ -f "$AGENTS_MD" ]; then
   pass "AGENTS.md exists"
 else
   fail "AGENTS.md missing"
+fi
+
+if git -C "$ROOT" ls-files --error-unmatch -- AGENTS.md >/dev/null 2>&1; then
+  pass "AGENTS.md is tracked"
+else
+  fail "AGENTS.md is not tracked"
 fi
 
 if grep -q 'vbw-debug-target.txt' "$AGENTS_MD" 2>/dev/null; then
@@ -51,10 +57,46 @@ else
   fail "CONTRIBUTING.md missing local debug target setup"
 fi
 
-if grep -q '^AGENTS\.md$' "$IGNORE" 2>/dev/null; then
+if git -C "$ROOT" check-ignore --no-index -q -- AGENTS.md; then
   fail ".gitignore still ignores AGENTS.md"
 else
   pass ".gitignore allows AGENTS.md to be tracked"
+fi
+
+if git -C "$ROOT" ls-files --error-unmatch -- CLAUDE.md >/dev/null 2>&1; then
+  pass "CLAUDE.md is tracked"
+else
+  fail "CLAUDE.md is not tracked"
+fi
+
+if [ -L "$CLAUDE_MD" ]; then
+  pass "CLAUDE.md is a symlink"
+else
+  fail "CLAUDE.md is not a symlink"
+fi
+
+if [ -L "$CLAUDE_MD" ] && [ "$(readlink "$CLAUDE_MD")" = "AGENTS.md" ]; then
+  pass "CLAUDE.md points to AGENTS.md"
+else
+  fail "CLAUDE.md does not point to AGENTS.md"
+fi
+
+if [ "$(git -C "$ROOT" ls-files -s -- CLAUDE.md 2>/dev/null | awk 'NR == 1 { print $1 }')" = "120000" ]; then
+  pass "CLAUDE.md is tracked as a symlink"
+else
+  fail "CLAUDE.md is not tracked with symlink mode"
+fi
+
+if git -C "$ROOT" check-ignore --no-index -q -- CLAUDE.md; then
+  fail ".gitignore still ignores CLAUDE.md"
+else
+  pass ".gitignore allows CLAUDE.md to be tracked"
+fi
+
+if git -C "$ROOT" check-ignore --no-index -q -- .claude/vbw-debug-target.txt; then
+  pass ".claude/vbw-debug-target.txt remains gitignored"
+else
+  fail ".claude/vbw-debug-target.txt is no longer gitignored"
 fi
 
 echo ""

--- a/tests/resolve-debug-target.bats
+++ b/tests/resolve-debug-target.bats
@@ -5,6 +5,7 @@ setup() {
   SCRIPT="$REPO_ROOT/scripts/resolve-debug-target.sh"
   ORIG_HOME="$HOME"
   ORIG_CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR-__UNSET__}"
+  ORIG_VBW_DEBUG_TARGET_REPO="${VBW_DEBUG_TARGET_REPO-__UNSET__}"
   TEST_ROOT="$(mktemp -d)"
   FAKE_PLUGIN_ROOT="$TEST_ROOT/plugin"
   CLAUDE_CONFIG_DIR="$TEST_ROOT/claude-config"
@@ -18,6 +19,7 @@ setup() {
   TARGET_B="$(cd "$TARGET_B" && pwd -P)"
 
   export CLAUDE_CONFIG_DIR
+  unset VBW_DEBUG_TARGET_REPO
 }
 
 teardown() {
@@ -28,6 +30,12 @@ teardown() {
     unset CLAUDE_CONFIG_DIR
   else
     export CLAUDE_CONFIG_DIR="$ORIG_CLAUDE_CONFIG_DIR"
+  fi
+
+  if [ "$ORIG_VBW_DEBUG_TARGET_REPO" = "__UNSET__" ]; then
+    unset VBW_DEBUG_TARGET_REPO
+  else
+    export VBW_DEBUG_TARGET_REPO="$ORIG_VBW_DEBUG_TARGET_REPO"
   fi
 }
 

--- a/tests/resolve-debug-target.bats
+++ b/tests/resolve-debug-target.bats
@@ -11,6 +11,7 @@ setup() {
 
   mkdir -p "$FAKE_PLUGIN_ROOT/.claude" "$CLAUDE_CONFIG_DIR/vbw" "$TARGET_A" "$TARGET_B"
 
+  FAKE_PLUGIN_ROOT="$(cd "$FAKE_PLUGIN_ROOT" && pwd -P)"
   TARGET_A="$(cd "$TARGET_A" && pwd -P)"
   TARGET_B="$(cd "$TARGET_B" && pwd -P)"
 
@@ -42,6 +43,23 @@ teardown() {
   [ "$output" = "$TARGET_B" ]
 }
 
+@test "resolve-debug-target: relative env override is rejected before cwd-sensitive fallback" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+  export VBW_DEBUG_TARGET_REPO="../consumer-b"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VBW_DEBUG_TARGET_REPO"* ]]
+  [[ "$output" == *"must be an absolute path"* ]]
+
+  run bash -c 'cd / && bash "$1" repo --plugin-root "$2"' _ "$SCRIPT" "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VBW_DEBUG_TARGET_REPO"* ]]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
 @test "resolve-debug-target: global fallback works when repo-local file is absent" {
   printf '%s\n' "$TARGET_A" > "$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"
 
@@ -49,6 +67,26 @@ teardown() {
 
   [ "$status" -eq 0 ]
   [ "$output" = "$TARGET_A" ]
+}
+
+@test "resolve-debug-target: relative repo-local file is rejected" {
+  printf '%s\n' '../consumer-a' > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"* ]]
+  [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "resolve-debug-target: relative global fallback is rejected" {
+  printf '%s\n' '../consumer-a' > "$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"* ]]
+  [[ "$output" == *"must be an absolute path"* ]]
 }
 
 @test "resolve-debug-target: planning-dir appends .vbw-planning" {

--- a/tests/resolve-debug-target.bats
+++ b/tests/resolve-debug-target.bats
@@ -3,6 +3,8 @@
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   SCRIPT="$REPO_ROOT/scripts/resolve-debug-target.sh"
+  ORIG_HOME="$HOME"
+  ORIG_CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR-__UNSET__}"
   TEST_ROOT="$(mktemp -d)"
   FAKE_PLUGIN_ROOT="$TEST_ROOT/plugin"
   CLAUDE_CONFIG_DIR="$TEST_ROOT/claude-config"
@@ -21,7 +23,12 @@ setup() {
 teardown() {
   rm -rf "$TEST_ROOT"
   unset VBW_DEBUG_TARGET_REPO
-  unset CLAUDE_CONFIG_DIR
+  export HOME="$ORIG_HOME"
+  if [ "$ORIG_CLAUDE_CONFIG_DIR" = "__UNSET__" ]; then
+    unset CLAUDE_CONFIG_DIR
+  else
+    export CLAUDE_CONFIG_DIR="$ORIG_CLAUDE_CONFIG_DIR"
+  fi
 }
 
 @test "resolve-debug-target: repo-local file resolves repo path" {
@@ -69,6 +76,18 @@ teardown() {
   [ "$output" = "$TARGET_A" ]
 }
 
+@test "resolve-debug-target: global fallback uses HOME/.config/claude-code when CLAUDE_CONFIG_DIR is unset" {
+  unset CLAUDE_CONFIG_DIR
+  export HOME="$TEST_ROOT/home"
+  mkdir -p "$HOME/.config/claude-code/vbw"
+  printf '%s\n' "$TARGET_A" > "$HOME/.config/claude-code/vbw/debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TARGET_A" ]
+}
+
 @test "resolve-debug-target: relative repo-local file is rejected" {
   printf '%s\n' '../consumer-a' > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
 
@@ -87,6 +106,33 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"* ]]
   [[ "$output" == *"must be an absolute path"* ]]
+}
+
+@test "resolve-debug-target: blank repo-local file is a hard error even when global fallback exists" {
+  cat > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt" <<'EOF'
+# comment only
+
+EOF
+  printf '%s\n' "$TARGET_A" > "$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"* ]]
+  [[ "$output" == *"first non-empty, non-comment line"* ]]
+}
+
+@test "resolve-debug-target: blank global fallback is a hard error" {
+  cat > "$CLAUDE_CONFIG_DIR/vbw/debug-target.txt" <<'EOF'
+# comment only
+
+EOF
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"* ]]
+  [[ "$output" == *"first non-empty, non-comment line"* ]]
 }
 
 @test "resolve-debug-target: planning-dir appends .vbw-planning" {

--- a/tests/resolve-debug-target.bats
+++ b/tests/resolve-debug-target.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/resolve-debug-target.sh"
+  TEST_ROOT="$(mktemp -d)"
+  FAKE_PLUGIN_ROOT="$TEST_ROOT/plugin"
+  CLAUDE_CONFIG_DIR="$TEST_ROOT/claude-config"
+  TARGET_A="$TEST_ROOT/consumer-a"
+  TARGET_B="$TEST_ROOT/consumer-b"
+
+  mkdir -p "$FAKE_PLUGIN_ROOT/.claude" "$CLAUDE_CONFIG_DIR/vbw" "$TARGET_A" "$TARGET_B"
+
+  TARGET_A="$(cd "$TARGET_A" && pwd -P)"
+  TARGET_B="$(cd "$TARGET_B" && pwd -P)"
+
+  export CLAUDE_CONFIG_DIR
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+  unset VBW_DEBUG_TARGET_REPO
+  unset CLAUDE_CONFIG_DIR
+}
+
+@test "resolve-debug-target: repo-local file resolves repo path" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TARGET_A" ]
+}
+
+@test "resolve-debug-target: env override wins over repo-local file" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+  export VBW_DEBUG_TARGET_REPO="$TARGET_B"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TARGET_B" ]
+}
+
+@test "resolve-debug-target: global fallback works when repo-local file is absent" {
+  printf '%s\n' "$TARGET_A" > "$CLAUDE_CONFIG_DIR/vbw/debug-target.txt"
+
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TARGET_A" ]
+}
+
+@test "resolve-debug-target: planning-dir appends .vbw-planning" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+
+  run bash "$SCRIPT" planning-dir --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TARGET_A/.vbw-planning" ]
+}
+
+@test "resolve-debug-target: encoded-path matches Claude project encoding rule" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+  expected="${TARGET_A//\//-}"
+
+  run bash "$SCRIPT" encoded-path --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "resolve-debug-target: claude-project-dir uses CLAUDE_CONFIG_DIR fallback root" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+  expected="$CLAUDE_CONFIG_DIR/projects/${TARGET_A//\//-}"
+
+  run bash "$SCRIPT" claude-project-dir --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "resolve-debug-target: source reports where the target came from" {
+  printf '%s\n' "$TARGET_A" > "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"
+
+  run bash "$SCRIPT" source --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt" ]
+}
+
+@test "resolve-debug-target: missing config exits with clear guidance" {
+  run bash "$SCRIPT" repo --plugin-root "$FAKE_PLUGIN_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No VBW debug target repo configured."* ]]
+  [[ "$output" == *"VBW_DEBUG_TARGET_REPO"* ]]
+  [[ "$output" == *"$FAKE_PLUGIN_ROOT/.claude/vbw-debug-target.txt"* ]]
+}


### PR DESCRIPTION
Fixes #467
Related QA follow-up: #469

## What

This change makes the root instruction docs publish-safe without losing contributor usability.

It replaces maintainer-specific debug-target examples in `AGENTS.md` with a contributor-local debug-target mechanism, adds a shared resolver script for deriving the real consumer repo and its Claude log directory, and makes the plugin repo’s root `CLAUDE.md` a tracked symlink to `AGENTS.md` so Claude Code and AGENTS-based tooling share one canonical instruction source.

## Why

The root cause in #467 was twofold:

1. VBW had no shared runtime abstraction for “the contributor’s debug target repo,” so maintainer-local prose examples were effectively acting as configuration.
2. Once `AGENTS.md` became publishable, keeping a separate root `CLAUDE.md` copy would create drift between two instruction entrypoints that should stay identical.

This PR fixes both at the source by separating private local machine state from public docs and by linking `CLAUDE.md` directly to `AGENTS.md` instead of duplicating content.

## How

- `.gitignore` — removed only the root-doc ignore entries needed to track `AGENTS.md` and `CLAUDE.md`, while keeping `.claude/` ignored; retained the new mainline ignore for `docs/vbw-agentic-workflow-presentation-source.md`.
- `AGENTS.md` — rewrote the VBW debugging section around a contributor-local debug target, generic Claude log paths, and explicit absolute-path-only guidance.
- `CLAUDE.md` — added as a tracked symlink to `AGENTS.md` so the repo has one canonical root instruction file.
- `CONTRIBUTING.md` — documented local setup for `.claude/vbw-debug-target.txt`, absolute-path-only behavior, resolver checks, and the root-doc linkage.
- `scripts/resolve-debug-target.sh` — added deterministic resolution for repo-local/global/env configuration, explicit absolute-path validation, and derived outputs for repo root, `.vbw-planning`, encoded path, and Claude project dir.
- `tests/resolve-debug-target.bats` — added regression coverage for precedence, relative-path rejection, cwd-independence, and derived outputs.
- `testing/verify-debug-target-docs.sh` — added contract checks for publish-safe `AGENTS.md`, tracked `CLAUDE.md -> AGENTS.md` symlink behavior, and ignore semantics.
- `testing/list-contract-tests.sh` — registered the new debug-target contract test so `testing/run-all.sh` and CI enforce it.

## Acceptance criteria verification

1. `AGENTS.md` no longer contains maintainer-specific consumer repo paths, usernames, or derived encoded Claude project paths.  
   Satisfied by `AGENTS.md:13-36`, `AGENTS.md:51-71`, and `AGENTS.md:243-247`; enforced by `testing/verify-debug-target-docs.sh:48-52`.
2. VBW defines one documented contributor-local mechanism for configuring the debug target repo, with `./.claude/vbw-debug-target.txt` as the primary source of truth.  
   Satisfied by `AGENTS.md:15-36`, `CONTRIBUTING.md:83-105`, and `scripts/resolve-debug-target.sh:4-19` plus `:113-127`.
3. The configured debug target repo path remains private and gitignored; it is never required to be committed to the repository.  
   Satisfied by `.gitignore:19-20`, `CONTRIBUTING.md:93-99`, and `testing/verify-debug-target-docs.sh:96-99`.
4. A shared resolver exists for the debug target repo and can derive repo root, `.vbw-planning` path, encoded Claude project path, and Claude log directory.  
   Satisfied by `scripts/resolve-debug-target.sh:133-159`; covered by `tests/resolve-debug-target.bats:92-118`.
5. When no debug target is configured, the documented/runtime behavior fails clearly and instructs the user to provide one, rather than guessing a maintainer repo.  
   Satisfied by `AGENTS.md:33-47`, `scripts/resolve-debug-target.sh:125-128`, and `tests/resolve-debug-target.bats:130-136`.
6. `CONTRIBUTING.md` documents how a contributor sets up their local debug target repo without exposing their private path in git.  
   Satisfied by `CONTRIBUTING.md:83-119`.
7. The root `CLAUDE.md` exists as a tracked symlink to `AGENTS.md`, using the exact filename `CLAUDE.md`.  
   Satisfied by tracked symlink `CLAUDE.md -> AGENTS.md`; enforced by `testing/verify-debug-target-docs.sh:66-85`.
8. `.gitignore` is updated only enough to allow `AGENTS.md` and `CLAUDE.md` to be tracked while keeping `.claude/` and other local/private artifacts ignored.  
   Satisfied by `.gitignore` diff plus `testing/verify-debug-target-docs.sh:60-63` and `:90-99`.
9. Contract coverage proves the tracked `CLAUDE.md` symlink points to `AGENTS.md`.  
   Satisfied by `testing/verify-debug-target-docs.sh:72-85` and registration in `testing/list-contract-tests.sh:50-52`.
10. `bash testing/verify-lsp-first-policy.sh` passes after the `AGENTS.md` rewrite.  
   Verified directly and via `testing/run-all.sh`.
11. If diagnostics/report flows are updated to consume the resolver, regression coverage proves they target the configured repo and still redact private home-directory information in emitted diagnostics.  
   Not applicable in this PR because diagnostics/report flows were not updated.

## Testing

- [x] `bats tests/resolve-debug-target.bats`
- [x] `bash testing/verify-debug-target-docs.sh`
- [x] `bash testing/verify-lsp-first-policy.sh`
- [x] `bash testing/run-all.sh`
- [x] Re-ran `bash testing/run-all.sh` after merging the latest `origin/main`

## QA summary

- **Primary QA rounds completed:** 3 (`qa-investigator`)
  - Round 1: 1 medium contract finding fixed in `4133d9b`
  - Round 2: 1 low observation in unrelated `testing/README.md`; tracked separately in `#469`; no branch code changes, evidence commit `0013a3b`
  - Round 3: clean, evidence commit `7c1db92`
- **Cross-model QA rounds completed:** 1 (`qa-investigator-gpt-54` / GPT-5.4)
  - Round 1: 1 low regression fixed in `2685373`
- **Copilot PR review rounds completed:** 0 so far — pending Phase 4.5 after draft PR creation

## Key commits

- `6ded5ab` — initial implementation
- `4133d9b` — address QA round 1
- `fd536ce` — merge latest `origin/main`
- `0013a3b` — address QA round 2 (evidence commit)
- `7c1db92` — address QA round 3 (evidence commit)
- `2685373` — address cross-model QA round 1