### PR TITLE
fix(vibe): extract AskUserQuestion contract into shared reference

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -9,6 +9,10 @@ disable-model-invocation: true
 
 # VBW Vibe: $ARGUMENTS
 
+## Shared interaction contract
+
+@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md
+
 ## Context
 
 Working directory:
@@ -400,9 +404,9 @@ If $ARGUMENTS present but no flags detected, interpret user intent:
 - Verification keywords (verify, test, uat, check my work, acceptance test, walk through) -> Verify mode
 - Phase mutation keywords (add, insert, remove, skip, drop, new phase) -> relevant Phase Mutation mode
 - Completion keywords (done, ship, archive, wrap up, finish, complete) -> Archive mode
-- Ambiguous -> AskUserQuestion with 2-3 contextual options
+- Ambiguous -> AskUserQuestion with contextual options
 
-ALWAYS call AskUserQuestion to confirm interpreted intent before executing.
+Confirm the interpreted intent with AskUserQuestion before executing.
 
 ### Path 3: State detection (no args)
 
@@ -626,11 +630,11 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
 
 ### Confirmation Gate
 
-Every mode triggers confirmation before executing. **Use the AskUserQuestion tool** to present the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`), providing the recommended option and alternatives from the table below where listed. Do not render the confirmation as prose text or run a no-op command — the AskUserQuestion tool must be invoked so the user can respond via the interactive UI. For simple yes/no confirmations without a table entry, offer the affirmative action as recommended and a "Skip" or "Not now" alternative.
+Every mode triggers confirmation before executing. Follow the shared interaction contract in `references/ask-user-question.md`, then use the AskUserQuestion tool with the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`). This section stays local to `/vbw:vibe`: it defines when confirmation is skipped, which routing copy to use, and which alternatives belong to each route. For simple yes/no confirmations without a table entry, offer the affirmative action as recommended and a "Skip" or "Not now" alternative.
 - **Exception:** `--yolo` skips all confirmation gates. Error guards (missing roadmap, uninitialized project) still halt.
 - **Exception:** Flags skip confirmation (explicit intent).
 
-**Discussion-aware alternatives (NON-NEGOTIABLE):** Alternatives must reflect whether discussion has already happened for the target phase. Never offer "discuss this phase" as if discussion never happened — when `{NN}-CONTEXT.md` exists, use continuation-aware wording like "Start a discussion" (which enters the Discussion Engine's continuation mode, building on existing context rather than repeating it).
+**Discussion-aware alternatives:** Alternatives must reflect whether discussion has already happened for the target phase. Never offer "discuss this phase" as if discussion never happened — when `{NN}-CONTEXT.md` exists, use continuation-aware wording like "Start a discussion" (which enters the Discussion Engine's continuation mode, building on existing context rather than repeating it).
 
 | Routing state | Recommended | Alternatives |
 | --- | --- | --- |
@@ -638,8 +642,6 @@ Every mode triggers confirmation before executing. **Use the AskUserQuestion too
 | `needs_plan_and_execute` | "Plan and execute phase {NN}" | "Plan only (review before executing)", "Start a discussion (explore gray areas before planning)" |
 | `needs_execute` | "Execute phase {NN}" | "Review plans first", "Start a discussion (revisit scope before executing)" |
 | `milestone_uat_issues` | "Create remediation phases" | "Start fresh with new work", "Not now" |
-
-**AskUserQuestion parameters:** Set the recommended option's `isRecommended` flag. Output 3–4 blank lines before the AskUserQuestion call (the dialog obscures trailing text).
 
 ## Modes
 
@@ -1021,7 +1023,6 @@ This mode handles the case where a milestone was archived before UAT issues were
    - **"Create remediation phases"** (set `isRecommended` when `milestone_uat_major_or_higher=true`): Create one remediation phase per affected milestone phase. Auto-populate each phase goal from the UAT issue descriptions. Route to Plan mode for the first created phase.
    - **"Start fresh with new work"**: Acknowledge the stale UAT issues, mark them as acknowledged (`.remediated`) so they don't re-trigger archive blocking, then proceed as if all_done. The user can define new work via `/vbw:vibe` with arguments.
    - **"Not now"**: Skip milestone UAT recovery without marking anything. The unresolved UAT issues will re-trigger on the next `/vbw:vibe` invocation.
-   Output 3–4 blank lines before the AskUserQuestion call (the dialog obscures trailing text).
    **`--yolo` exception:** If `--yolo` was passed, skip the AskUserQuestion and auto-select "Create remediation phases" (the recommended action).
 3. If the user chooses remediation: create remediation phases via script — one per affected milestone phase:
    ```bash

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -630,7 +630,7 @@ When `next_phase_state=needs_qa_remediation`, resume QA remediation at the persi
 
 ### Confirmation Gate
 
-Every mode triggers confirmation before executing. Follow the shared interaction contract in `references/ask-user-question.md`, then use the AskUserQuestion tool with the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`). This section stays local to `/vbw:vibe`: it defines when confirmation is skipped, which routing copy to use, and which alternatives belong to each route. For simple yes/no confirmations without a table entry, offer the affirmative action as recommended and a "Skip" or "Not now" alternative.
+Every mode triggers confirmation before executing. Follow the shared interaction contract in `references/ask-user-question.md`, then use the AskUserQuestion tool with the question from the routing table's Confirmation column (marked with `→ AskUserQuestion:`). This section stays local to `/vbw:vibe`: it defines when confirmation is skipped, which routing copy to use, and which alternatives belong to each route.
 - **Exception:** `--yolo` skips all confirmation gates. Error guards (missing roadmap, uninitialized project) still halt.
 - **Exception:** Flags skip confirmation (explicit intent).
 

--- a/references/ask-user-question.md
+++ b/references/ask-user-question.md
@@ -13,11 +13,31 @@ Last reviewed: 2026-04-18
 - Mark the preferred option with `isRecommended` when one option is genuinely better.
 - Leave 3–4 blank lines before the tool call so the dialog does not cover the last line of prose.
 
+### Batch vs. sequence
+
+- Batch independent questions in a single AskUserQuestion call when answers do not depend on each other.
+- Sequence dependent questions across separate calls when answer N determines what to ask for N+1.
+
 ## Intentional freeform
 
 - Do not fake a bounded menu when the real choice space is high-cardinality or unbounded.
 - Use intentional freeform input when the user may need to name, number, search, or describe something outside a short fixed list.
 - If the user takes the `Other` path to explain their answer, treat that as real follow-up input rather than forcing them back into another pseudo-menu.
+
+### Freeform handoff
+
+- When a user selects "Other" and signals freeform intent ("let me describe it", "I'll explain", "something else"), stop using AskUserQuestion. Ask follow-up as plain text at the normal prompt.
+- Wait for the freeform response. Resume AskUserQuestion only after processing it.
+- Same rule applies when you include a freeform-indicating option ("Let me explain") and the user selects it.
+- Users can also reference options by number from the Other path: `#2 but with pagination disabled`. Accept these hybrid responses without forcing a re-selection.
+
+## Anti-patterns
+
+- **Checklist walking** — marching through a predetermined question list regardless of what the user already said.
+- **Canned questions** — asking questions whose answers are already in context.
+- **Shallow acceptance** — taking vague answers ("something like X") without probing for specifics.
+- **Premature constraints** — narrowing options before the problem space is understood.
+- **Fake bounded menus** — presenting a fixed option list when the real choice space is unbounded or high-cardinality.
 
 ## Examples
 
@@ -38,3 +58,13 @@ Why this stays freeform:
 - the list length is not bounded to 2–4 options
 - the correct answer may be a number, a phrase, or a new clarification
 - pretending this is a fixed menu creates fake structure and worse UX
+
+### Example — decision gate
+
+Header: Next step
+Question: Ready to proceed with implementation?
+Options:
+- Proceed (Recommended)
+- Keep exploring
+
+Why two options: Decision gates are binary commit/defer choices. Extra options add noise without value.

--- a/references/ask-user-question.md
+++ b/references/ask-user-question.md
@@ -1,0 +1,40 @@
+# AskUserQuestion Contract
+
+Source note: Stable VBW-facing contract distilled from Claude Code interactive prompt behavior plus the repo's current `references/execute-protocol.md` and `references/discussion-engine.md` anchor examples.
+Last reviewed: 2026-04-18
+
+## Structured choices
+
+- Keep headers short. Prefer compact labels over sentence-length titles.
+- Use structured choices when the real decision is bounded.
+- Treat 2–4 options as the sweet spot for a single question.
+- Ask 1–4 questions per tool call.
+- When options exist, Claude Code still exposes an `Other` path. Treat it as the built-in escape hatch instead of pretending freeform input does not exist.
+- Mark the preferred option with `isRecommended` when one option is genuinely better.
+- Leave 3–4 blank lines before the tool call so the dialog does not cover the last line of prose.
+
+## Intentional freeform
+
+- Do not fake a bounded menu when the real choice space is high-cardinality or unbounded.
+- Use intentional freeform input when the user may need to name, number, search, or describe something outside a short fixed list.
+- If the user takes the `Other` path to explain their answer, treat that as real follow-up input rather than forcing them back into another pseudo-menu.
+
+## Examples
+
+### Example — structured single-select
+
+Header: Confirm
+Question: Continue with phase 03 now?
+Options:
+- Execute phase 03 (Recommended — the plan is already complete)
+- Review plans first
+- Not now
+
+### Example — intentional freeform
+
+Prompt: Tell me which todo to act on. Use the todo number or describe the item in your own words.
+
+Why this stays freeform:
+- the list length is not bounded to 2–4 options
+- the correct answer may be a number, a phrase, or a new clarification
+- pretending this is a fixed menu creates fake structure and worse UX

--- a/scripts/verify-vibe.sh
+++ b/scripts/verify-vibe.sh
@@ -198,7 +198,7 @@ check "REQ-21" "vibe.md has keyword-based intent matching" grep -q "keywords" "$
 
 # REQ-22: Ambiguous intents handled
 check "REQ-22" "vibe.md handles ambiguous intents" grep -q "Ambiguous" "$VIBE"
-check "REQ-22" "vibe.md offers 2-3 options for ambiguity" grep -q "2-3.*options" "$VIBE"
+check "REQ-22" "vibe.md routes ambiguity to contextual AskUserQuestion flow" grep -q "Ambiguous -> AskUserQuestion with contextual options" "$VIBE"
 
 group_end "NL Parsing"
 

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -223,13 +223,13 @@ else
   fail "ask-user-question: missing short-header rule"
 fi
 
-if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '2.?4 options' "$ASK_USER_QUESTION_REF"; then
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '2[-–]4 options' "$ASK_USER_QUESTION_REF"; then
   pass "ask-user-question: documents 2-4 option sweet spot"
 else
   fail "ask-user-question: missing 2-4 option guidance"
 fi
 
-if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '1.?4 questions' "$ASK_USER_QUESTION_REF"; then
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '1[-–]4 questions' "$ASK_USER_QUESTION_REF"; then
   pass "ask-user-question: documents 1-4 question guidance"
 else
   fail "ask-user-question: missing 1-4 question guidance"
@@ -307,7 +307,7 @@ else
   fail "vibe: confirmation gate lost vibe-local routing constructs"
 fi
 
-if grep -Eq '2.?4 options|1.?4 questions|freeform|high-cardinality' <<< "$VIBE_CONFIRMATION_BLOCK" \
+if grep -Eq '2[-–]4 options|1[-–]4 questions|freeform|high-cardinality' <<< "$VIBE_CONFIRMATION_BLOCK" \
   || grep -Fq '`Other` path' <<< "$VIBE_CONFIRMATION_BLOCK" \
   || grep -Fq 'Keep headers short' <<< "$VIBE_CONFIRMATION_BLOCK" \
   || grep -Fq 'dialog obscures' <<< "$VIBE_CONFIRMATION_BLOCK" \

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -191,6 +191,13 @@ echo "=== AskUserQuestion Contract Verification ==="
 
 ASK_USER_QUESTION_REF="$ROOT/references/ask-user-question.md"
 VIBE_COMMAND_FILE="$COMMANDS_DIR/vibe.md"
+VIBE_CONFIRMATION_BLOCK="$({
+  awk '
+    /^### Confirmation Gate$/ { in_block=1; print; next }
+    in_block && /^## / { exit }
+    in_block { print }
+  ' "$VIBE_COMMAND_FILE"
+} || true)"
 
 if [ -f "$ASK_USER_QUESTION_REF" ]; then
   pass "ask-user-question: shared reference exists"
@@ -253,22 +260,36 @@ else
   fail "vibe: missing shared AskUserQuestion reference include"
 fi
 
-if grep -Fq '**AskUserQuestion parameters:**' "$VIBE_COMMAND_FILE"; then
-  fail "vibe: still carries duplicated AskUserQuestion parameter block"
+if [ -n "$VIBE_CONFIRMATION_BLOCK" ]; then
+  pass "vibe: confirmation gate block extracted for boundary checks"
 else
-  pass "vibe: no duplicated AskUserQuestion parameter block"
+  fail "vibe: could not extract confirmation gate block"
 fi
 
-if grep -Fq 'dialog obscures trailing text' "$VIBE_COMMAND_FILE"; then
-  fail "vibe: still duplicates generic AskUserQuestion spacing guidance"
+if grep -Fq 'references/ask-user-question.md' <<< "$VIBE_CONFIRMATION_BLOCK"; then
+  pass "vibe: confirmation gate points to shared AskUserQuestion reference"
 else
-  pass "vibe: spacing guidance now lives in shared reference"
+  fail "vibe: confirmation gate missing shared AskUserQuestion reference"
 fi
 
-if grep -Fq 'AskUserQuestion with 2-3 contextual options' "$VIBE_COMMAND_FILE"; then
-  fail "vibe: still duplicates numeric structured-choice guidance in intent routing"
+if grep -Fq '**Exception:** `--yolo` skips all confirmation gates.' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  && grep -Fq '**Exception:** Flags skip confirmation (explicit intent).' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  && grep -Fq '| Routing state | Recommended | Alternatives |' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  && grep -Fq '**Discussion-aware alternatives:**' <<< "$VIBE_CONFIRMATION_BLOCK"; then
+  pass "vibe: confirmation gate keeps vibe-local routing behavior"
 else
-  pass "vibe: intent routing no longer hardcodes generic 2-3 option guidance"
+  fail "vibe: confirmation gate lost vibe-local routing constructs"
+fi
+
+if grep -Eq '2.?4 options|1.?4 questions|freeform|high-cardinality' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  || grep -Fq '`Other` path' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  || grep -Fq 'Keep headers short' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  || grep -Fq 'dialog obscures' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  || grep -Fq 'For simple yes/no confirmations without a table entry' <<< "$VIBE_CONFIRMATION_BLOCK" \
+  || grep -Fq '**AskUserQuestion parameters:**' <<< "$VIBE_CONFIRMATION_BLOCK"; then
+  fail "vibe: confirmation gate still carries generic AskUserQuestion contract guidance"
+else
+  pass "vibe: confirmation gate keeps generic AskUserQuestion contract guidance out of vibe-local prose"
 fi
 
 echo ""

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -187,6 +187,91 @@ for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
 done
 
 echo ""
+echo "=== AskUserQuestion Contract Verification ==="
+
+ASK_USER_QUESTION_REF="$ROOT/references/ask-user-question.md"
+VIBE_COMMAND_FILE="$COMMANDS_DIR/vibe.md"
+
+if [ -f "$ASK_USER_QUESTION_REF" ]; then
+  pass "ask-user-question: shared reference exists"
+else
+  fail "ask-user-question: shared reference missing"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq 'Source note:' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: source note present"
+else
+  fail "ask-user-question: missing source note"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq 'Last reviewed:' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: last reviewed metadata present"
+else
+  fail "ask-user-question: missing last reviewed metadata"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq 'Keep headers short' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents short-header rule"
+else
+  fail "ask-user-question: missing short-header rule"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '2.?4 options' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents 2-4 option sweet spot"
+else
+  fail "ask-user-question: missing 2-4 option guidance"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Eq '1.?4 questions' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents 1-4 question guidance"
+else
+  fail "ask-user-question: missing 1-4 question guidance"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq '`Other` path' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents built-in Other path"
+else
+  fail "ask-user-question: missing built-in Other path guidance"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq 'high-cardinality or unbounded' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents intentional freeform boundary"
+else
+  fail "ask-user-question: missing intentional freeform boundary"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq '### Example — structured single-select' "$ASK_USER_QUESTION_REF" \
+  && grep -Fq '### Example — intentional freeform' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: includes structured and freeform examples"
+else
+  fail "ask-user-question: missing structured/freeform example coverage"
+fi
+
+if grep -Fq '@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md' "$VIBE_COMMAND_FILE"; then
+  pass "vibe: loads shared AskUserQuestion reference"
+else
+  fail "vibe: missing shared AskUserQuestion reference include"
+fi
+
+if grep -Fq '**AskUserQuestion parameters:**' "$VIBE_COMMAND_FILE"; then
+  fail "vibe: still carries duplicated AskUserQuestion parameter block"
+else
+  pass "vibe: no duplicated AskUserQuestion parameter block"
+fi
+
+if grep -Fq 'dialog obscures trailing text' "$VIBE_COMMAND_FILE"; then
+  fail "vibe: still duplicates generic AskUserQuestion spacing guidance"
+else
+  pass "vibe: spacing guidance now lives in shared reference"
+fi
+
+if grep -Fq 'AskUserQuestion with 2-3 contextual options' "$VIBE_COMMAND_FILE"; then
+  fail "vibe: still duplicates numeric structured-choice guidance in intent routing"
+else
+  pass "vibe: intent routing no longer hardcodes generic 2-3 option guidance"
+fi
+
+echo ""
 echo "=== skills.md Step 5b Verification ==="
 
 SKILLS_FILE="$COMMANDS_DIR/skills.md"

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -274,7 +274,7 @@ else
   fail "ask-user-question: missing decision gate example"
 fi
 
-if [ -f "$ASK_USER_QUESTION_REF" ] && ! grep -Eq 'github\.com/.*issues|fixes #[0-9]+|see #[0-9]+|issue #[0-9]+|parent.*#[0-9]+' "$ASK_USER_QUESTION_REF"; then
+if [ -f "$ASK_USER_QUESTION_REF" ] && ! grep -Eiq 'github\.com/.*issues|fixes #[0-9]+|see #[0-9]+|issue #[0-9]+|parent.*#[0-9]+' "$ASK_USER_QUESTION_REF"; then
   pass "ask-user-question: no volatile upstream issue links"
 else
   fail "ask-user-question: contains volatile upstream issue links"

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -254,6 +254,32 @@ else
   fail "ask-user-question: missing structured/freeform example coverage"
 fi
 
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq '### Freeform handoff' "$ASK_USER_QUESTION_REF" \
+  && grep -Fq 'stop using AskUserQuestion' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: documents freeform handoff rule"
+else
+  fail "ask-user-question: missing freeform handoff rule"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq '## Anti-patterns' "$ASK_USER_QUESTION_REF" \
+  && grep -Fq 'Fake bounded menus' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: includes anti-patterns section"
+else
+  fail "ask-user-question: missing anti-patterns section"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && grep -Fq '### Example — decision gate' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: includes decision gate example"
+else
+  fail "ask-user-question: missing decision gate example"
+fi
+
+if [ -f "$ASK_USER_QUESTION_REF" ] && ! grep -Eq 'github\.com/.*issues|fixes #[0-9]+|see #[0-9]+|issue #[0-9]+|parent.*#[0-9]+' "$ASK_USER_QUESTION_REF"; then
+  pass "ask-user-question: no volatile upstream issue links"
+else
+  fail "ask-user-question: contains volatile upstream issue links"
+fi
+
 if grep -Fq '@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md' "$VIBE_COMMAND_FILE"; then
   pass "vibe: loads shared AskUserQuestion reference"
 else


### PR DESCRIPTION
Fixes #487

## What

Extracts generic AskUserQuestion interaction guidance from `commands/vibe.md` into a new shared reference at `references/ask-user-question.md`, and adds contract test coverage to prevent the old duplication from returning.

## Why

Generic AskUserQuestion contract text was duplicated inside `commands/vibe.md` instead of living in a shared reference. This made the command heavier than necessary, increased drift risk, and encouraged copy-pasting high-intensity wording into other prompt artifacts. The root cause is architectural: no centralized interaction contract existed for commands to point at.

## How

- **`references/ask-user-question.md`** (NEW): Shared interaction contract covering structured choices (headers, option count, spacing, batch vs. sequence), intentional freeform guidance, freeform handoff rule (stop AskUserQuestion when user signals freeform intent via "Other"), option-by-reference tip, anti-patterns section, and three examples (structured single-select, intentional freeform, decision gate).

- **`commands/vibe.md`**: Added `@include` of the shared reference. Slimmed the Confirmation Gate section to remove all generic AskUserQuestion contract guidance (parameter blocks, spacing rules, option-count guidance, generic yes/no fallback). Retains only vibe-specific routing exceptions and alternatives table.

- **`testing/verify-commands-contract.sh`**: Added AskUserQuestion Contract Verification section with: reference existence/metadata checks, section-scoped boundary guard for vibe.md's Confirmation Gate (asserts no generic contract vocabulary leaks back), and specific assertions for freeform handoff rule, anti-patterns section, decision gate example, and volatile-link absence (case-insensitive).

- **`scripts/verify-vibe.sh`**: Updated REQ-22 check from `grep -q "2-3.*options"` to match new `AskUserQuestion.*contextual` wording.

## Acceptance criteria verification

1. ✅ Shared reference at `references/ask-user-question.md` — exists, 70 lines
2. ✅ Only stable documented invariants — no volatile issue links, no issue-status-dependent guidance
3. ✅ Includes: source note (line 3), last-reviewed date (line 4), structured example, freeform example, freeform handoff rule, anti-patterns section, decision gate example
4. ✅ No volatile upstream issue links — verified by case-insensitive contract guard
5. ✅ `commands/vibe.md` points to shared reference via `@include`
6. ✅ `commands/vibe.md` retains only vibe-specific routing/confirmation behavior — verified by section-scoped boundary guard
7. ✅ Rewrite, not lift-and-shift — materially softer wording, restructured content
8. ✅ All tests pass: 44/44 contract, 3010/3010 BATS

## Testing

- `bash testing/verify-commands-contract.sh` — 440 PASS, 0 FAIL
- `bash testing/run-all.sh` — lint 1/1, contract 44/44, BATS 3010/3010

## QA summary

- **Primary QA (Claude Opus 4.6)**: 3 rounds. Round 1 found 2 low findings (generic sentence in vibe.md, weak contract guard) — fixed. Rounds 2–3 clean.
- **Cross-model QA (GPT-5.4)**: 2 rounds. Round 1 found 1 high observation (discussion-engine/execute-protocol alignment — out of scope, tracked by sibling #483) and 1 medium contract finding (missing contract assertions for new sections) — fixed. Round 2 found 1 low finding (case-insensitive volatile-link regex) — fixed.
- **All findings fixed**: 4 legitimate findings across 5 QA rounds, 1 observation filed for sibling issue.
- **Copilot PR review**: pending