### PR TITLE
fix(debug): normalize debug session lifecycle spacing

### DIFF
--- a/scripts/write-debug-session.sh
+++ b/scripts/write-debug-session.sh
@@ -80,13 +80,46 @@ update_frontmatter() {
 # section content are preserved verbatim and do not prematurely end a section.
 KNOWN_SECTIONS_RE='^## (Issue|Investigation|Plan|Implementation|QA|UAT|Remediation History)$'
 
+# Strip leading and trailing blank lines while preserving intentional internal spacing.
+normalize_content() {
+  printf '%s' "$1" | awk '
+    { buf[++n] = $0 }
+    END {
+      start = 1
+      while (start <= n && buf[start] == "") start++
+      end = n
+      while (end >= start && buf[end] == "") end--
+      for (i = start; i <= end; i++) print buf[i]
+    }
+  '
+}
+
+write_normalized_content_file() {
+  local content="$1" file="$2"
+  normalize_content "$content" > "$file"
+}
+
+# Escape multiline values for markdown tables without relying on sed implementation quirks.
+escape_table_cell() {
+  awk '
+    BEGIN { first = 1 }
+    {
+      sub(/\r$/, "", $0)
+      gsub(/\|/, "\\|", $0)
+      if (!first) printf "<br>"
+      printf "%s", $0
+      first = 0
+    }
+  '
+}
+
 # Replace content of a section (from ## Heading to next known top-level section or EOF)
 replace_section() {
   local heading="$1" content="$2"
   local tmpfile content_file
   tmpfile=$(mktemp)
   content_file=$(mktemp)
-  printf '%s\n' "$content" > "$content_file"
+  write_normalized_content_file "$content" "$content_file"
   awk -v heading="$heading" -v cfile="$content_file" -v bre="$KNOWN_SECTIONS_RE" '
     BEGIN { in_section = 0; printed = 0 }
     $0 ~ bre {
@@ -97,9 +130,13 @@ replace_section() {
       if ($0 == "## " heading) {
         print $0
         print ""
-        while ((getline line < cfile) > 0) print line
+        content_printed = 0
+        while ((getline line < cfile) > 0) {
+          print line
+          content_printed = 1
+        }
         close(cfile)
-        print ""
+        if (content_printed) print ""
         in_section = 1
         next
       }
@@ -118,35 +155,21 @@ replace_section() {
 # Append content under a section heading (before the next known top-level section or at EOF)
 append_to_section() {
   local heading="$1" content="$2"
-  local tmpfile content_file
-  tmpfile=$(mktemp)
-  content_file=$(mktemp)
-  printf '%s\n' "$content" > "$content_file"
-  awk -v heading="$heading" -v cfile="$content_file" -v bre="$KNOWN_SECTIONS_RE" '
-    BEGIN { in_section = 0; appended = 0 }
-    $0 ~ bre {
-      if (in_section && !appended) {
-        while ((getline line < cfile) > 0) print line
-        close(cfile)
-        print ""
-        appended = 1
-      }
-      in_section = 0
-      if ($0 == "## " heading) {
-        in_section = 1
-      }
-    }
-    { print }
-    END {
-      if (in_section && !appended) {
-        while ((getline line < cfile) > 0) print line
-        close(cfile)
-        print ""
-      }
-    }
-  ' "$SESSION_FILE" > "$tmpfile"
-  rm -f "$content_file"
-  mv "$tmpfile" "$SESSION_FILE"
+  local current_section normalized_new combined_content
+
+  current_section=$(extract_section "$heading" "$SESSION_FILE")
+  current_section=$(normalize_content "$current_section")
+  normalized_new=$(normalize_content "$content")
+
+  if [ -n "$current_section" ] && [ -n "$normalized_new" ]; then
+    combined_content="${current_section}"$'\n\n'"${normalized_new}"
+  elif [ -n "$normalized_new" ]; then
+    combined_content="$normalized_new"
+  else
+    combined_content="$current_section"
+  fi
+
+  replace_section "$heading" "$combined_content"
 }
 
 # Extract content of a section (from ## Heading to next known top-level section or EOF),
@@ -325,10 +348,10 @@ case "$MODE" in
         QA_ENTRY+=$'\n'"| Check | Status | Evidence |"$'\n'
         QA_ENTRY+="| ----- | ------ | -------- |"$'\n'
         for i in $(seq 0 $((CHECKS_TOTAL - 1))); do
-          D_ID=$(echo "$json" | jq -r ".checks[$i].id // \"C$((i+1))\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
-          D_DESC=$(echo "$json" | jq -r ".checks[$i].description // \"Check $((i+1))\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
-          D_STATUS=$(echo "$json" | jq -r ".checks[$i].status // \"—\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
-          D_EVIDENCE=$(echo "$json" | jq -r ".checks[$i].evidence // \"—\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
+          D_ID=$(echo "$json" | jq -r ".checks[$i].id // \"C$((i+1))\"" | escape_table_cell)
+          D_DESC=$(echo "$json" | jq -r ".checks[$i].description // \"Check $((i+1))\"" | escape_table_cell)
+          D_STATUS=$(echo "$json" | jq -r ".checks[$i].status // \"—\"" | escape_table_cell)
+          D_EVIDENCE=$(echo "$json" | jq -r ".checks[$i].evidence // \"—\"" | escape_table_cell)
           QA_ENTRY+="| $D_ID: $D_DESC | $D_STATUS | $D_EVIDENCE |"$'\n'
         done
       fi
@@ -350,9 +373,9 @@ case "$MODE" in
         QA_ENTRY+=$'\n'"| Check | Status | Detail |"$'\n'
         QA_ENTRY+="| ----- | ------ | ------ |"$'\n'
         for i in $(seq 0 $((DETAIL_COUNT - 1))); do
-          D_NAME=$(echo "$json" | jq -r ".details[$i].name // \"Check $((i+1))\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
-          D_STATUS=$(echo "$json" | jq -r ".details[$i].status // \"—\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
-          D_DETAIL=$(echo "$json" | jq -r ".details[$i].detail // \"—\"" | sed ':a;N;$!ba;s/\r\n/<br>/g;s/\r/<br>/g;s/\n/<br>/g;s/|/\\|/g')
+          D_NAME=$(echo "$json" | jq -r ".details[$i].name // \"Check $((i+1))\"" | escape_table_cell)
+          D_STATUS=$(echo "$json" | jq -r ".details[$i].status // \"—\"" | escape_table_cell)
+          D_DETAIL=$(echo "$json" | jq -r ".details[$i].detail // \"—\"" | escape_table_cell)
           QA_ENTRY+="| $D_NAME | $D_STATUS | $D_DETAIL |"$'\n'
         done
       fi

--- a/scripts/write-debug-session.sh
+++ b/scripts/write-debug-session.sh
@@ -99,6 +99,11 @@ write_normalized_content_file() {
   normalize_content "$content" > "$file"
 }
 
+# Normalize free-form block bodies before embedding them under nested markdown headings.
+normalize_block_body() {
+  normalize_content "$1"
+}
+
 # Escape multiline values for markdown tables without relying on sed implementation quirks.
 escape_table_cell() {
   awk '
@@ -258,12 +263,14 @@ case "$MODE" in
     fi
 
     ROOT_CAUSE=$(echo "$json" | jq -r '.root_cause // empty')
+    ROOT_CAUSE=$(normalize_block_body "$ROOT_CAUSE")
     if [ -n "$ROOT_CAUSE" ]; then
       INVESTIGATION+=$'\n'"### Root Cause"$'\n\n'"$ROOT_CAUSE"
     fi
 
     PLAN=$(echo "$json" | jq -r '.plan // empty')
     IMPL=$(echo "$json" | jq -r '.implementation // empty')
+    IMPL=$(normalize_block_body "$IMPL")
 
     # Build Changed Files list
     CHANGED_FILES=""
@@ -384,6 +391,7 @@ case "$MODE" in
     fi
 
     SUMMARY=$(echo "$json" | jq -r '.summary // empty')
+    SUMMARY=$(normalize_block_body "$SUMMARY")
     [ -n "$SUMMARY" ] && QA_ENTRY+=$'\n'"$SUMMARY"$'\n'
 
     append_to_section "QA" "$QA_ENTRY"
@@ -429,6 +437,7 @@ case "$MODE" in
         CP_DESC=$(echo "$json" | jq -r ".checkpoints[$i].description // \"Checkpoint $((i+1))\"")
         CP_RESULT=$(echo "$json" | jq -r ".checkpoints[$i].result // \"pending\"")
         CP_RESPONSE=$(echo "$json" | jq -r ".checkpoints[$i].user_response // empty")
+        CP_RESPONSE=$(normalize_content "$CP_RESPONSE")
         case "$CP_RESULT" in
           pass) UAT_ENTRY+="- [x] $CP_DESC"$'\n' ;;
           skip) UAT_ENTRY+="- [-] $CP_DESC (**SKIPPED**)"$'\n' ;;
@@ -449,6 +458,7 @@ case "$MODE" in
         ISSUE_TYPE=$(echo "$json" | jq -r ".issues[$i] | type")
         if [ "$ISSUE_TYPE" = "object" ]; then
           ISSUE_DESC=$(echo "$json" | jq -r ".issues[$i].description // \"Issue $((i+1))\"")
+          ISSUE_DESC=$(normalize_content "$ISSUE_DESC")
           ISSUE_SEV=$(echo "$json" | jq -r ".issues[$i].severity // empty")
           if [ -n "$ISSUE_SEV" ]; then
             UAT_ENTRY+="- [$ISSUE_SEV] $ISSUE_DESC"$'\n'
@@ -457,12 +467,14 @@ case "$MODE" in
           fi
         else
           ISSUE_DESC=$(echo "$json" | jq -r ".issues[$i] // \"Issue $((i+1))\"")
+          ISSUE_DESC=$(normalize_content "$ISSUE_DESC")
           UAT_ENTRY+="- $ISSUE_DESC"$'\n'
         fi
       done
     fi
 
     SUMMARY=$(echo "$json" | jq -r '.summary // empty')
+    SUMMARY=$(normalize_block_body "$SUMMARY")
     [ -n "$SUMMARY" ] && UAT_ENTRY+=$'\n'"$SUMMARY"$'\n'
 
     append_to_section "UAT" "$UAT_ENTRY"

--- a/scripts/write-debug-session.sh
+++ b/scripts/write-debug-session.sh
@@ -79,16 +79,20 @@ update_frontmatter() {
 # Only these lines are treated as section delimiters — user-pasted ## headings inside
 # section content are preserved verbatim and do not prematurely end a section.
 KNOWN_SECTIONS_RE='^## (Issue|Investigation|Plan|Implementation|QA|UAT|Remediation History)$'
+BLANK_LINE_RE='^[[:space:]]*$'
 
 # Strip leading and trailing blank lines while preserving intentional internal spacing.
 normalize_content() {
-  printf '%s' "$1" | awk '
+  printf '%s' "$1" | awk -v blank_re="$BLANK_LINE_RE" '
+    function is_blank(line) {
+      return line ~ blank_re
+    }
     { buf[++n] = $0 }
     END {
       start = 1
-      while (start <= n && buf[start] == "") start++
+      while (start <= n && is_blank(buf[start])) start++
       end = n
-      while (end >= start && buf[end] == "") end--
+      while (end >= start && is_blank(buf[end])) end--
       for (i = start; i <= end; i++) print buf[i]
     }
   '
@@ -182,7 +186,10 @@ append_to_section() {
 # Strips leading and trailing blank lines (BSD-compatible)
 extract_section() {
   local heading="$1" file="$2"
-  awk -v heading="$heading" -v bre="$KNOWN_SECTIONS_RE" '
+  awk -v heading="$heading" -v bre="$KNOWN_SECTIONS_RE" -v blank_re="$BLANK_LINE_RE" '
+    function is_blank(line) {
+      return line ~ blank_re
+    }
     $0 ~ bre {
       if (in_section) exit
       if ($0 == "## " heading) { in_section = 1; next }
@@ -194,8 +201,8 @@ extract_section() {
     END {
       # Find first and last non-empty lines
       start = 0; end = 0
-      for (i = 1; i <= n; i++) { if (buf[i] != "") { start = i; break } }
-      for (i = n; i >= 1; i--) { if (buf[i] != "") { end = i; break } }
+      for (i = 1; i <= n; i++) { if (!is_blank(buf[i])) { start = i; break } }
+      for (i = n; i >= 1; i--) { if (!is_blank(buf[i])) { end = i; break } }
       for (i = start; i <= end; i++) print buf[i]
     }
   ' "$file"

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -30,6 +30,24 @@ get_suggestion() {
   bash "$SCRIPTS_DIR/suggest-next.sh" debug 2>/dev/null || true
 }
 
+# Helper: assert generated markdown does not accumulate repeated blank lines
+assert_no_repeated_blank_lines() {
+  local file="$1"
+  run awk '
+    BEGIN { blank_run = 0 }
+    /^[[:space:]]*$/ {
+      blank_run++
+      if (blank_run > 1) {
+        printf "repeated blank lines ending at line %d\n", NR
+        exit 1
+      }
+      next
+    }
+    { blank_run = 0 }
+  ' "$file"
+  [ "$status" -eq 0 ]
+}
+
 # ── Happy path lifecycle ─────────────────────────────────
 
 @test "full lifecycle: debug → QA pass → UAT pass → complete" {
@@ -176,6 +194,32 @@ get_suggestion() {
   # Remediation history should exist
   grep -q "## Remediation History" "$SESSION_FILE"
   grep -q "CSS flex" "$SESSION_FILE"  # archived from round 1
+}
+
+@test "write-debug-session normalizes blank lines across repeated lifecycle transitions" {
+  SESSION_FILE=$(start_session)
+
+  echo '{"mode":"investigation","issue":"Spacing repro","hypotheses":[],"root_cause":"Writer boundary issue","plan":"Normalize spacing","changed_files":["scripts/write-debug-session.sh"],"commit":"aaa111"}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"qa","round":1,"result":"FAIL","checks":[{"id":"c1","description":"first qa","status":"fail","evidence":"e1"}],"summary":"round1"}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"status","status":"qa_failed"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+
+  echo '{"mode":"status","status":"investigating"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"investigation","issue":"Spacing repro remediation","hypotheses":[],"root_cause":"Writer boundary issue","plan":"Normalize spacing","changed_files":["scripts/write-debug-session.sh"],"commit":"bbb222"}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"qa","round":2,"result":"PASS","checks":[{"id":"c2","description":"second qa","status":"pass","evidence":"e2"}],"summary":"round2"}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"status","status":"uat_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+  echo '{"mode":"uat","round":1,"result":"issues_found","checkpoints":[{"description":"checkpoint 1","result":"issue","user_response":"needs fix"}],"issues":[{"description":"uat issue","severity":"major"}],"summary":"uat1"}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+
+  grep -q "### Round 2 — PASS" "$SESSION_FILE"
+  grep -q "## UAT" "$SESSION_FILE"
+  grep -q "## Remediation History" "$SESSION_FILE"
+  assert_no_repeated_blank_lines "$SESSION_FILE"
 }
 
 # ── suggest-next lifecycle chain ─────────────────────────

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -198,9 +198,9 @@ assert_no_repeated_blank_lines() {
 
 @test "write-debug-session normalizes blank lines across repeated lifecycle transitions" {
   SESSION_FILE=$(start_session)
-  ROOT_CAUSE_PADDING=$'\n\nRoot cause paragraph one\n\nRoot cause paragraph two\n\n'
-  QA_SUMMARY_PADDING=$'\n\nQA summary paragraph one\n\nQA summary paragraph two\n\n'
-  UAT_SUMMARY_PADDING=$'\n\nUAT summary paragraph one\n\nUAT summary paragraph two\n\n'
+  ROOT_CAUSE_PADDING=$' \n\t \nRoot cause paragraph one\n\nRoot cause paragraph two\n \t \n\t\n'
+  QA_SUMMARY_PADDING=$'\t\n  \nQA summary paragraph one\n\nQA summary paragraph two\n \t\n\t \n'
+  UAT_SUMMARY_PADDING=$'  \n\t\nUAT summary paragraph one\n\nUAT summary paragraph two\n\t \n  \n'
 
   jq -n \
     --arg root_cause "$ROOT_CAUSE_PADDING" \
@@ -260,6 +260,39 @@ assert_no_repeated_blank_lines() {
     END {
       if (!found) {
         print "Root Cause heading not found"
+        exit 1
+      }
+    }
+  ' "$SESSION_FILE"
+  [ "$status" -eq 0 ]
+  run awk '
+    /^## Remediation History$/ {
+      getline
+      if ($0 != "") {
+        print "expected exactly one blank line after Remediation History heading"
+        exit 1
+      }
+      getline
+      if ($0 !~ /^### Round 1 — /) {
+        print "unexpected remediation round heading: " $0
+        exit 1
+      }
+      getline
+      if ($0 != "") {
+        print "expected exactly one blank line after remediation round heading"
+        exit 1
+      }
+      getline
+      if ($0 != "#### Investigation") {
+        print "unexpected remediation subsection heading: " $0
+        exit 1
+      }
+      found = 1
+      exit 0
+    }
+    END {
+      if (!found) {
+        print "Remediation History section not found"
         exit 1
       }
     }

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -198,27 +198,101 @@ assert_no_repeated_blank_lines() {
 
 @test "write-debug-session normalizes blank lines across repeated lifecycle transitions" {
   SESSION_FILE=$(start_session)
+  ROOT_CAUSE_PADDING=$'\n\nRoot cause paragraph one\n\nRoot cause paragraph two\n\n'
+  QA_SUMMARY_PADDING=$'\n\nQA summary paragraph one\n\nQA summary paragraph two\n\n'
+  UAT_SUMMARY_PADDING=$'\n\nUAT summary paragraph one\n\nUAT summary paragraph two\n\n'
 
-  echo '{"mode":"investigation","issue":"Spacing repro","hypotheses":[],"root_cause":"Writer boundary issue","plan":"Normalize spacing","changed_files":["scripts/write-debug-session.sh"],"commit":"aaa111"}' \
+  jq -n \
+    --arg root_cause "$ROOT_CAUSE_PADDING" \
+    '{mode:"investigation", issue:"Spacing repro", hypotheses:[], root_cause:$root_cause, plan:"Normalize spacing", changed_files:["scripts/write-debug-session.sh"], commit:"aaa111"}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
-  echo '{"mode":"qa","round":1,"result":"FAIL","checks":[{"id":"c1","description":"first qa","status":"fail","evidence":"e1"}],"summary":"round1"}' \
+  jq -n \
+    --arg summary "$QA_SUMMARY_PADDING" \
+    '{mode:"qa", round:1, result:"FAIL", checks:[{id:"c1", description:"first qa", status:"fail", evidence:"e1"}], summary:$summary}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   echo '{"mode":"status","status":"qa_failed"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
 
   echo '{"mode":"status","status":"investigating"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
-  echo '{"mode":"investigation","issue":"Spacing repro remediation","hypotheses":[],"root_cause":"Writer boundary issue","plan":"Normalize spacing","changed_files":["scripts/write-debug-session.sh"],"commit":"bbb222"}' \
+  jq -n \
+    --arg root_cause "$ROOT_CAUSE_PADDING" \
+    '{mode:"investigation", issue:"Spacing repro remediation", hypotheses:[], root_cause:$root_cause, plan:"Normalize spacing", changed_files:["scripts/write-debug-session.sh"], commit:"bbb222"}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
-  echo '{"mode":"qa","round":2,"result":"PASS","checks":[{"id":"c2","description":"second qa","status":"pass","evidence":"e2"}],"summary":"round2"}' \
+  jq -n \
+    --arg summary "$QA_SUMMARY_PADDING" \
+    '{mode:"qa", round:2, result:"PASS", checks:[{id:"c2", description:"second qa", status:"pass", evidence:"e2"}], summary:$summary}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
   echo '{"mode":"status","status":"uat_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
-  echo '{"mode":"uat","round":1,"result":"issues_found","checkpoints":[{"description":"checkpoint 1","result":"issue","user_response":"needs fix"}],"issues":[{"description":"uat issue","severity":"major"}],"summary":"uat1"}' \
+  jq -n \
+    --arg summary "$UAT_SUMMARY_PADDING" \
+    '{mode:"uat", round:1, result:"issues_found", checkpoints:[{description:"checkpoint 1", result:"issue", user_response:"needs fix"}], issues:[{description:"uat issue", severity:"major"}], summary:$summary}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
 
   grep -q "### Round 2 — PASS" "$SESSION_FILE"
   grep -q "## UAT" "$SESSION_FILE"
   grep -q "## Remediation History" "$SESSION_FILE"
+  run awk '
+    /^### Root Cause$/ {
+      getline
+      if ($0 != "") {
+        print "expected exactly one blank line after Root Cause heading"
+        exit 1
+      }
+      getline
+      if ($0 != "Root cause paragraph one") {
+        print "unexpected first root cause paragraph: " $0
+        exit 1
+      }
+      getline
+      if ($0 != "") {
+        print "expected preserved paragraph break inside root cause"
+        exit 1
+      }
+      getline
+      if ($0 != "Root cause paragraph two") {
+        print "unexpected second root cause paragraph: " $0
+        exit 1
+      }
+      found = 1
+      exit 0
+    }
+    END {
+      if (!found) {
+        print "Root Cause heading not found"
+        exit 1
+      }
+    }
+  ' "$SESSION_FILE"
+  [ "$status" -eq 0 ]
+  run awk '
+    $0 == "QA summary paragraph one" {
+      if (previous != "") {
+        print "expected exactly one blank line before QA summary"
+        exit 1
+      }
+      getline
+      if ($0 != "") {
+        print "expected preserved paragraph break inside QA summary"
+        exit 1
+      }
+      getline
+      if ($0 != "QA summary paragraph two") {
+        print "unexpected second QA summary paragraph: " $0
+        exit 1
+      }
+      found = 1
+      exit 0
+    }
+    { previous = $0 }
+    END {
+      if (!found) {
+        print "QA summary paragraph not found"
+        exit 1
+      }
+    }
+  ' "$SESSION_FILE"
+  [ "$status" -eq 0 ]
   assert_no_repeated_blank_lines "$SESSION_FILE"
 }
 


### PR DESCRIPTION
Fixes #492

## What
This change fixes the debug-session spacing regression at the runtime writer layer. `scripts/write-debug-session.sh` now uses one whitespace-aware boundary normalizer for section replacement, extraction, and appends so repeated investigation/QA/UAT/remediation writes no longer accumulate doubled blank lines. `tests/debug-session-lifecycle.bats` now exercises whitespace-only padding and remediation-history transitions so the defect fails loudly if it reappears.

## Why
Issue #492 was caused by the deterministic writer owning lifecycle persistence but treating only `""` as blank while section replacement/appends also managed separators. That let space/tab-only padding survive at section edges and reappear as doubled blank lines across lifecycle transitions. Fixing the behavior centrally in the writer is the correct architectural fix because the live artifacts are produced by runtime scripts, not by prompt wording or templates.

## How
- `scripts/write-debug-session.sh` — added a shared whitespace-aware blank-line definition used by `normalize_content` and `extract_section`, then kept `replace_section`, `append_to_section`, and remediation archival on that single normalized persistence path.
- `tests/debug-session-lifecycle.bats` — expanded lifecycle regression coverage to inject spaces/tabs on otherwise blank boundary lines, assert exact single-blank separators after nested headings and remediation-history headings, and keep the whole-file repeated-blank-line guard.

## Acceptance criteria verification
1. Newly written debug session markdown contains exactly one blank line between lifecycle sections and round blocks at canonical boundaries.
   - Satisfied by centralized boundary trimming and normalized section writes in `scripts/write-debug-session.sh:85-109` and `scripts/write-debug-session.sh:125-181`.
2. Repeated writes across investigation, QA, UAT, and remediation history do not accumulate doubled empty lines.
   - Satisfied by normalized section append/rewrite flow in `scripts/write-debug-session.sh:164-181` and remediation archival through the same path in `scripts/write-debug-session.sh:213-241`.
3. `scripts/write-debug-session.sh` normalizes inserted content centrally instead of relying on each builder path to manage boundary whitespace perfectly by hand.
   - Satisfied by the shared helpers in `scripts/write-debug-session.sh:85-109` and their use from the writer paths in `scripts/write-debug-session.sh:125-181`.
4. Internal paragraph spacing inside a section remains intact; only unintended leading/trailing boundary blank lines are removed.
   - Satisfied by trim-only normalization in `scripts/write-debug-session.sh:85-99`, with regression assertions in `tests/debug-session-lifecycle.bats:235-267` and `tests/debug-session-lifecycle.bats:301-329`.
5. `tests/debug-session-lifecycle.bats` includes regression coverage that fails when generated debug session artifacts contain consecutive blank-line pairs at these lifecycle boundaries.
   - Satisfied by `assert_no_repeated_blank_lines` in `tests/debug-session-lifecycle.bats:33-49` and the whitespace-aware lifecycle regression in `tests/debug-session-lifecycle.bats:199-329`.
6. `bash testing/verify-debug-session-contract.sh` passes.
   - Verified on this branch; relevant contract checks remain in `testing/verify-debug-session-contract.sh:76-90`, `testing/verify-debug-session-contract.sh:210-213`, and `testing/verify-debug-session-contract.sh:441`.
7. `bash testing/run-all.sh` passes.
   - Verified on this branch after the final `origin/main` sync.

## Testing
- [x] `bats tests/debug-session-lifecycle.bats`
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bash testing/run-all.sh`

Results from the final local validation run:
- `Lint checks: 1/1 passed`
- `Contract checks: 44/44 passed`
- `BATS: 3011 passed, 0 failed`

## QA summary
- Primary QA (`qa-investigator`): 3 rounds completed
  - Round 1: 1 medium contract finding fixed in `ad83661`
  - Round 2: 1 medium + 1 low contract findings fixed in `98cf31d`
  - Round 3: 0 findings; evidence commit `f181ff9`
  - False positives: 0
- Cross-model QA (`qa-investigator-gpt-54`, GPT-5.4): 1 round completed
  - Round 1: 0 findings; evidence commit `f2d844f`
  - False positives: 0
- Copilot PR review: 0 rounds completed so far (next phase after this draft PR)
