### PR TITLE
feat: add post-archive lifecycle hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Yes, the same command again. When Phase 1 finishes, run it again for Phase 2. An
 /vbw:vibe --archive
 ```
 
-When all phases are built, archive the work. VBW runs a completion audit, archives state to `.vbw-planning/milestones/`, tags the git release, and updates project docs. In hook-enabled/archive-flow execution, unresolved UAT is script-blocked (active or milestone) and is not bypassed by `--skip-audit`/`--force`. You shipped. With actual verification. Your future self won't want to set the codebase on fire. Probably.
+When all phases are built, archive the work. VBW runs a completion audit, archives state to `.vbw-planning/milestones/`, tags the git release, and updates project docs. In hook-enabled/archive-flow execution, unresolved UAT is script-blocked (active or milestone) and is not bypassed by `--skip-audit`/`--force`. If `hooks.post_archive` is configured, VBW runs it after successful archive completion; missing or failing user hooks warn but do not block shipping. You shipped. With actual verification. Your future self won't want to set the codebase on fire. Probably.
 
 That's it. `init` → `vibe` (repeat) → `vibe --archive`. Two commands for an entire development lifecycle.
 
@@ -578,6 +578,22 @@ Quick reference for every key in `config/defaults.json`, in order. Click the sec
 | `bash_guard` | `true`* | [Safety](#safety) |
 
 *`bash_guard` is not in `defaults.json` — it's read directly from project config with a default of `true` when absent.
+
+### Optional extension hooks
+
+Not every opt-in extension point lives in `config/defaults.json` or appears in `/vbw:config`. Sparse extension keys may be absent in brownfield repos and are treated as valid no-ops until you opt in.
+
+`hooks.post_archive` is one of these sparse config keys. Add it manually to `.vbw-planning/config.json` when you want a script to run after `/vbw:vibe --archive` completes successfully:
+
+```json
+{
+  "hooks": {
+    "post_archive": "scripts/hooks/post-archive.sh"
+  }
+}
+```
+
+Paths may be absolute or project-relative. VBW invokes the hook via `bash` with three positional arguments: milestone slug, archive path, and tag (empty when `--no-tag` was used). If `hooks.post_archive` is absent, archive no-ops through the dispatcher. If the configured hook is missing or fails, VBW warns and continues the archive flow.
 
 ### Effort profiles
 

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1430,6 +1430,11 @@ FAIL -> STOP with remediation suggestions. WARN -> proceed with warnings.
 7. Git branch merge: if `milestone/{SLUG}` branch exists, merge --no-ff. Conflict -> abort, warn. No branch -> skip.
 8. Git tag: unless --no-tag, `git tag -a {tag} -m "Shipped milestone: {name}"`. Default: `milestone/{SLUG}`.
 9. Regenerate CLAUDE.md: update Active Context, remove shipped refs. Preserve non-VBW content — only replace VBW-managed sections, keep user's own sections intact.
+9b. Post-archive hook (non-blocking): after successful archive completion, run:
+   ```bash
+   bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/post-archive-hook.sh "{SLUG}" ".vbw-planning/milestones/{SLUG}" "{tag}" .vbw-planning/config.json
+   ```
+   Use the tag selected in step 8, or an empty third argument when `--no-tag` was used. Repos without `hooks.post_archive` configured no-op through the dispatcher. Any warnings are non-blocking.
 10. Present: Phase Banner with metrics (phases, tasks, commits, requirements, deviations), archive path, tag, branch status, memory status. Run `bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/suggest-next.sh vibe`.
 
 ### Pure-Vibe Phase Loop

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1400,7 +1400,7 @@ FAIL -> STOP with remediation suggestions. WARN -> proceed with warnings.
    ```bash
    MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh .vbw-planning)
    ```
-   This reads ROADMAP.md phase names and outputs a numbered kebab-case slug (e.g., `01-setup-api-layer`). Override with `--tag` if provided. **Never use a hardcoded slug like "default" — always use the script output.**
+  This reads ROADMAP.md phase names and outputs a numbered kebab-case slug (e.g., `01-setup-api-layer`). Keep this milestone slug separate from any custom git tag passed via `--tag`. **Never use a hardcoded slug like "default" — always use the script output.**
 2. Parse args: --tag=vN.N.N (custom tag), --no-tag (skip), --force (skip non-UAT audit).
 3. Compute summary: from ROADMAP (phases), SUMMARY.md files (tasks/commits/deviations), REQUIREMENTS.md (satisfied count).
 4. **Rolling summary (conditional):** If `rolling_summary=true` in config:

--- a/scripts/log-event.sh
+++ b/scripts/log-event.sh
@@ -41,7 +41,7 @@ case "$EVENT_TYPE" in
   phase_planned|task_created|task_claimed|task_started|artifact_written|gate_passed|gate_failed|task_completed_candidate|task_completed_confirmed|task_blocked|task_reassigned|shutdown_sent|shutdown_received)
     ;;
   # Additional metric/internal types
-  token_overage|token_cap_escalated|file_conflict|smart_route|contract_revision|cache_hit|task_completion_rejected|snapshot_restored|state_recovered|message_rejected)
+  token_overage|token_cap_escalated|file_conflict|smart_route|contract_revision|cache_hit|task_completion_rejected|snapshot_restored|state_recovered|message_rejected|milestone_shipped)
     ;;
   *)
     echo "[log-event] WARNING: unknown event type '${EVENT_TYPE}' rejected" >&2

--- a/scripts/post-archive-hook.sh
+++ b/scripts/post-archive-hook.sh
@@ -17,12 +17,13 @@ warn() {
   echo "[post-archive-hook] WARNING: $*" >&2
 }
 
-resolve_from_project_root() {
+resolve_from_base() {
   local path="$1"
+  local base_dir="$2"
 
   case "$path" in
     /*) printf '%s\n' "$path" ;;
-    *)  printf '%s/%s\n' "$PROJECT_ROOT" "$path" ;;
+    *)  printf '%s/%s\n' "$base_dir" "$path" ;;
   esac
 }
 
@@ -30,14 +31,24 @@ MILESTONE_SLUG="${1:-}"
 ARCHIVE_PATH="${2:-}"
 TAG="${3-}"
 
-PROJECT_ROOT="${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}"
-DEFAULT_CONFIG_PATH="${VBW_PLANNING_DIR:-$PROJECT_ROOT/.vbw-planning}/config.json"
+BASE_ROOT="${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}"
+DEFAULT_CONFIG_PATH="${VBW_PLANNING_DIR:-$BASE_ROOT/.vbw-planning}/config.json"
 CONFIG_PATH="${4:-$DEFAULT_CONFIG_PATH}"
-CONFIG_PATH=$(resolve_from_project_root "$CONFIG_PATH")
+CONFIG_PATH=$(resolve_from_base "$CONFIG_PATH" "$BASE_ROOT")
 
-PLANNING_DIR=$(dirname "$CONFIG_PATH")
+if CONFIG_DIR=$(cd "$(dirname "$CONFIG_PATH")" 2>/dev/null && pwd -P 2>/dev/null); then
+  CONFIG_PATH="$CONFIG_DIR/$(basename "$CONFIG_PATH")"
+  PLANNING_DIR="$CONFIG_DIR"
+else
+  PLANNING_DIR=$(dirname "$CONFIG_PATH")
+fi
+
+PROJECT_ROOT=$(dirname "$PLANNING_DIR")
 export VBW_CONFIG_ROOT="$PROJECT_ROOT"
 export VBW_PLANNING_DIR="$PLANNING_DIR"
+
+[ -n "$MILESTONE_SLUG" ] || exit 0
+[ -n "$ARCHIVE_PATH" ] || exit 0
 
 LOG_EVENT_SCRIPT="$SCRIPT_DIR/log-event.sh"
 if [ -f "$LOG_EVENT_SCRIPT" ]; then
@@ -47,9 +58,6 @@ if [ -f "$LOG_EVENT_SCRIPT" ]; then
     "tag=$TAG" \
     >/dev/null 2>&1 || true
 fi
-
-[ -n "$MILESTONE_SLUG" ] || exit 0
-[ -n "$ARCHIVE_PATH" ] || exit 0
 
 if [ ! -f "$CONFIG_PATH" ]; then
   warn "config not found at $CONFIG_PATH; skipping post_archive hook"
@@ -68,7 +76,7 @@ HOOK_PATH=$(jq -r '.hooks.post_archive // ""' "$CONFIG_PATH" 2>/dev/null) || {
 
 [ -n "$HOOK_PATH" ] || exit 0
 
-HOOK_PATH=$(resolve_from_project_root "$HOOK_PATH")
+HOOK_PATH=$(resolve_from_base "$HOOK_PATH" "$PROJECT_ROOT")
 
 if [ ! -f "$HOOK_PATH" ]; then
   warn "configured post_archive hook not found at $HOOK_PATH; skipping"

--- a/scripts/post-archive-hook.sh
+++ b/scripts/post-archive-hook.sh
@@ -85,7 +85,10 @@ if [ ! -f "$HOOK_PATH" ]; then
   exit 0
 fi
 
-if ! bash "$HOOK_PATH" "$MILESTONE_SLUG" "$ARCHIVE_PATH" "$TAG"; then
+if ! (
+  cd "$PROJECT_ROOT" 2>/dev/null &&
+    bash "$HOOK_PATH" "$MILESTONE_SLUG" "$ARCHIVE_PATH" "$TAG"
+); then
   warn "configured post_archive hook failed at $HOOK_PATH; continuing archive"
 fi
 

--- a/scripts/post-archive-hook.sh
+++ b/scripts/post-archive-hook.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -u
+
+# post-archive-hook.sh <milestone-slug> <archive-path> <tag> [config-path]
+# Fail-open dispatcher for user-configured post-archive hooks.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P 2>/dev/null || dirname "$0")
+ROOT_HELPER="$SCRIPT_DIR/lib/vbw-config-root.sh"
+
+if [ -f "$ROOT_HELPER" ]; then
+  # shellcheck source=lib/vbw-config-root.sh
+  . "$ROOT_HELPER"
+  find_vbw_root "$SCRIPT_DIR" 2>/dev/null || true
+fi
+
+warn() {
+  echo "[post-archive-hook] WARNING: $*" >&2
+}
+
+resolve_from_project_root() {
+  local path="$1"
+
+  case "$path" in
+    /*) printf '%s\n' "$path" ;;
+    *)  printf '%s/%s\n' "$PROJECT_ROOT" "$path" ;;
+  esac
+}
+
+MILESTONE_SLUG="${1:-}"
+ARCHIVE_PATH="${2:-}"
+TAG="${3-}"
+
+PROJECT_ROOT="${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}"
+DEFAULT_CONFIG_PATH="${VBW_PLANNING_DIR:-$PROJECT_ROOT/.vbw-planning}/config.json"
+CONFIG_PATH="${4:-$DEFAULT_CONFIG_PATH}"
+CONFIG_PATH=$(resolve_from_project_root "$CONFIG_PATH")
+
+PLANNING_DIR=$(dirname "$CONFIG_PATH")
+export VBW_CONFIG_ROOT="$PROJECT_ROOT"
+export VBW_PLANNING_DIR="$PLANNING_DIR"
+
+LOG_EVENT_SCRIPT="$SCRIPT_DIR/log-event.sh"
+if [ -f "$LOG_EVENT_SCRIPT" ]; then
+  bash "$LOG_EVENT_SCRIPT" milestone_shipped archive \
+    "slug=$MILESTONE_SLUG" \
+    "archive_path=$ARCHIVE_PATH" \
+    "tag=$TAG" \
+    >/dev/null 2>&1 || true
+fi
+
+[ -n "$MILESTONE_SLUG" ] || exit 0
+[ -n "$ARCHIVE_PATH" ] || exit 0
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  warn "config not found at $CONFIG_PATH; skipping post_archive hook"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq unavailable; skipping post_archive hook"
+  exit 0
+fi
+
+HOOK_PATH=$(jq -r '.hooks.post_archive // ""' "$CONFIG_PATH" 2>/dev/null) || {
+  warn "could not read hooks.post_archive from $CONFIG_PATH; skipping post_archive hook"
+  exit 0
+}
+
+[ -n "$HOOK_PATH" ] || exit 0
+
+HOOK_PATH=$(resolve_from_project_root "$HOOK_PATH")
+
+if [ ! -f "$HOOK_PATH" ]; then
+  warn "configured post_archive hook not found at $HOOK_PATH; skipping"
+  exit 0
+fi
+
+if ! bash "$HOOK_PATH" "$MILESTONE_SLUG" "$ARCHIVE_PATH" "$TAG"; then
+  warn "configured post_archive hook failed at $HOOK_PATH; continuing archive"
+fi
+
+exit 0

--- a/scripts/post-archive-hook.sh
+++ b/scripts/post-archive-hook.sh
@@ -50,6 +50,8 @@ export VBW_PLANNING_DIR="$PLANNING_DIR"
 [ -n "$MILESTONE_SLUG" ] || exit 0
 [ -n "$ARCHIVE_PATH" ] || exit 0
 
+ARCHIVE_PATH=$(resolve_from_base "$ARCHIVE_PATH" "$PROJECT_ROOT")
+
 LOG_EVENT_SCRIPT="$SCRIPT_DIR/log-event.sh"
 if [ -f "$LOG_EVENT_SCRIPT" ]; then
   bash "$LOG_EVENT_SCRIPT" milestone_shipped archive \

--- a/scripts/token-baseline.sh
+++ b/scripts/token-baseline.sh
@@ -91,11 +91,11 @@ count_escalations_legacy() {
 get_phases() {
   local phases=""
   if [ -f "$EVENTS_FILE" ]; then
-    phases=$(jq -s '[.[].phase] | unique | sort | .[]' "$EVENTS_FILE" 2>/dev/null || echo "")
+    phases=$(jq -r -s '[.[] | .phase | select((type == "number") or (type == "string" and test("^[0-9]+$")))] | map(tostring) | unique | sort_by(tonumber) | .[]' "$EVENTS_FILE" 2>/dev/null || echo "")
   fi
   if [ -f "$METRICS_FILE" ]; then
     local metric_phases
-    metric_phases=$(jq -s '[.[].phase] | unique | sort | .[]' "$METRICS_FILE" 2>/dev/null || echo "")
+    metric_phases=$(jq -r -s '[.[] | .phase | select((type == "number") or (type == "string" and test("^[0-9]+$")))] | map(tostring) | unique | sort_by(tonumber) | .[]' "$METRICS_FILE" 2>/dev/null || echo "")
     if [ -n "$metric_phases" ]; then
       if [ -n "$phases" ]; then
         phases=$(printf '%s\n%s' "$phases" "$metric_phases" | sort -n | uniq)
@@ -253,8 +253,8 @@ build_comparison() {
   # Detect phase changes (new/removed phases)
   local phase_changes="{}"
   local baseline_phases current_phases
-  baseline_phases=$(echo "$baseline" | jq -r '.phases | keys[]' 2>/dev/null || echo "")
-  current_phases=$(echo "$current" | jq -r '.phases | keys[]' 2>/dev/null || echo "")
+  baseline_phases=$(echo "$baseline" | jq -r '.phases | keys[] | select(test("^[0-9]+$"))' 2>/dev/null || echo "")
+  current_phases=$(echo "$current" | jq -r '.phases | keys[] | select(test("^[0-9]+$"))' 2>/dev/null || echo "")
 
   for bp in $baseline_phases; do
     if ! echo "$current_phases" | grep -qw "$bp"; then
@@ -310,7 +310,7 @@ build_report() {
   echo "|-------|----------|-----------------|-------|---------------|"
 
   local phase_keys
-  phase_keys=$(echo "$measurement" | jq -r '.phases | keys[] | tonumber' 2>/dev/null | sort -n || echo "")
+  phase_keys=$(echo "$measurement" | jq -r '.phases | keys[] | select(test("^[0-9]+$")) | tonumber' 2>/dev/null | sort -n || echo "")
   local t_ov t_tr t_ta t_opt
   t_ov=$(echo "$measurement" | jq -r '.totals.overages // 0' 2>/dev/null)
   t_tr=$(echo "$measurement" | jq -r '.totals.truncated_chars // .totals.truncated_lines // 0' 2>/dev/null)

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -541,6 +541,35 @@ else
 fi
 
 echo ""
+echo "=== Archive Hook Wiring Verification ==="
+
+archive_block=$(mode_block "### Mode: Archive")
+
+if printf '%s\n' "$archive_block" | grep -Fq '9b. Post-archive hook (non-blocking): after successful archive completion, run:'; then
+  pass "vibe: Archive mode includes explicit post-archive hook step"
+else
+  fail "vibe: Archive mode missing explicit post-archive hook step"
+fi
+
+if printf '%s\n' "$archive_block" | grep -Fq 'bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/post-archive-hook.sh "{SLUG}" ".vbw-planning/milestones/{SLUG}" "{tag}" .vbw-planning/config.json'; then
+  pass "vibe: Archive mode wires post-archive hook with slug/archive/tag/config arguments"
+else
+  fail "vibe: Archive mode missing post-archive hook argument contract"
+fi
+
+archive_regen_line=$(printf '%s\n' "$archive_block" | awk '/9\. Regenerate CLAUDE\.md:/{print NR; exit}')
+archive_hook_line=$(printf '%s\n' "$archive_block" | awk '/9b\. Post-archive hook \(non-blocking\):/{print NR; exit}')
+archive_present_line=$(printf '%s\n' "$archive_block" | awk '/10\. Present:/{print NR; exit}')
+
+if [ -n "$archive_regen_line" ] && [ -n "$archive_hook_line" ] && [ -n "$archive_present_line" ] \
+  && [ "$archive_regen_line" -lt "$archive_hook_line" ] \
+  && [ "$archive_hook_line" -lt "$archive_present_line" ]; then
+  pass "vibe: Archive post-archive hook remains between CLAUDE regeneration and final presentation"
+else
+  fail "vibe: Archive post-archive hook ordering drifted outside the successful archive sequence"
+fi
+
+echo ""
 echo "=== QA Result Gate Contract ==="
 
 QA_FILE="$COMMANDS_DIR/qa.md"

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -551,6 +551,24 @@ else
   fail "vibe: Archive mode missing explicit post-archive hook step"
 fi
 
+if printf '%s\n' "$archive_block" | grep -Fq 'MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh .vbw-planning)'; then
+  pass "vibe: Archive mode derives milestone slug via derive-milestone-slug.sh"
+else
+  fail "vibe: Archive mode missing deterministic milestone slug derivation"
+fi
+
+if printf '%s\n' "$archive_block" | grep -Fq 'Parse args: --tag=vN.N.N (custom tag), --no-tag (skip), --force (skip non-UAT audit).'; then
+  pass "vibe: Archive mode still defines --tag as a custom git tag"
+else
+  fail "vibe: Archive mode no longer defines --tag as a custom git tag"
+fi
+
+if printf '%s\n' "$archive_block" | grep -Fq 'Override with `--tag` if provided.'; then
+  fail "vibe: Archive mode still lets --tag override milestone slug"
+else
+  pass "vibe: Archive mode keeps milestone slug separate from custom --tag"
+fi
+
 if printf '%s\n' "$archive_block" | grep -Fq 'bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/post-archive-hook.sh "{SLUG}" ".vbw-planning/milestones/{SLUG}" "{tag}" .vbw-planning/config.json'; then
   pass "vibe: Archive mode wires post-archive hook with slug/archive/tag/config arguments"
 else

--- a/tests/event-type-validation.bats
+++ b/tests/event-type-validation.bats
@@ -29,6 +29,15 @@ teardown() {
   [ "$output" = "1" ]
 }
 
+@test "event-types: accepts internal milestone_shipped event type" {
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/log-event.sh" milestone_shipped archive slug=01-demo archive_path=.vbw-planning/milestones/01-demo tag=milestone/01-demo
+  [ "$status" -eq 0 ]
+  [ -f .vbw-planning/.events/event-log.jsonl ]
+  run jq -r '.event + ":" + .phase' .vbw-planning/.events/event-log.jsonl
+  [ "$output" = "milestone_shipped:archive" ]
+}
+
 @test "event-types: rejects unknown event type" {
   cd "$TEST_TEMP_DIR"
   run bash -c "bash '$SCRIPTS_DIR/log-event.sh' bogus_event 1 2>&1"

--- a/tests/post-archive-hook.bats
+++ b/tests/post-archive-hook.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  create_test_config
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+@test "post-archive-hook: no config key no-ops and writes milestone event" {
+  cd "$TEST_TEMP_DIR"
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "01-demo" \
+    ".vbw-planning/milestones/01-demo" \
+    "milestone/01-demo"
+
+  [ "$status" -eq 0 ]
+  [ -f .vbw-planning/.events/event-log.jsonl ]
+
+  run jq -r '.event + ":" + .phase + ":" + .data.slug + ":" + .data.archive_path + ":" + .data.tag' .vbw-planning/.events/event-log.jsonl
+  [ "$output" = "milestone_shipped:archive:01-demo:.vbw-planning/milestones/01-demo:milestone/01-demo" ]
+}
+
+@test "post-archive-hook: missing hook file warns and succeeds" {
+  cd "$TEST_TEMP_DIR"
+  jq '.hooks = {"post_archive": "scripts/hooks/missing.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "01-demo" \
+    ".vbw-planning/milestones/01-demo" \
+    "milestone/01-demo"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"configured post_archive hook not found"* ]]
+}
+
+@test "post-archive-hook: resolves project-relative hook path" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p scripts/hooks
+  cat > scripts/hooks/post-archive.sh <<EOF
+#!/usr/bin/env bash
+printf 'slug=%s\narchive=%s\ntag=%s\n' "\$1" "\$2" "\$3" > "$TEST_TEMP_DIR/hook-args.txt"
+EOF
+
+  jq '.hooks = {"post_archive": "scripts/hooks/post-archive.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "01-demo" \
+    ".vbw-planning/milestones/01-demo" \
+    "milestone/01-demo"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/hook-args.txt" ]
+
+  run cat "$TEST_TEMP_DIR/hook-args.txt"
+  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=milestone/01-demo' ]
+}
+
+@test "post-archive-hook: hook failure warns and still succeeds" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p scripts/hooks
+  cat > scripts/hooks/post-archive.sh <<'EOF'
+#!/usr/bin/env bash
+echo "hook exploded" >&2
+exit 17
+EOF
+
+  jq '.hooks = {"post_archive": "scripts/hooks/post-archive.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "01-demo" \
+    ".vbw-planning/milestones/01-demo" \
+    "milestone/01-demo"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hook exploded"* ]]
+  [[ "$output" == *"configured post_archive hook failed"* ]]
+}
+
+@test "post-archive-hook: preserves empty tag argument" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p scripts/hooks
+  cat > scripts/hooks/post-archive.sh <<EOF
+#!/usr/bin/env bash
+printf 'slug=%s\narchive=%s\ntag=%s\n' "\$1" "\$2" "\$3" > "$TEST_TEMP_DIR/hook-args.txt"
+EOF
+
+  jq '.hooks = {"post_archive": "scripts/hooks/post-archive.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "01-demo" \
+    ".vbw-planning/milestones/01-demo" \
+    ""
+
+  [ "$status" -eq 0 ]
+
+  run cat "$TEST_TEMP_DIR/hook-args.txt"
+  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=' ]
+}

--- a/tests/post-archive-hook.bats
+++ b/tests/post-archive-hook.bats
@@ -134,6 +134,28 @@ EOF
   [ "$output" = "$expected" ]
 }
 
+@test "post-archive-hook: runs user hook from project root when invoked in subdir" {
+  cd "$TEST_TEMP_DIR"
+  root_real=$(pwd -P)
+  mkdir -p scripts/hooks subdir
+  cat > scripts/hooks/post-archive.sh <<EOF
+#!/usr/bin/env bash
+printf 'pwd=%s\nslug=%s\narchive=%s\ntag=%s\nroot_file=%s\n' "\$(pwd -P)" "\$1" "\$2" "\$3" "\$(if [ -f scripts/hooks/post-archive.sh ]; then echo yes; else echo no; fi)" > "$TEST_TEMP_DIR/hook-context.txt"
+EOF
+
+  jq '.hooks = {"post_archive": "scripts/hooks/post-archive.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash -c "cd '$TEST_TEMP_DIR/subdir' && bash '$SCRIPTS_DIR/post-archive-hook.sh' '01-demo' '.vbw-planning/milestones/01-demo' 'milestone/01-demo'"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/hook-context.txt" ]
+
+  run cat "$TEST_TEMP_DIR/hook-context.txt"
+  expected=$(printf 'pwd=%s\nslug=%s\narchive=%s\ntag=%s\nroot_file=%s' "$root_real" "01-demo" "$root_real/.vbw-planning/milestones/01-demo" "milestone/01-demo" "yes")
+  [ "$output" = "$expected" ]
+}
+
 @test "post-archive-hook: invalid archive context writes no milestone event" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/post-archive-hook.bats
+++ b/tests/post-archive-hook.bats
@@ -106,3 +106,35 @@ EOF
   run cat "$TEST_TEMP_DIR/hook-args.txt"
   [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=' ]
 }
+
+@test "post-archive-hook: absolute config path anchors relative hook off-root" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p scripts/hooks "$TEST_TEMP_DIR/outside"
+  cat > scripts/hooks/post-archive.sh <<EOF
+#!/usr/bin/env bash
+printf 'slug=%s\narchive=%s\ntag=%s\n' "\$1" "\$2" "\$3" > "$TEST_TEMP_DIR/hook-args.txt"
+EOF
+
+  jq '.hooks = {"post_archive": "scripts/hooks/post-archive.sh"}' .vbw-planning/config.json > .vbw-planning/config.json.tmp
+  mv .vbw-planning/config.json.tmp .vbw-planning/config.json
+
+  run bash -c "cd '$TEST_TEMP_DIR/outside' && bash '$SCRIPTS_DIR/post-archive-hook.sh' '01-demo' '.vbw-planning/milestones/01-demo' 'milestone/01-demo' '$TEST_TEMP_DIR/.vbw-planning/config.json'"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/hook-args.txt" ]
+
+  run cat "$TEST_TEMP_DIR/hook-args.txt"
+  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=milestone/01-demo' ]
+}
+
+@test "post-archive-hook: invalid archive context writes no milestone event" {
+  cd "$TEST_TEMP_DIR"
+
+  run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
+    "" \
+    ".vbw-planning/milestones/01-demo" \
+    "milestone/01-demo"
+
+  [ "$status" -eq 0 ]
+  [ ! -f .vbw-planning/.events/event-log.jsonl ]
+}

--- a/tests/post-archive-hook.bats
+++ b/tests/post-archive-hook.bats
@@ -13,6 +13,7 @@ teardown() {
 
 @test "post-archive-hook: no config key no-ops and writes milestone event" {
   cd "$TEST_TEMP_DIR"
+  root_real=$(pwd -P)
 
   run bash "$SCRIPTS_DIR/post-archive-hook.sh" \
     "01-demo" \
@@ -23,7 +24,7 @@ teardown() {
   [ -f .vbw-planning/.events/event-log.jsonl ]
 
   run jq -r '.event + ":" + .phase + ":" + .data.slug + ":" + .data.archive_path + ":" + .data.tag' .vbw-planning/.events/event-log.jsonl
-  [ "$output" = "milestone_shipped:archive:01-demo:.vbw-planning/milestones/01-demo:milestone/01-demo" ]
+  [ "$output" = "milestone_shipped:archive:01-demo:$root_real/.vbw-planning/milestones/01-demo:milestone/01-demo" ]
 }
 
 @test "post-archive-hook: missing hook file warns and succeeds" {
@@ -42,6 +43,7 @@ teardown() {
 
 @test "post-archive-hook: resolves project-relative hook path" {
   cd "$TEST_TEMP_DIR"
+  root_real=$(pwd -P)
   mkdir -p scripts/hooks
   cat > scripts/hooks/post-archive.sh <<EOF
 #!/usr/bin/env bash
@@ -60,7 +62,8 @@ EOF
   [ -f "$TEST_TEMP_DIR/hook-args.txt" ]
 
   run cat "$TEST_TEMP_DIR/hook-args.txt"
-  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=milestone/01-demo' ]
+  expected=$(printf 'slug=%s\narchive=%s\ntag=%s' "01-demo" "$root_real/.vbw-planning/milestones/01-demo" "milestone/01-demo")
+  [ "$output" = "$expected" ]
 }
 
 @test "post-archive-hook: hook failure warns and still succeeds" {
@@ -87,6 +90,7 @@ EOF
 
 @test "post-archive-hook: preserves empty tag argument" {
   cd "$TEST_TEMP_DIR"
+  root_real=$(pwd -P)
   mkdir -p scripts/hooks
   cat > scripts/hooks/post-archive.sh <<EOF
 #!/usr/bin/env bash
@@ -104,11 +108,13 @@ EOF
   [ "$status" -eq 0 ]
 
   run cat "$TEST_TEMP_DIR/hook-args.txt"
-  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=' ]
+  expected=$(printf 'slug=%s\narchive=%s\ntag=%s' "01-demo" "$root_real/.vbw-planning/milestones/01-demo" "")
+  [ "$output" = "$expected" ]
 }
 
 @test "post-archive-hook: absolute config path anchors relative hook off-root" {
   cd "$TEST_TEMP_DIR"
+  root_real=$(pwd -P)
   mkdir -p scripts/hooks "$TEST_TEMP_DIR/outside"
   cat > scripts/hooks/post-archive.sh <<EOF
 #!/usr/bin/env bash
@@ -124,7 +130,8 @@ EOF
   [ -f "$TEST_TEMP_DIR/hook-args.txt" ]
 
   run cat "$TEST_TEMP_DIR/hook-args.txt"
-  [ "$output" = $'slug=01-demo\narchive=.vbw-planning/milestones/01-demo\ntag=milestone/01-demo' ]
+  expected=$(printf 'slug=%s\narchive=%s\ntag=%s' "01-demo" "$root_real/.vbw-planning/milestones/01-demo" "milestone/01-demo")
+  [ "$output" = "$expected" ]
 }
 
 @test "post-archive-hook: invalid archive context writes no milestone event" {

--- a/tests/token-baseline.bats
+++ b/tests/token-baseline.bats
@@ -99,6 +99,32 @@ JSON
   [ "$delta" -eq -2 ]
 }
 
+@test "token-baseline: ignores archive lifecycle pseudo-phase" {
+  cd "$TEST_TEMP_DIR"
+  echo '{"ts":"2026-02-13T10:00:00Z","event_id":"e1","event":"task_started","phase":1}' >> .vbw-planning/.events/event-log.jsonl
+  echo '{"ts":"2026-02-13T10:00:01Z","event_id":"e2","event":"milestone_shipped","phase":"archive","data":{"slug":"01-demo","archive_path":"/tmp/demo/.vbw-planning/milestones/01-demo","tag":"milestone/01-demo"}}' >> .vbw-planning/.events/event-log.jsonl
+  echo '{"ts":"2026-02-13T10:00:00Z","event":"token_overage","phase":1,"data":{"role":"dev","lines_total":"500","lines_max":"800","lines_truncated":"100"}}' >> .vbw-planning/.metrics/run-metrics.jsonl
+
+  run bash scripts/token-baseline.sh measure
+  [ "$status" -eq 0 ]
+  archive_present=$(echo "$output" | jq '.phases | has("archive")')
+  [ "$archive_present" = "false" ]
+
+  mkdir -p .vbw-planning/.baselines
+  cat > .vbw-planning/.baselines/token-baseline.json <<'JSON'
+{"timestamp":"2026-02-10T00:00:00Z","phases":{"1":{"overages":1,"truncated_chars":100,"tasks":1,"escalations_legacy":0,"overages_per_task":1},"archive":{"overages":0,"truncated_chars":0,"tasks":0,"escalations_legacy":0,"overages_per_task":0}},"totals":{"overages":1,"truncated_chars":100,"tasks":1,"escalations_legacy":0,"overages_per_task":1},"budget_utilization":{}}
+JSON
+
+  run bash scripts/token-baseline.sh compare
+  [ "$status" -eq 0 ]
+  archive_change=$(echo "$output" | jq '.phase_changes | has("archive")')
+  [ "$archive_change" = "false" ]
+
+  run bash scripts/token-baseline.sh report
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"| archive |"* ]]
+}
+
 @test "token-baseline: compare exits 0 when no baseline exists" {
   cd "$TEST_TEMP_DIR"
   echo '{"ts":"2026-02-13T10:00:00Z","event":"token_overage","phase":1,"data":{"role":"dev","lines_total":"500","lines_max":"800","lines_truncated":"100"}}' >> .vbw-planning/.metrics/run-metrics.jsonl


### PR DESCRIPTION
Fixes #210

## What

This change adds a first-class post-archive lifecycle extension point to VBW’s Archive mode. `commands/vibe.md` now invokes a dedicated dispatcher after successful archive completion, `scripts/post-archive-hook.sh` resolves and runs an optional `hooks.post_archive` script from `.vbw-planning/config.json`, and the dispatcher emits an internal `milestone_shipped` lifecycle event. The change also adds regression coverage for dispatcher behavior, Archive-mode wiring, and downstream event-log consumers so the hook remains stable if the archive flow evolves.

## Why

Issue #210 describes a real gap in the archive lifecycle: users had no stable post-archive hook and had to rely on brittle PostToolUse path matching against archive artifacts. The right architectural fix is a dedicated archive completion boundary with a single dispatcher entry point, not more path heuristics. That keeps archive behavior explicit, config-driven, and forward-compatible even if the implementation details of archive mode change.

## How

- `commands/vibe.md` — adds one non-blocking post-archive dispatcher step after successful archive completion and keeps milestone slug semantics separate from custom `--tag` handling.
- `scripts/post-archive-hook.sh` — new fail-open dispatcher that reads `hooks.post_archive`, normalizes config/root/archive paths, runs the user hook from the canonical project root, preserves empty tag behavior, and logs `milestone_shipped` only when archive context is valid.
- `scripts/log-event.sh` — accepts `milestone_shipped` as an internal lifecycle event.
- `scripts/token-baseline.sh` — filters non-numeric lifecycle markers out of phase-based token baseline reporting so the new archive event does not create bogus pseudo-phases.
- `tests/post-archive-hook.bats` — covers no-op config, missing hook, failing hook, empty tag, off-root absolute-config invocation, and subdirectory invocation from inside the repo.
- `tests/event-type-validation.bats` — pins `milestone_shipped` as an allowed internal event.
- `tests/token-baseline.bats` — verifies archive lifecycle markers do not leak into token-baseline phase reporting.
- `testing/verify-commands-contract.sh` — pins the Archive-mode wiring, argument contract, ordering, and slug/tag separation so `commands/vibe.md` cannot silently drop or corrupt the feature.
- `README.md` — documents sparse opt-in `hooks.post_archive` configuration and runtime behavior.

## Acceptance criteria verification

1. **Archive mode exposes a first-class post-archive lifecycle hook after successful archive completion.**
   - Satisfied by `commands/vibe.md` Archive mode wiring and `testing/verify-commands-contract.sh` archive-hook contract checks.
2. **Users can configure the hook centrally via `.vbw-planning/config.json` using `hooks.post_archive`.**
   - Satisfied by `scripts/post-archive-hook.sh` config lookup and `README.md` configuration docs.
3. **The hook receives reliable milestone context for downstream automation.**
   - Satisfied by `scripts/post-archive-hook.sh` normalized slug/archive/tag forwarding and `tests/post-archive-hook.bats` coverage for root, off-root, empty-tag, and subdirectory invocation cases.
4. **The lifecycle event remains robust and does not regress touched downstream behavior.**
   - Satisfied by `scripts/log-event.sh`, `tests/event-type-validation.bats`, `scripts/token-baseline.sh`, `tests/token-baseline.bats`, and `testing/verify-commands-contract.sh`.

## Testing

- [x] `bash -n scripts/post-archive-hook.sh scripts/token-baseline.sh`
- [x] `shellcheck -S warning scripts/post-archive-hook.sh scripts/token-baseline.sh`
- [x] `bats tests/post-archive-hook.bats tests/event-type-validation.bats tests/token-baseline.bats`
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/run-all.sh`
- [x] Required GitHub Actions checks green on `ece3ff986ee90988da603b1b40e541d03166712c`

## QA summary

- Primary QA rounds completed: **3** (`qa-investigator`)
  - Round 1: fixed config-root anchoring and false-positive event emission
  - Round 2: fixed canonical archive-path forwarding and token-baseline pseudo-phase regression
  - Round 3: clean
- Cross-model QA rounds completed: **4** (`qa-investigator-gpt-54` / GPT-5.4)
  - Round 1: fixed project-root execution for user hooks
  - Round 2: added command-contract coverage for archive wiring
  - Round 3: fixed slug/tag wording drift in Archive mode
  - Round 4: clean
- Copilot PR review rounds completed: **1**
  - Round 1: fresh review state `COMMENTED`, 0 inline comments, 0 unresolved Copilot threads
- Findings fixed vs false positives:
  - Fixed: all legitimate findings from both QA phases and the Copilot review loop
  - False positives: none carried forward
- CI/CD status: all required GitHub Actions checks green