### PR TITLE
fix(testing): stabilize run-all overlap auto-tune test

### DIFF
--- a/testing/run-all-state-utils.sh
+++ b/testing/run-all-state-utils.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+# run-all-state-utils.sh — shared run-all suite coordination helpers.
+# Source from testing/run-all.sh or test harnesses that need to query the same
+# active-peer invariant used by the local auto-throttle path.
+
+initialize_run_all_state() {
+  local repo_identity
+
+  repo_identity="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "$ROOT")"
+  case "$repo_identity" in
+    /*) ;;
+    *) repo_identity="$ROOT/$repo_identity" ;;
+  esac
+  repo_identity="$(cd "$repo_identity" 2>/dev/null && pwd || printf '%s' "$repo_identity")"
+  RUN_ALL_REPO_KEY="$(printf '%s' "$repo_identity" | jq -sRr @uri 2>/dev/null || true)"
+  RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT"
+  if [ -n "$RUN_ALL_REPO_KEY" ]; then
+    RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT/$RUN_ALL_REPO_KEY"
+  fi
+  RUN_ALL_PROCESS_START="$(ps -o lstart= -p $$ 2>/dev/null || true)"
+  RUN_ALL_PROCESS_COMMAND="$(ps -o command= -p $$ 2>/dev/null || true)"
+}
+
+run_all_token_is_valid() {
+  local entry="$1"
+  local pid repo_key process_start process_command current_start current_command
+
+  [ -f "$entry" ] || return 1
+
+  pid="$(jq -r '.pid // empty' "$entry" 2>/dev/null || true)"
+  repo_key="$(jq -r '.repo_key // empty' "$entry" 2>/dev/null || true)"
+  process_start="$(jq -r '.process_start // empty' "$entry" 2>/dev/null || true)"
+  process_command="$(jq -r '.process_command // empty' "$entry" 2>/dev/null || true)"
+
+  case "$pid" in
+    ''|*[!0-9]*)
+      rm -f "$entry" 2>/dev/null || true
+      return 1
+      ;;
+  esac
+
+  if [ -z "$repo_key" ] || [ -z "$process_start" ] || [ -z "$process_command" ]; then
+    rm -f "$entry" 2>/dev/null || true
+    return 1
+  fi
+
+  if [ "$repo_key" != "$RUN_ALL_REPO_KEY" ]; then
+    rm -f "$entry" 2>/dev/null || true
+    return 1
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    rm -f "$entry" 2>/dev/null || true
+    return 1
+  fi
+
+  current_start="$(ps -o lstart= -p "$pid" 2>/dev/null || true)"
+  current_command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+
+  if [ -z "$current_start" ] || [ -z "$current_command" ]; then
+    rm -f "$entry" 2>/dev/null || true
+    return 1
+  fi
+
+  if [ "$process_start" != "$current_start" ] || [ "$process_command" != "$current_command" ]; then
+    rm -f "$entry" 2>/dev/null || true
+    return 1
+  fi
+
+  case "$current_command" in
+    *"run-all.sh"*)
+      return 0
+      ;;
+  esac
+
+  rm -f "$entry" 2>/dev/null || true
+  return 1
+}
+
+prune_run_all_tokens() {
+  local entry
+
+  [ -d "$RUN_ALL_STATE_DIR" ] || return 0
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    run_all_token_is_valid "$entry" >/dev/null 2>&1 || true
+  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
+}
+
+count_run_all_tokens() {
+  local count=0 entry
+
+  [ -d "$RUN_ALL_STATE_DIR" ] || {
+    echo 0
+    return 0
+  }
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    if run_all_token_is_valid "$entry"; then
+      count=$((count + 1))
+    fi
+  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
+
+  echo "$count"
+}
+
+count_run_all_tokens_with_grace() {
+  local attempt current_count observed_count=0
+
+  for attempt in 1 2 3 4; do
+    current_count="$(count_run_all_tokens)"
+    if [ "$current_count" -gt "$observed_count" ]; then
+      observed_count="$current_count"
+    fi
+    if [ "$observed_count" -gt 1 ] || [ "$attempt" -eq 4 ]; then
+      break
+    fi
+    sleep 0.05
+  done
+
+  echo "$observed_count"
+}
+
+register_run_all_token() {
+  local final_token
+
+  [ -n "$RUN_ALL_REPO_KEY" ] || return 1
+  [ -n "$RUN_ALL_PROCESS_START" ] || return 1
+  [ -n "$RUN_ALL_PROCESS_COMMAND" ] || return 1
+  mkdir -p "$RUN_ALL_STATE_DIR" 2>/dev/null || return 1
+  prune_run_all_tokens
+  RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token.tmp" 2>/dev/null)" || {
+    RUN_ALL_TOKEN=""
+    return 1
+  }
+  if ! jq -n \
+    --arg pid "$$" \
+    --arg repo_key "$RUN_ALL_REPO_KEY" \
+    --arg process_start "$RUN_ALL_PROCESS_START" \
+    --arg process_command "$RUN_ALL_PROCESS_COMMAND" \
+    '{pid: $pid, repo_key: $repo_key, process_start: $process_start, process_command: $process_command}' > "$RUN_ALL_TOKEN"; then
+    rm -f "$RUN_ALL_TOKEN"
+    RUN_ALL_TOKEN=""
+    return 1
+  fi
+  final_token="${RUN_ALL_TOKEN%.tmp}"
+  if ! mv "$RUN_ALL_TOKEN" "$final_token"; then
+    rm -f "$RUN_ALL_TOKEN"
+    RUN_ALL_TOKEN=""
+    return 1
+  fi
+  RUN_ALL_TOKEN="$final_token"
+}

--- a/testing/run-all.sh
+++ b/testing/run-all.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LIST_BATS_FILES="$ROOT/testing/list-bats-files.sh"
 LIST_CONTRACT_TESTS="$ROOT/testing/list-contract-tests.sh"
+RUN_ALL_STATE_UTILS="$ROOT/testing/run-all-state-utils.sh"
 
 TMPDIR_JOBS="$(mktemp -d)"
 RUN_ALL_STATE_ROOT="${RUN_ALL_STATE_DIR:-${TMPDIR:-/tmp}/vbw-run-all-suites-${UID:-$(id -u)}}"
@@ -15,6 +16,9 @@ RUN_ALL_TOKEN=""
 RUN_ALL_REPO_KEY=""
 RUN_ALL_PROCESS_START=""
 RUN_ALL_PROCESS_COMMAND=""
+
+# shellcheck source=testing/run-all-state-utils.sh
+source "$RUN_ALL_STATE_UTILS"
 
 declare -a JOB_NAMES=()
 declare -a JOB_PIDS=()
@@ -55,157 +59,6 @@ run_job() {
   JOB_TYPES+=("$type")
   "$@" > "$TMPDIR_JOBS/$name.out" 2>&1 &
   JOB_PIDS+=("$!")
-}
-
-initialize_run_all_state() {
-  local repo_identity
-
-  repo_identity="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "$ROOT")"
-  case "$repo_identity" in
-    /*) ;;
-    *) repo_identity="$ROOT/$repo_identity" ;;
-  esac
-  repo_identity="$(cd "$repo_identity" 2>/dev/null && pwd || printf '%s' "$repo_identity")"
-  RUN_ALL_REPO_KEY="$(printf '%s' "$repo_identity" | jq -sRr @uri 2>/dev/null || true)"
-  RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT"
-  if [ -n "$RUN_ALL_REPO_KEY" ]; then
-    RUN_ALL_STATE_DIR="$RUN_ALL_STATE_ROOT/$RUN_ALL_REPO_KEY"
-  fi
-  RUN_ALL_PROCESS_START="$(ps -o lstart= -p $$ 2>/dev/null || true)"
-  RUN_ALL_PROCESS_COMMAND="$(ps -o command= -p $$ 2>/dev/null || true)"
-}
-
-run_all_token_is_valid() {
-  local entry="$1"
-  local pid repo_key process_start process_command current_start current_command
-
-  [ -f "$entry" ] || return 1
-
-  pid="$(jq -r '.pid // empty' "$entry" 2>/dev/null || true)"
-  repo_key="$(jq -r '.repo_key // empty' "$entry" 2>/dev/null || true)"
-  process_start="$(jq -r '.process_start // empty' "$entry" 2>/dev/null || true)"
-  process_command="$(jq -r '.process_command // empty' "$entry" 2>/dev/null || true)"
-
-  case "$pid" in
-    ''|*[!0-9]*)
-      rm -f "$entry" 2>/dev/null || true
-      return 1
-      ;;
-  esac
-
-  if [ -z "$repo_key" ] || [ -z "$process_start" ] || [ -z "$process_command" ]; then
-    rm -f "$entry" 2>/dev/null || true
-    return 1
-  fi
-
-  if [ "$repo_key" != "$RUN_ALL_REPO_KEY" ]; then
-    rm -f "$entry" 2>/dev/null || true
-    return 1
-  fi
-
-  if ! kill -0 "$pid" 2>/dev/null; then
-    rm -f "$entry" 2>/dev/null || true
-    return 1
-  fi
-
-  current_start="$(ps -o lstart= -p "$pid" 2>/dev/null || true)"
-  current_command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
-
-  if [ -z "$current_start" ] || [ -z "$current_command" ]; then
-    rm -f "$entry" 2>/dev/null || true
-    return 1
-  fi
-
-  if [ "$process_start" != "$current_start" ] || [ "$process_command" != "$current_command" ]; then
-    rm -f "$entry" 2>/dev/null || true
-    return 1
-  fi
-
-  case "$current_command" in
-    *"run-all.sh"*)
-      return 0
-      ;;
-  esac
-
-  rm -f "$entry" 2>/dev/null || true
-  return 1
-}
-
-prune_run_all_tokens() {
-  local entry
-
-  [ -d "$RUN_ALL_STATE_DIR" ] || return 0
-
-  while IFS= read -r entry; do
-    [ -n "$entry" ] || continue
-    run_all_token_is_valid "$entry" >/dev/null 2>&1 || true
-  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
-}
-
-count_run_all_tokens() {
-  local count=0 entry
-
-  [ -d "$RUN_ALL_STATE_DIR" ] || {
-    echo 0
-    return 0
-  }
-
-  while IFS= read -r entry; do
-    [ -n "$entry" ] || continue
-    if run_all_token_is_valid "$entry"; then
-      count=$((count + 1))
-    fi
-  done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name 'suite.*.token' -print 2>/dev/null)
-
-  echo "$count"
-}
-
-count_run_all_tokens_with_grace() {
-  local attempt current_count observed_count=0
-
-  for attempt in 1 2 3 4; do
-    current_count="$(count_run_all_tokens)"
-    if [ "$current_count" -gt "$observed_count" ]; then
-      observed_count="$current_count"
-    fi
-    if [ "$observed_count" -gt 1 ] || [ "$attempt" -eq 4 ]; then
-      break
-    fi
-    sleep 0.05
-  done
-
-  echo "$observed_count"
-}
-
-register_run_all_token() {
-  local final_token
-
-  [ -n "$RUN_ALL_REPO_KEY" ] || return 1
-  [ -n "$RUN_ALL_PROCESS_START" ] || return 1
-  [ -n "$RUN_ALL_PROCESS_COMMAND" ] || return 1
-  mkdir -p "$RUN_ALL_STATE_DIR" 2>/dev/null || return 1
-  prune_run_all_tokens
-  RUN_ALL_TOKEN="$(mktemp "$RUN_ALL_STATE_DIR/suite.$$.XXXXXX.token.tmp" 2>/dev/null)" || {
-    RUN_ALL_TOKEN=""
-    return 1
-  }
-  if ! jq -n \
-    --arg pid "$$" \
-    --arg repo_key "$RUN_ALL_REPO_KEY" \
-    --arg process_start "$RUN_ALL_PROCESS_START" \
-    --arg process_command "$RUN_ALL_PROCESS_COMMAND" \
-    '{pid: $pid, repo_key: $repo_key, process_start: $process_start, process_command: $process_command}' > "$RUN_ALL_TOKEN"; then
-    rm -f "$RUN_ALL_TOKEN"
-    RUN_ALL_TOKEN=""
-    return 1
-  fi
-  final_token="${RUN_ALL_TOKEN%.tmp}"
-  if ! mv "$RUN_ALL_TOKEN" "$final_token"; then
-    rm -f "$RUN_ALL_TOKEN"
-    RUN_ALL_TOKEN=""
-    return 1
-  fi
-  RUN_ALL_TOKEN="$final_token"
 }
 
 auto_tune_bats_workers() {

--- a/tests/run-all-orchestration.bats
+++ b/tests/run-all-orchestration.bats
@@ -27,6 +27,7 @@ create_stub_workspace() {
   local name path
   mkdir -p "$root/testing" "$root/scripts" "$root/tests" "$root/bin"
   cp "$PROJECT_ROOT/testing/run-all.sh" "$root/testing/run-all.sh"
+  cp "$PROJECT_ROOT/testing/run-all-state-utils.sh" "$root/testing/run-all-state-utils.sh"
   cp "$PROJECT_ROOT/testing/list-bats-files.sh" "$root/testing/list-bats-files.sh"
   cp "$PROJECT_ROOT/testing/run-bats-shard.sh" "$root/testing/run-bats-shard.sh"
   cp "$PROJECT_ROOT/testing/list-contract-tests.sh" "$root/testing/list-contract-tests.sh"
@@ -117,6 +118,70 @@ link_run_all_system_tools() {
   done
 }
 
+wait_for_active_run_all_peer() {
+  local workspace="$1"
+  local state_root="$2"
+  local attempts="${3:-100}"
+  local host_bash
+
+  host_bash="$(command -v bash)"
+
+  "$host_bash" -c '
+    set -euo pipefail
+
+    workspace="$1"
+    state_root="$2"
+    attempts="$3"
+
+    ROOT="$workspace"
+    RUN_ALL_STATE_ROOT="$state_root"
+    RUN_ALL_STATE_DIR=""
+    RUN_ALL_TOKEN=""
+    RUN_ALL_REPO_KEY=""
+    RUN_ALL_PROCESS_START=""
+    RUN_ALL_PROCESS_COMMAND=""
+
+    # shellcheck source=testing/run-all-state-utils.sh
+    source "$ROOT/testing/run-all-state-utils.sh"
+    initialize_run_all_state
+
+    attempt=0
+    stable_countable_reads=0
+    while [ "$attempt" -lt "$attempts" ]; do
+      current_count="$(count_run_all_tokens_with_grace)"
+      if [ "$current_count" -ge 1 ]; then
+        stable_countable_reads=$((stable_countable_reads + 1))
+        if [ "$stable_countable_reads" -ge 2 ]; then
+          echo "active_run_all_suites=$current_count"
+          echo "stable_countable_reads=$stable_countable_reads"
+          exit 0
+        fi
+      else
+        stable_countable_reads=0
+      fi
+      attempt=$((attempt + 1))
+      sleep 0.1
+    done
+
+    echo "Timed out waiting for the first suite to become stably countable as an active peer."
+    echo "workspace=$workspace"
+    echo "state_root=$state_root"
+    echo "repo_key=$RUN_ALL_REPO_KEY"
+    echo "state_dir=$RUN_ALL_STATE_DIR"
+    echo "stable_countable_reads=$stable_countable_reads"
+    if [ -d "$RUN_ALL_STATE_DIR" ]; then
+      while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        echo "token=$entry"
+        echo "$(cat "$entry" 2>/dev/null || true)"
+      done < <(find "$RUN_ALL_STATE_DIR" -maxdepth 1 -type f -name "suite.*.token" -print | sort)
+    else
+      echo "state_dir_missing=true"
+    fi
+    exit 1
+  ' _ "$workspace" "$state_root" "$attempts"
+}
+
 @test "default local worker count auto-tunes when a real peer suite overlaps" {
   local root="$TEST_TEMP_DIR/stub-repo-auto-tune"
   local linked_root="$TEST_TEMP_DIR/stub-repo-auto-tune-worktree"
@@ -130,27 +195,27 @@ link_run_all_system_tools() {
   create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
-  env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  env -u BATS_WORKERS GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
 
-  # Wait for the first suite's token to appear before launching the second,
-  # otherwise the second suite may not see the first as a concurrent peer.
-  local token_found=false
-  for _wait in $(seq 1 100); do
-    if compgen -G "$state_dir"/*/*.token >/dev/null 2>&1; then
-      token_found=true; break
-    fi
-    sleep 0.1
-  done
-  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
+  # Wait for the same active-peer invariant run-all.sh uses before launching the
+  # second suite; token-file existence alone races ahead of token validation.
+  run wait_for_active_run_all_peer "$linked_root" "$state_dir"
+  [ "$status" -eq 0 ] || { echo "$output"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
-  run env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
+  # Full-suite stress runs may set BATS_WORKERS in the parent environment; unset
+  # it here so this scenario still exercises the default-worker auto-tune path.
+  run env -u BATS_WORKERS GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"
   wait "$first_pid"
 
-  echo "$output" | grep -q 'Auto-tuned BATS_WORKERS from 8 to 4 for 2 concurrent local test suite(s)'
+  if ! echo "$output" | grep -q 'Auto-tuned BATS_WORKERS from 8 to 4 for 2 concurrent local test suite(s)'; then
+    echo "second suite output never reported auto-tuning despite a stably countable peer"
+    echo "$output"
+    return 1
+  fi
 }
 
 @test "explicit BATS_WORKERS overrides auto-tuning during real overlap" {
@@ -166,26 +231,23 @@ link_run_all_system_tools() {
   create_stub_git_worktree_pair "$root" "$linked_root"
   export PATH="$root/bin:$PATH"
 
-  env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
+  env -u BATS_WORKERS GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$first_bats_log" BATS_HOLD_UNTIL_FILE="$release_file" bash -c "cd '$root' && bash testing/run-all.sh" >"$first_output" 2>&1 &
   first_pid=$!
 
-  # Wait for the first suite's token to appear before launching the second.
-  local token_found=false
-  for _wait in $(seq 1 100); do
-    if compgen -G "$state_dir"/*/*.token >/dev/null 2>&1; then
-      token_found=true; break
-    fi
-    sleep 0.1
-  done
-  [[ "$token_found" = true ]] || { echo "first suite token never appeared"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
+  run wait_for_active_run_all_peer "$linked_root" "$state_dir"
+  [ "$status" -eq 0 ] || { echo "$output"; touch "$release_file"; wait "$first_pid" 2>/dev/null || true; return 1; }
 
-  run env GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
+  run env -u BATS_WORKERS GITHUB_ACTIONS=false RUN_ALL_STATE_DIR="$state_dir" BATS_LOG="$second_bats_log" BATS_WORKERS=7 bash -c "cd '$linked_root' && bash testing/run-all.sh"
   [ "$status" -eq 0 ]
 
   touch "$release_file"
   wait "$first_pid"
 
-  [[ "$output" != *'Auto-tuned BATS_WORKERS'* ]]
+  if [[ "$output" == *'Auto-tuned BATS_WORKERS'* ]]; then
+    echo "second suite output unexpectedly auto-tuned despite explicit BATS_WORKERS"
+    echo "$output"
+    return 1
+  fi
   echo "$output" | grep -q '7 bats workers'
 }
 


### PR DESCRIPTION
Fixes #466

## What

Stabilizes the linked-worktree overlap orchestration tests by sharing the runner's run-all state/count helpers with the BATS harness and by clearing inherited outer-suite `BATS_WORKERS` values so the nested default-worker scenario actually exercises the default-worker path.

Files changed:
- `testing/run-all.sh` — sources the shared run-all state helpers.
- `testing/run-all-state-utils.sh` — new shared helper for repo-key resolution, token validation/pruning, active-suite counting, and token registration.
- `tests/run-all-orchestration.bats` — waits on the shared active-peer invariant, copies the helper into stub workspaces, and unsets inherited `BATS_WORKERS` in the nested default-path overlap scenario.

## Why

The observed failure under `BATS_WORKERS=12 bash testing/run-all.sh` turned out to be a test-harness contract problem, not a worker-math bug. The nested overlap scenario inherited `BATS_WORKERS=12` from the outer full-suite run, so the inner “default workers” path could accidentally behave like an explicit-override case. Separately, the overlap test was still waiting on token-file existence instead of the same countable-peer invariant the production runner uses.

The chosen fix is the architectural one for this test surface:
- share the exact run-all token/count logic between runtime and test code, and
- explicitly clear inherited `BATS_WORKERS` where the scenario contract says “no explicit BATS_WORKERS”.

That fixes the real contamination path instead of stretching sleeps or special-casing the current reproducer.

## How

- `testing/run-all.sh`
  - sources `testing/run-all-state-utils.sh` so runtime and tests share one implementation of repo-key resolution, token validation, active-suite counting, and token registration.
- `testing/run-all-state-utils.sh`
  - centralizes `initialize_run_all_state`, `run_all_token_is_valid`, `prune_run_all_tokens`, `count_run_all_tokens`, `count_run_all_tokens_with_grace`, and `register_run_all_token`.
- `tests/run-all-orchestration.bats`
  - copies the shared helper into stub workspaces so the harness exercises the same code path as the real runner.
  - replaces token-file polling with `wait_for_active_run_all_peer`, which shells into the stub workspace and waits on `count_run_all_tokens_with_grace`.
  - unsets inherited `BATS_WORKERS` for the nested default overlap scenario so outer full-suite stress runs do not flip the test into the explicit-override branch.
  - keeps the explicit-override scenario explicit by passing `BATS_WORKERS=7` only where that behavior is under test.

## Acceptance criteria verification

1. `tests/run-all-orchestration.bats` test `default local worker count auto-tunes when a real peer suite overlaps` passes deterministically across repeated local runs and no longer flips pass/fail on immediate rerun.
   - Satisfied by `tests/run-all-orchestration.bats:185-219` and verified by `bats tests/run-all-orchestration.bats` passing in 20 consecutive runs on this branch.
2. The overlap test waits on the same invariant that `testing/run-all.sh` uses to count active peer suites, not merely on token-file existence.
   - Satisfied by shared helper use in `testing/run-all.sh:75-111`, `testing/run-all-state-utils.sh:7-155`, and `tests/run-all-orchestration.bats:121-183`.
3. In the test scenario with two local suites from linked worktrees and no explicit `BATS_WORKERS`, the second suite reliably reports `Auto-tuned BATS_WORKERS from 8 to 4 for 2 concurrent local test suite(s)`.
   - Satisfied by `tests/run-all-orchestration.bats:198-218`, which clears inherited `BATS_WORKERS`, waits for a countable peer, and asserts the exact line emitted from `testing/run-all.sh:104-110`.
4. The neighboring test `explicit BATS_WORKERS overrides auto-tuning during real overlap` still passes and still preserves the explicit worker count.
   - Satisfied by `tests/run-all-orchestration.bats:221-252`.
5. `bash testing/run-all.sh` passes after the fix, and repeated targeted runs of `bats tests/run-all-orchestration.bats` do not reproduce the line-153 flake.
   - Satisfied by clean local runs of both `BATS_WORKERS=12 bash testing/run-all.sh` and `bash testing/run-all.sh`, plus the repeated targeted BATS loop.

## Testing

- [x] `bats tests/run-all-orchestration.bats` — 20 consecutive runs
- [x] `BATS_WORKERS=12 bash testing/run-all.sh`
- [x] `bash testing/run-all.sh`

## QA summary

- Primary QA rounds completed: 3 (`qa-investigator`)
  - Legitimate findings: 0
  - False positives: 0
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54` / GPT-5.4)
  - Legitimate findings: 0
  - False positives: 0
- Copilot PR review rounds completed so far: 0
  - Phase 4.5 begins after this draft PR is opened
