### PR TITLE
fix(compact): harden unauthenticated context cache handling

### DIFF
--- a/scripts/suggest-compact.sh
+++ b/scripts/suggest-compact.sh
@@ -11,7 +11,13 @@ set -u
 #   mode: execute|plan|verify|qa|discuss
 #
 # Reads:
-#   .vbw-planning/.context-usage   — "session_id|used_pct|context_window_size" (cached by statusline; legacy 2-field "used_pct|context_window_size" also accepted)
+#   .vbw-planning/.context-usage   — statusline cache written as
+#                                    "session_id|used_pct|context_window_size"
+#                                    This guard only trusts authenticated
+#                                    same-session 3-field entries. Legacy
+#                                    2-field "used_pct|context_window_size"
+#                                    entries are treated as unauthenticated
+#                                    and skipped conservatively.
 #   .vbw-planning/config.json      — compaction_threshold, autonomy, effort
 #   Plugin root reference files     — measured per mode
 #   .vbw-planning/ project files    — measured per mode
@@ -252,6 +258,19 @@ esac
 TOTAL_BYTES=$((FIXED_BYTES + VARIABLE_BYTES))
 EST_COST=$(( TOTAL_BYTES / CHARS_PER_TOKEN + BASELINE_OVERHEAD ))
 
+# Only authenticated session IDs can authorize a pre-flight warning.
+# `unknown` is a writer-side placeholder from vbw-statusline.sh, not proof that
+# the cache belongs to the current session.
+authoritative_session_id() {
+  local sid="${1:-}"
+
+  [ -n "$sid" ] || return 1
+  [ "$sid" = "unknown" ] && return 1
+  [[ "$sid" =~ [^a-zA-Z0-9._-] ]] && return 1
+
+  return 0
+}
+
 # Read cached context usage from statusline
 if [ ! -f "$USAGE_FILE" ]; then
   # No cached data yet (first command in session) — can't guard, skip silently
@@ -260,21 +279,24 @@ fi
 
 IFS='|' read -r FIELD1 FIELD2 FIELD3 < "$USAGE_FILE" 2>/dev/null || exit 0
 
-# Parse format: new 3-field "SESSION_ID|PCT|CTX_SIZE" or legacy 2-field "PCT|CTX_SIZE"
+# Parse format: authenticated 3-field "SESSION_ID|PCT|CTX_SIZE"
+# or legacy 2-field "PCT|CTX_SIZE". This guard now prefers false negatives to
+# false-positive warnings, so unauthenticated cache formats skip silently.
 if [ -n "${FIELD3:-}" ] && [[ "${FIELD2:-}" =~ ^[0-9]+$ ]] && [[ "${FIELD3:-}" =~ ^[0-9]+$ ]]; then
-  # 3-field format: validate session freshness
+  # 3-field format: require an authenticated same-session cache entry
   FILE_SID="$FIELD1"
   USED_PCT="$FIELD2"
   CTX_SIZE="$FIELD3"
-  CURRENT_SID="${CLAUDE_SESSION_ID:-unknown}"
+  CURRENT_SID="${CLAUDE_SESSION_ID:-}"
+  authoritative_session_id "$FILE_SID" || exit 0
+  authoritative_session_id "$CURRENT_SID" || exit 0
   if [ "$FILE_SID" != "$CURRENT_SID" ]; then
     # Stale data from a different session — skip guard (#238)
     exit 0
   fi
 elif [[ "${FIELD1:-}" =~ ^[0-9]+$ ]] && [[ "${FIELD2:-}" =~ ^[0-9]+$ ]] && [ -z "${FIELD3:-}" ]; then
-  # Legacy 2-field format: no session check (backward compat)
-  USED_PCT="$FIELD1"
-  CTX_SIZE="$FIELD2"
+  # Legacy 2-field format is unauthenticated, so skip the warning guard.
+  exit 0
 else
   # Unrecognized format
   exit 0

--- a/tests/suggest-compact.bats
+++ b/tests/suggest-compact.bats
@@ -49,6 +49,37 @@ teardown() {
   teardown_temp_dir
 }
 
+AUTH_SID="test-session-auth"
+
+write_authenticated_usage() {
+  local pct="$1"
+  local second="${2:-}"
+  local third="${3:-}"
+  local size sid
+
+  if [ -n "$second" ] && [[ "$second" =~ ^[0-9]+$ ]]; then
+    size="$second"
+    sid="${third:-$AUTH_SID}"
+  else
+    sid="${second:-$AUTH_SID}"
+    size="${third:-200000}"
+  fi
+
+  printf '%s|%s|%s\n' "$sid" "$pct" "$size" > .vbw-planning/.context-usage
+}
+
+write_unknown_usage() {
+  local pct="$1"
+  local size="${2:-200000}"
+  printf 'unknown|%s|%s\n' "$pct" "$size" > .vbw-planning/.context-usage
+}
+
+write_legacy_usage() {
+  local pct="$1"
+  local size="${2:-200000}"
+  printf '%s|%s\n' "$pct" "$size" > .vbw-planning/.context-usage
+}
+
 # =============================================================================
 # No output when preconditions not met
 # =============================================================================
@@ -64,23 +95,23 @@ teardown() {
 # =============================================================================
 
 @test "suggest-compact: silent when context at 30% (200K window)" {
-  echo "30|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 30
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
 @test "suggest-compact: silent when context at 50%" {
-  echo "50|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 50
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
 @test "suggest-compact: silent when context at 70% for light command" {
   # 70% of 200K = 60K remaining; discuss NEEDED=2875 — plenty of room
-  echo "70|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
+  write_authenticated_usage 70
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -91,8 +122,8 @@ teardown() {
 
 @test "suggest-compact: warns when context at 95% for execute mode" {
   # 95% of 200K = 10K remaining; execute NEEDED=12190 → warns
-  echo "95|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
   [[ "$output" == *"95%"* ]]
@@ -101,16 +132,16 @@ teardown() {
 
 @test "suggest-compact: warns when context at 99% for any mode" {
   # 99% of 200K = 2K remaining; even lightest mode (verify NEEDED=2070) warns
-  echo "99|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
+  write_authenticated_usage 99
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
 
 @test "suggest-compact: warns when context at 94% for execute mode" {
   # 94% → 12K remaining; execute NEEDED=12190 → barely warns (12000 < 12190)
-  echo "94|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 94
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -120,28 +151,28 @@ teardown() {
 # =============================================================================
 
 @test "suggest-compact: recommends /compact for standard autonomy" {
-  echo "95|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"RECOMMENDED"* ]]
   [[ "$output" == *"/compact"* ]]
 }
 
 @test "suggest-compact: auto-triggers for confident autonomy" {
-  echo "95|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 95
   jq '.autonomy = "confident"' .vbw-planning/config.json > .vbw-planning/config.json.tmp \
     && mv .vbw-planning/config.json.tmp .vbw-planning/config.json
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"ACTION REQUIRED"* ]]
   [[ "$output" == *"confident"* ]]
 }
 
 @test "suggest-compact: auto-triggers for pure-vibe autonomy" {
-  echo "95|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 95
   jq '.autonomy = "pure-vibe"' .vbw-planning/config.json > .vbw-planning/config.json.tmp \
     && mv .vbw-planning/config.json.tmp .vbw-planning/config.json
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"ACTION REQUIRED"* ]]
   [[ "$output" == *"pure-vibe"* ]]
@@ -155,12 +186,12 @@ teardown() {
   # 94% → 12K remaining
   # execute NEEDED=12190 → warns (12000 < 12190)
   # plan NEEDED=2760 → OK (12000 > 2760)
-  echo "94|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" plan
+  write_authenticated_usage 94
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" plan
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -169,12 +200,12 @@ teardown() {
   # 94% → 12K remaining
   # verify NEEDED=2070 → OK
   # execute NEEDED=12190 → warns
-  echo "94|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
+  write_authenticated_usage 94
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -185,8 +216,8 @@ teardown() {
 
 @test "suggest-compact: phase plans increase execute cost" {
   # At 93% without plans: remaining=14000, execute NEEDED=12190 → OK
-  echo "93|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 93
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
@@ -194,7 +225,7 @@ teardown() {
   # 14000 < 15640 → warns
   mkdir -p .vbw-planning/phases/01-setup
   printf '%*s' 15000 '' > .vbw-planning/phases/01-setup/01-PLAN.md
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -205,8 +236,8 @@ teardown() {
   # 6000 < 7475 → warns
   printf '%*s' 5000 '' > .vbw-planning/STATE.md
   printf '%*s' 5000 '' > .vbw-planning/ROADMAP.md
-  echo "97|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" qa
+  write_authenticated_usage 97
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" qa
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -218,10 +249,10 @@ teardown() {
 @test "suggest-compact: respects compaction_threshold from config" {
   # 60% of 200K = 120K used; execute EST_COST=10600; projected=130600
   # threshold 130000 → 130600 > 130K → warns
-  echo "60|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 60
   jq '.compaction_threshold = 130000' .vbw-planning/config.json > .vbw-planning/config.json.tmp \
     && mv .vbw-planning/config.json.tmp .vbw-planning/config.json
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -229,10 +260,10 @@ teardown() {
 @test "suggest-compact: no warn when below compaction_threshold" {
   # 40% of 200K = 80K used; discuss EST_COST=2500; projected=82500
   # threshold 130000 → 82500 < 130K → OK
-  echo "40|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 40
   jq '.compaction_threshold = 130000' .vbw-planning/config.json > .vbw-planning/config.json.tmp \
     && mv .vbw-planning/config.json.tmp .vbw-planning/config.json
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -264,23 +295,23 @@ teardown() {
 
 @test "suggest-compact: handles missing config.json gracefully" {
   rm -f .vbw-planning/config.json
-  echo "95|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
 
 @test "suggest-compact: defaults to execute mode when no mode given" {
-  echo "95|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh"
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh"
   [ "$status" -eq 0 ]
   [[ "$output" == *"execute"* ]]
 }
 
 @test "suggest-compact: unknown mode uses fallback cost" {
   # unknown: NEEDED=8625. 96% → 8000 remaining → warns (8000 < 8625)
-  echo "96|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" unknown_mode
+  write_authenticated_usage 96
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" unknown_mode
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -290,8 +321,8 @@ teardown() {
 # =============================================================================
 
 @test "suggest-compact: warns at 100% usage" {
-  echo "100|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
+  write_authenticated_usage 100
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" discuss
   [ "$status" -eq 0 ]
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
@@ -301,8 +332,8 @@ teardown() {
 # =============================================================================
 
 @test "suggest-compact: output shows byte breakdown" {
-  echo "95|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [[ "$output" == *"B fixed"* ]]
   [[ "$output" == *"project files"* ]]
@@ -377,9 +408,9 @@ teardown() {
 
   # At 99% → remaining = 2000. Without SOURCE-UAT exclusion, the huge
   # SOURCE-UAT would inflate the cost and trigger a warning.
-  echo "99|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 99
 
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
   [ "$status" -eq 0 ]
   # With the fix, SOURCE-UAT bytes are subtracted, so the cost should
   # be based on only the canonical UAT (2000B) not the 50000B SOURCE-UAT
@@ -393,14 +424,14 @@ teardown() {
   printf '%*s' 1000 '' > .vbw-planning/phases/01-setup/01-UAT.md
 
   # 96% of 200K → remaining = 8000 tokens. verify without SOURCE-UAT is fine.
-  echo "96|200000" > .vbw-planning/.context-usage
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
+  write_authenticated_usage 96
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
   # Now add a huge SOURCE-UAT — should still be fine (excluded from sum)
   printf '%*s' 100000 '' > .vbw-planning/phases/01-setup/01-SOURCE-UAT.md
-  run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" verify
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -439,24 +470,23 @@ teardown() {
   [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
 }
 
-@test "suggest-compact: legacy 2-field format still works (backward compat)" {
-  echo "95|200000" > .vbw-planning/.context-usage
+@test "suggest-compact: legacy 2-field format skips silently" {
+  write_legacy_usage 95
   run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
-  [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
+  [ -z "$output" ]
 }
 
-@test "suggest-compact: missing CLAUDE_SESSION_ID defaults to unknown on both sides" {
-  # Both writer and reader default to "unknown" — should match and proceed
-  echo "unknown|95|200000" > .vbw-planning/.context-usage
+@test "suggest-compact: unknown session placeholder is not authoritative" {
+  write_unknown_usage 95
   unset CLAUDE_SESSION_ID
   run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
-  [[ "$output" == *"PRE-FLIGHT CONTEXT GUARD"* ]]
+  [ -z "$output" ]
 }
 
 @test "suggest-compact: 3-field format with low usage no warn" {
-  echo "my-session|30|200000" > .vbw-planning/.context-usage
+  write_authenticated_usage 30 my-session
   CLAUDE_SESSION_ID="my-session" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [ -z "$output" ]
@@ -474,6 +504,61 @@ teardown() {
   # 30% of 200K = 60000 used tokens + EST_COST → below 165000 → no warn
   echo "my-session|30|200000" > .vbw-planning/.context-usage
   CLAUDE_SESSION_ID="my-session" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: missing CLAUDE_SESSION_ID skips high-pressure cache" {
+  write_authenticated_usage 95 test-session-auth
+  unset CLAUDE_SESSION_ID
+  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: empty CLAUDE_SESSION_ID skips high-pressure cache" {
+  write_authenticated_usage 95 test-session-auth
+  CLAUDE_SESSION_ID="" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: invalid cache session ID skips silently" {
+  write_authenticated_usage 95 200000 "bad session"
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: invalid current session ID skips silently" {
+  write_authenticated_usage 95
+  CLAUDE_SESSION_ID="bad session" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: malformed 3-field used percentage skips silently" {
+  echo "$AUTH_SID|abc|200000" > .vbw-planning/.context-usage
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: malformed 3-field context size skips silently" {
+  echo "$AUTH_SID|95|abc" > .vbw-planning/.context-usage
+  CLAUDE_SESSION_ID="$AUTH_SID" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: statusline unknown cache stays silent in suggest-compact" {
+  mkdir -p .vbw-planning
+  unset CLAUDE_SESSION_ID
+  echo '{"context_window":{"used_percentage":95,"remaining_percentage":5,"context_window_size":200000,"current_usage":{"input_tokens":10000,"output_tokens":5000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"cost":{"total_cost_usd":0,"total_duration_ms":0,"total_api_duration_ms":0,"total_lines_added":0,"total_lines_removed":0},"model":{"display_name":"Claude"},"version":"1.0"}' \
+    | bash "$SCRIPTS_DIR/vbw-statusline.sh" > /dev/null 2>&1
+  [ -f .vbw-planning/.context-usage ]
+
+  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }

--- a/tests/suggest-compact.bats
+++ b/tests/suggest-compact.bats
@@ -485,6 +485,22 @@ write_legacy_usage() {
   [ -z "$output" ]
 }
 
+@test "suggest-compact: unknown 43 percent cache skips silently" {
+  write_unknown_usage 43
+  unset CLAUDE_SESSION_ID
+  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "suggest-compact: unknown 58 percent cache skips silently" {
+  write_unknown_usage 58
+  unset CLAUDE_SESSION_ID
+  run bash "$SCRIPTS_DIR/suggest-compact.sh" execute
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "suggest-compact: 3-field format with low usage no warn" {
   write_authenticated_usage 30 my-session
   CLAUDE_SESSION_ID="my-session" run bash "$SCRIPTS_DIR/suggest-compact.sh" execute


### PR DESCRIPTION
Fixes #494

## What

This change hardens VBW’s pre-flight compact guard so `scripts/suggest-compact.sh` only trusts session-authenticated 3-field `.context-usage` cache entries.

Modified files:
- `scripts/suggest-compact.sh` — adds an explicit authority gate for cache session IDs and stops trusting unauthenticated legacy cache input.
- `tests/suggest-compact.bats` — reshapes the regression suite so behavior/math tests run on authenticated 3-field fixtures, and adds explicit silent-skip coverage for `unknown`, missing, invalid, malformed, and legacy cache inputs.

Behavioral change:
- `unknown == unknown` no longer authorizes a pre-flight compact warning.
- Legacy 2-field cache entries no longer drive warnings in `suggest-compact.sh`.
- Valid same-session authenticated cache entries still use the existing headroom and threshold math.

## Why

The bug was not the warning math. The bug was cache authority.

`vbw-statusline.sh` writes `.context-usage` using `${CLAUDE_SESSION_ID:-unknown}`, while `suggest-compact.sh` previously accepted any 3-field cache entry when `FILE_SID == CURRENT_SID`. That let placeholder `unknown` values on both sides pass freshness validation and drive visible `/compact` warnings. The correct architectural fix is to treat `unknown`, missing, invalid, and legacy unauthenticated cache states as non-authoritative and fail open to a silent skip. That keeps VBW conservative in the face of poisoned cache input and prefers false negatives over false positives.

## How

- `scripts/suggest-compact.sh`: added `authoritative_session_id()` and applied it to both file-side and current-side session IDs before any warning logic runs; legacy 2-field cache input now exits silently instead of participating in warning decisions.
- `tests/suggest-compact.bats`: migrated authenticated behavior tests off legacy 2-field fixtures, added explicit coverage for `unknown|95|200000`, `unknown|43|200000`, `unknown|58|200000`, missing/empty/invalid `CLAUDE_SESSION_ID`, malformed 3-field numeric entries, and legacy 2-field silent-skip behavior.
- `tests/suggest-compact.bats`: added an end-to-end assertion that a statusline-written `unknown` cache remains silent when read by `suggest-compact.sh`.

## Acceptance criteria verification

1. `scripts/suggest-compact.sh` only trusts 3-field cache entries when both `FILE_SID` and `CURRENT_SID` are present, valid, non-`unknown`, and exactly equal.
   - Satisfied by `scripts/suggest-compact.sh` lines 264-295.
   - Tested in `tests/suggest-compact.bats` lines 459-470, 527-553.
2. `unknown == unknown` no longer passes cache freshness validation.
   - Satisfied by `scripts/suggest-compact.sh` lines 267-269 and 291-292.
   - Tested in `tests/suggest-compact.bats` lines 480-500 and 570-579.
3. If `FILE_SID` is empty, `unknown`, or invalid, `scripts/suggest-compact.sh` exits `0` without warning.
   - Satisfied by `scripts/suggest-compact.sh` lines 267-269 and 291.
   - Tested in `tests/suggest-compact.bats` lines 480-500 and 542-546.
4. If `CURRENT_SID` is empty, `unknown`, or invalid, `scripts/suggest-compact.sh` exits `0` without warning.
   - Satisfied by `scripts/suggest-compact.sh` lines 290-292.
   - Tested in `tests/suggest-compact.bats` lines 527-553.
5. Valid same-session authenticated cache entries still preserve the existing `REMAINING`, `NEEDED`, and `THRESHOLD_EXCEEDED` warning behavior.
   - Preserved in `scripts/suggest-compact.sh` lines 305-344.
   - Tested in `tests/suggest-compact.bats` lines 123-240, 466-524.
6. Legacy 2-field cache input no longer drives warnings in `scripts/suggest-compact.sh` because it cannot be session-authenticated.
   - Satisfied by `scripts/suggest-compact.sh` lines 297-299.
   - Tested in `tests/suggest-compact.bats` lines 473-477.
7. `tests/suggest-compact.bats` covers valid authenticated warnings, `unknown|95|200000`, lower-pressure unauthenticated inputs, missing/invalid `CLAUDE_SESSION_ID`, malformed numeric entries, and legacy 2-field silent-skip behavior.
   - Satisfied by `tests/suggest-compact.bats` lines 123-240, 466-579.
8. `tests/sessionstart-compact-hooks.bats` and `tests/statusline-autocompact-normalization.bats` still pass.
   - Verified by focused test runs; related coverage remains in `tests/sessionstart-compact-hooks.bats` lines 535-542 and `tests/statusline-autocompact-normalization.bats` lines 14-15.
9. `bash testing/run-all.sh` passes.
   - Verified in this branch before PR creation.

## Testing

- [x] `bats tests/suggest-compact.bats`
- [x] `bats tests/sessionstart-compact-hooks.bats`
- [x] `bats tests/statusline-autocompact-normalization.bats`
- [x] `bash testing/run-all.sh`

Focused results:
- `tests/suggest-compact.bats`: 51 passed, 0 failed
- `tests/sessionstart-compact-hooks.bats`: 35 passed, 0 failed
- `tests/statusline-autocompact-normalization.bats`: 30 passed, 0 failed

Full validation:
- `bash testing/run-all.sh`: lint 1/1, contract checks 44/44, BATS 3020 passed / 0 failed

## QA summary

### Primary QA (`qa-investigator`)
- Rounds completed: 3
- Round 1: 1 legitimate low-severity contract finding fixed in `1b18d08`
- Round 2: clean, recorded in `c9cdd0e`
- Round 3: clean, recorded in `d0967eb`
- Findings fixed: 1
- False positives: 0

### Cross-model QA (`qa-investigator-gpt-54`, GPT-5.4)
- Rounds completed: 1
- Round 1: clean, recorded in `0cb177d`
- Findings fixed: 0
- False positives: 0

### Copilot PR review
- Rounds completed so far: 0
- Status: pending post-PR Phase 4.5 review loop

### Supporting commits
- Implementation commit: `73d15e8` — `fix(compact): reject unauthenticated context cache`
- QA remediation commit: `1b18d08` — `fix(compact): address QA round 1`
- Main sync merge commit: `4f8a62f`

## Scope boundary check

This PR intentionally does **not**:
- change `.claude-code-router` integration
- change visible statusline rendering
- redesign compaction thresholds or cost estimation
- change other `.context-usage` consumers such as `scripts/lib/resolve-caveman-level.sh`

This is a narrow robustness fix for the pre-flight compact guard only.