### PR TITLE
fix(workflow): enhance agent and planner to support user-authored plan reuse and in-place audits

### DIFF
--- a/.github/agents/fix-issue.agent.md
+++ b/.github/agents/fix-issue.agent.md
@@ -32,6 +32,8 @@ Execute these steps in order. Do not skip steps.
 
 1. **Search existing issues** (open and closed) via #tool:github/list_issues and #tool:github/search_issues to avoid duplicates.
 2. **If an issue exists**, use it as the tracking source of truth. Read the full issue body — you will need its acceptance criteria later. Note the issue number.
+
+    **Contract split (NON-NEGOTIABLE).** The issue is the public verification contract for QA, PR text, and reviewer communication. A saved planner-authored or user-authored plan is the execution guide for implementation order, dependencies, and risky areas. Keep them aligned. If a user-authored plan introduces must-have acceptance criteria or scope boundaries that are not already captured in the issue, update the issue with a sanitized version before QA begins. Do not copy local absolute path prefixes (for example `/Users/.../`) or other PII into GitHub.
 3. **If no issue exists**, create one via #tool:github/issue_write (method: `create`) using the structure from `.github/ISSUE_TEMPLATE/` (bug_report for bugs, feature_request for enhancements). Assign to the authenticated user (your GitHub username) and apply at least one label (`bug`, `enhancement`, or a domain label).
 
    **Issue body requirements (NON-NEGOTIABLE).** The issue body is the verification contract for the entire workflow — the QA agent will use it to scope its review. Every issue you create must include:
@@ -140,22 +142,29 @@ Execute these steps in order. Do not skip steps.
 ### Phase 1.5: Plan the Fix
 
 <handoff_plan_gate>
-Before invoking the planner, check whether this conversation already contains a plan from `fix-planner-vbw`. This happens when the user started in the planner agent and used the "Start Fix Workflow" handoff button to reach this agent. Detect it by checking TWO conditions:
-1. The conversation history contains a response from `fix-planner-vbw` (the handoff prompt or preceding planner output is visible in the thread).
-2. That response confirms EITHER (a) the plan was saved — it names an actual path the memory tool wrote to, OR (b) memory write was unavailable and the full plan is provided inline in the response.
+Before invoking the planner, check whether this conversation already contains an execution-ready plan for THIS issue. There are two valid sources:
+1. **Planner handoff** — the conversation history contains a response from `fix-planner-vbw` (the handoff prompt or preceding planner output is visible in the thread), and that response confirms EITHER (a) the plan was saved — it names an actual path the memory tool wrote to, OR (b) memory write was unavailable and the full plan is provided inline in the response.
+2. **User-authored execution contract** — the conversation history contains a user message with a detailed implementation plan for this issue, and the thread also contains either the full plan inline or a direct user instruction to "save this plan", "use this plan", or "execute the saved plan".
 
-If BOTH conditions are met, reuse the handed-off plan:
-- **Saved plan**: If #tool:vscode/memory is not exposed yet and #tool:activate_vs_code_interaction is available, call #tool:activate_vs_code_interaction first to expose the deferred VS Code tools. Then read the plan from the confirmed path via #tool:vscode/memory. Use that full plan as the execution guide.
-- **Inline fallback**: Use the full inline plan from the planner response as the execution guide.
+If either source exists, reuse that plan instead of spawning the planner for a fresh initial plan:
+- **Planner handoff**: If #tool:vscode/memory is not exposed yet and #tool:activate_vs_code_interaction is available, call #tool:activate_vs_code_interaction first to expose the deferred VS Code tools. Then read the plan from the confirmed path via #tool:vscode/memory and use it as the execution guide.
+- **User-authored plan**: Save the plan to `/memories/session/plan.md` exactly as written before any summarization, sanitization, or planner invocation. Do not reorder, trim, normalize, or paraphrase it. If `/memories/session/plan.md` already exists and does not exactly match the user-authored plan in this thread, replace its contents so the saved file matches the user's text exactly. After saving, read `/memories/session/plan.md` back and treat that saved file as the source execution guide.
+- **Inline fallback**: Use the full inline plan as the execution guide only when memory write is genuinely unavailable in this run.
 
-Then skip the rest of Phase 1.5 and proceed directly to Phase 2.
+If the user explicitly told you to execute the saved/presented plan, do NOT stop after saving it — continue the workflow.
 
-Do NOT treat generic existence of `/memories/session/plan.md` as proof of a handoff — session memory may contain stale plans from prior tasks. The handoff is only valid when the planner output is visible in THIS conversation thread.
+The issue remains the public verification contract. If the reused plan introduces must-have acceptance criteria or scope boundaries that the issue does not already capture, sanitize that material (strip local absolute path prefixes like `/Users/.../` and other PII) and update the issue or add a clarifying issue comment before QA begins.
+
+If the source was a user-authored plan, you must still invoke `fix-planner-vbw` — but only in audit mode. Tell it to read `/memories/session/plan.md`, QA-evaluate that saved plan against the issue and codebase, and follow its existing audit loop against that same saved path. It must not replan from scratch or fork a second canonical plan file. If the original plan is sufficient, keep using `/memories/session/plan.md` unchanged. If refinement is needed, amend `/memories/session/plan.md` in place through the planner's established audit/update flow so the canonical execution guide stays at one path.
+
+Then skip the rest of Phase 1.5 and proceed directly to Phase 2. For user-authored plans, Phase 2 begins only after the audit-mode planner returns.
+
+Do NOT treat generic existence of `/memories/session/plan.md` as proof of a valid plan — session memory may contain stale plans from prior tasks. The plan is only valid when its source (planner or user-authored) is visible in THIS conversation thread.
 
 This gate applies only to the initial Phase 1.5 plan. Later planner invocations (Phase 3 step 14b for QA findings, Phase 3.5 step 19 for cross-model findings, Phase 4.5 step 27c for Copilot findings) are unaffected and remain unconditional.
 </handoff_plan_gate>
 
-**If no handoff plan exists**, invoke the `fix-planner-vbw` sub-agent with the issue number, full issue body, and any known root-cause clues. Instruct it to use `#tool:searchSubagent` for targeted lookups and escalate to *Explore* subagents for multi-step analysis when nested subagents are available; otherwise it should perform discovery directly with read/search tools.
+**If no existing execution plan exists**, invoke the `fix-planner-vbw` sub-agent with the issue number, full issue body, and any known root-cause clues. Instruct it to use `#tool:searchSubagent` for targeted lookups and escalate to *Explore* subagents for multi-step analysis when nested subagents are available; otherwise it should perform discovery directly with read/search tools.
 
 The planner should save its output to `/memories/session/plan.md` when #tool:vscode/memory is available and return the actual path the memory tool confirmed it wrote to. Preferred path: if the planner confirms a saved plan path and #tool:vscode/memory is not exposed yet while #tool:activate_vs_code_interaction is available, call #tool:activate_vs_code_interaction first to expose the deferred VS Code tools. Then read the saved plan from that confirmed path using #tool:vscode/memory before proceeding. Fallback: if the planner reports that memory write was unavailable in this run and returns the full plan inline, use that inline plan as the execution guide instead of blocking on a saved memory file. In the fallback case, the resolved URI is informational only — do not treat it as proof the plan was persisted. Do not rely on a short summary when a saved or inline full plan is available. If the plan identifies missing context or risky assumptions, resolve those before creating the worktree or editing files.
 
@@ -314,6 +323,7 @@ Start with round N = 1. **Repeat the following steps, incrementing N each round:
     - The issue number and branch name (no PR exists yet during QA)
     - The **worktree absolute path** where the changes live (so the sub-agent reads files from the correct location, not the main repo checkout)
     - The **full issue body** — especially the acceptance criteria and scope boundary. This is the verification contract. Tell the QA agent: "The acceptance criteria in the issue are your primary verification targets. Findings must relate to whether this change correctly and completely satisfies these criteria, or introduces regressions in code touched by the change."
+    - If a validated execution plan exists, include it as supplemental context for risky invariants or intentionally tricky behaviors, but tell the QA agent it does **NOT** replace or narrow the issue contract. If the plan and issue differ, the issue body wins.
     - Explicit instruction that this round is a **full-contract review of the current branch state**, not a review of only the latest remediation commit. Tell the QA agent: "Treat any 'latest commit', 'what changed since round N', or 'especially these files' framing as orientation only. Unless I explicitly say 'delta-only review', you must still re-verify the full issue contract against the current branch state."
     - Instruction to review commits, read changed files in full, and act as devil's advocate — but scoped to the issue contract
     - Instruction to classify each finding as **critical**, **high**, **medium**, or **low** severity

--- a/.github/agents/fix-planner.agent.md
+++ b/.github/agents/fix-planner.agent.md
@@ -23,6 +23,8 @@ Your SOLE responsibility is planning. NEVER edit files or implement the fix your
 - Treat the actual runtime tool list as authoritative. This agent is declared with #tool:vscode/memory, but some GPT-5.4 and other deferred-tool runs initially expose only #tool:vscode/resolveMemoryFileUri plus #tool:activate_vs_code_interaction. If #tool:vscode/memory is absent and #tool:activate_vs_code_interaction is available, call #tool:activate_vs_code_interaction first, then re-check for #tool:vscode/memory before concluding memory write is unavailable. When #tool:vscode/memory remains absent after activation, do not claim the plan was saved and do not instruct others to read a nonexistent saved file.
 - STOP if you consider using editing tools — plans are for others to execute. The only write tool you may use is #tool:vscode/memory for persisting the plan when that tool is actually exposed in the current run. If it is unavailable, return the plan inline instead of using editing tools as a workaround.
 - Treat the issue body as the source-of-truth contract. The plan is the execution guide, not a replacement for the acceptance criteria.
+- When the caller supplies an existing saved or inline plan and asks you to validate, audit, or refine it, treat that plan as the draft execution guide. Read it first. Preserve its accepted decisions unless the issue or codebase contradict them. Do not discard it and replan from scratch.
+- When the caller says a saved user-authored plan must first be persisted exactly as written, treat that saved file as the canonical starting point for the audit. If the saved plan is already sufficient, keep using its existing path unchanged. If refinement is needed, amend that same saved plan path in place through the established persist + audit loop. Do not fork a second canonical plan path unless the caller explicitly overrides the workflow and asks for one.
 - If you are interacting directly with the user in chat, use #tool:vscode/askQuestions to clarify requirements and validate assumptions before finalizing the plan.
 - When invoked as a subagent, do not ask the user follow-up questions. Capture ambiguities, assumptions, and recommended defaults inside the plan instead.
 - Prefer focused context gathering. If the task spans multiple independent areas, use 2-3 *Explore* subagents in parallel when nested subagents are enabled. If nested subagents are unavailable or *Explore* is not accessible, use #tool:search and #tool:read directly.
@@ -84,6 +86,7 @@ Cycle through these phases based on how the agent is being used. If you are work
 
 ## 1. Discovery
 
+- If the caller supplied an existing saved or inline plan, read it first and treat it as the draft execution guide to audit against the issue and codebase.
 - Read the issue body and identify the affected areas of the codebase.
 - Gather context, analogous existing features, and likely root-cause locations.
 - Use #tool:searchSubagent for targeted lookups (find files by pattern, locate definitions, keyword searches). For multi-step analysis that requires chaining reads and synthesizing understanding, escalate to an *Explore* subagent.
@@ -126,12 +129,20 @@ If you are invoked as a subagent, incorporate brownfield considerations, risky a
 
 ## 4. Persist
 
-- If #tool:vscode/memory is exposed in the current run, save the plan to `/memories/session/plan.md` via #tool:vscode/memory.
-- If #tool:vscode/memory is NOT exposed in the current run, do NOT pretend the save succeeded. Use #tool:vscode/resolveMemoryFileUri to resolve the target URI, then keep the full plan in your response as inline fallback output. The resolved URI is informational only in this fallback path — it does not prove a file was written.
+- If the caller supplied an existing saved plan path to audit, keep using that same path as the selected target path. Otherwise use `/memories/session/plan.md` unless the caller explicitly requested a different path.
+- If the caller asked you to audit an existing saved plan and that plan is already sufficient, do not rewrite it just to satisfy persistence. Return the reviewed original path as the execution guide unchanged.
+- If #tool:vscode/memory is exposed in the current run, save the plan to the selected target path via #tool:vscode/memory.
+- If #tool:vscode/memory is NOT exposed in the current run, do NOT pretend the save succeeded. Use #tool:vscode/resolveMemoryFileUri to resolve the selected target URI, then keep the full plan in your response as inline fallback output. The resolved URI is informational only in this fallback path — it does not prove a file was written.
 - If you are interacting directly with the user:
   - when the plan was saved, show the scannable plan in chat after saving it
   - when memory write was unavailable, show the scannable plan in chat and state clearly that it could not be saved in this run
 - If you are invoked as a subagent, return only one of these two shapes:
+ - If you are invoked as a subagent while auditing an existing saved plan and it remains sufficient, you may return this third shape instead:
+  - **Existing saved plan remains sufficient**:
+    - confirmation that the saved plan was reviewed and remains the execution guide unchanged
+    - the exact existing saved path that was audited
+    - an instruction that the parent agent should keep using that saved path directly
+ - Otherwise return only one of these two shapes:
   - **Saved path available**:
     - confirmation that the plan was saved
     - the **actual path** from the memory tool's response (do not hardcode `/memories/session/plan.md` — return whatever path the tool confirms it wrote to)
@@ -156,6 +167,8 @@ After persisting (or assembling inline) the plan, run an iterative audit-fix cyc
 
 **Audit prompt** (spawn as subagent — use *Explore* agent):
 
+If the plan was saved to a non-default path, substitute that path anywhere the prompts below mention `/memories/session/plan.md`.
+
 If the plan was saved, use this prompt:
 
 > First, use #tool:vscode/resolveMemoryFileUri to resolve the path for `/memories/session/plan.md`, then read the plan at the resolved URI.
@@ -176,6 +189,8 @@ If the plan was NOT saved because #tool:vscode/memory was unavailable, paste the
 ## 4.6. Prompt Engineering Audit
 
 **Trigger condition:** The plan involves changes to LLM-consumed markdown artifacts — any of these paths: `commands/*.md`, `agents/vbw-*.md`, `templates/*.md`, `references/*.md`, `scripts/bootstrap-claude.sh`, `scripts/check-claude-md-staleness.sh`, `scripts/compile-context.sh`, `scripts/compile-*.sh`, or any hook handler that produces LLM-consumed text output. **Skip this phase** if the plan only touches bash script logic, config/JSON schemas, test infrastructure, or hook plumbing.
+
+If the plan was saved to a non-default path, substitute that path anywhere the prompts below mention `/memories/session/plan.md`.
 
 If the plan was saved successfully, spawn an *Explore* subagent with this prompt:
 

--- a/testing/verify-github-fix-workflow-contract.sh
+++ b/testing/verify-github-fix-workflow-contract.sh
@@ -9,6 +9,7 @@ STOP_GUARD="$ROOT/.github/hooks/fix-issue-stop-guard.sh"
 WAIT_GITHUB="$ROOT/.github/scripts/wait-github.py"
 RECORD_STATE="$ROOT/.github/scripts/fix-issue-record-state.sh"
 AGENT_MD="$ROOT/.github/agents/fix-issue.agent.md"
+PLANNER_AGENT="$ROOT/.github/agents/fix-planner.agent.md"
 REVIEW_AGENT="$ROOT/.github/agents/review-contributor-pr.agent.md"
 
 PASS=0
@@ -143,6 +144,32 @@ test_fix_issue_agent_has_ambient_context_antipattern() {
   fi
 }
 test_fix_issue_agent_has_ambient_context_antipattern
+
+test_fix_issue_agent_reuses_user_authored_plans() {
+  if grep -qF 'User-authored execution contract' "$AGENT_MD" \
+    && grep -qF 'Save the plan to `/memories/session/plan.md` exactly as written' "$AGENT_MD" \
+    && grep -qF 'replace its contents so the saved file matches the user' "$AGENT_MD" \
+    && grep -qF 'do NOT stop after saving it — continue the workflow' "$AGENT_MD" \
+    && grep -qF 'follow its existing audit loop against that same saved path' "$AGENT_MD" \
+    && grep -qF 'strip local absolute path prefixes like `/Users/.../` and other PII' "$AGENT_MD"; then
+    pass "fix-issue agent saves user-authored plans verbatim and audits the same saved path"
+  else
+    fail "fix-issue agent should save user-authored plans exactly as written, continue after saving, and audit the same saved plan path instead of forking a new one"
+  fi
+}
+test_fix_issue_agent_reuses_user_authored_plans
+
+test_fix_planner_agent_supports_existing_plan_audit_mode() {
+  if grep -qF 'When the caller supplies an existing saved or inline plan and asks you to validate, audit, or refine it' "$PLANNER_AGENT" \
+    && grep -qF 'Do not discard it and replan from scratch' "$PLANNER_AGENT" \
+    && grep -qF 'amend that same saved plan path in place' "$PLANNER_AGENT" \
+    && grep -qF 'If the caller asked you to audit an existing saved plan and that plan is already sufficient, do not rewrite it' "$PLANNER_AGENT"; then
+    pass "fix-planner agent supports in-place audit mode for existing plans"
+  else
+    fail "fix-planner agent should audit existing saved plans in place instead of forking a separate refined path"
+  fi
+}
+test_fix_planner_agent_supports_existing_plan_audit_mode
 
 test_wait_github_fails_fast_on_gh_errors() {
   setup_tmpdir


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

## Linked Issue

<!-- REQUIRED: Every PR must reference a tracking issue. CI will fail without one. -->
<!-- Accepted: Fixes/Closes/Resolves #N, full GitHub issue URL, bare #N, or sidebar link -->

Fixes #

## What

Brief description of the change.

## Why

What problem does this solve?

## How

Summary of the approach. Mention affected commands, agents, hooks, or scripts.

## Testing

- [ ] Loaded plugin locally (`claude-vbw` or `claude --plugin-dir "<path-to-vbw-clone>"`)
- [ ] Tested affected commands against a real project (not the VBW repo)
- [ ] No errors on plugin load
- [ ] Existing commands still work
- [ ] Ran QA review (2–4 separate AI sessions acting as devil's advocate on the diff)

## QA Review Evidence

Paste each QA round's report as a separate comment on this PR. Each round should have a corresponding fix commit (e.g., `fix(scope): address QA round 1`). Reviewers will verify the commit history matches the reported rounds.

QA must be run on a top-tier model: **Claude Opus 4.6**, **GPT-5.3 Codex high/xhigh**, or **Gemini 3.1 Pro**.

- **Rounds completed:** (number)
- **Model used:** (e.g., Claude Opus 4.6)
- **Fix commits:** (list commit SHAs or titles)

## Notes

Anything reviewers should know -- trade-offs, open questions, follow-up work.
