### PR TITLE
fix(todo): honor planning git boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Controls whether `.vbw-planning/` artifacts are committed, gitignored, or left f
 | :--- | :--- | :--- |
 | **`manual`** | Default. No commits, no gitignore. Planning files accumulate as untracked in `git status`. You manage them yourself. | When you want full control, or aren't sure yet. |
 | **`ignore`** | Adds `.vbw-planning/` to `.gitignore` during `/vbw:init`. Planning files exist locally but never enter version control. Clean `git status`. | Solo projects, prototyping, or when planning history doesn't matter. |
-| **`commit`** | Auto-commits `.vbw-planning/` artifacts at lifecycle boundaries — after bootstrap, after planning, after archive. Commit format: `chore(vbw): {action}`. Transient files (`.execution-state.json`, `.contracts/`, `.locks/`, `.token-state/`, compiled context) are excluded via `.vbw-planning/.gitignore`. | Teams that want an audit trail of planning decisions in version control. |
+| **`commit`** | Auto-commits `.vbw-planning/` artifacts (and `CLAUDE.md` when present) at helper-backed planning boundaries — for example after bootstrap, planning/discussion checkpoints, todo additions, and archive. Commit format: `chore(vbw): {action}`. Transient files (`.execution-state.json`, `.contracts/`, `.locks/`, `.token-state/`, compiled context) are excluded via `.vbw-planning/.gitignore`. | Teams that want an audit trail of planning decisions in version control. |
 
 #### `auto_push`
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -147,7 +147,7 @@ AskUserQuestion (single select):
 - "How should VBW planning artifacts be tracked in git?"
   - `manual` (default): don't auto-ignore or auto-commit planning files
   - `ignore`: keep `.vbw-planning/` ignored in root `.gitignore`
-  - `commit`: track `.vbw-planning/` + `CLAUDE.md` at lifecycle boundaries
+  - `commit`: track `.vbw-planning/` + `CLAUDE.md` at helper-backed planning boundaries (bootstrap, planning checkpoints, todo adds, archive)
 
 AskUserQuestion (single select):
 - "When should VBW push commits?"

--- a/commands/todo.md
+++ b/commands/todo.md
@@ -18,38 +18,50 @@ allowed-tools: Read, Edit, Bash
 
 1. **Not initialized** (no .vbw-planning/ dir): STOP "Run /vbw:init first."
 2. **Missing description:** STOP: `Usage: /vbw:todo <description> [--priority=high|normal|low]`
-3. **Restricted mode:** If the current permission mode does not allow edits, STOP: "`/vbw:todo` needs write access to update `.vbw-planning/STATE.md`. If you're in read-only or another restricted mode, switch to a write-enabled mode (for example bypass permissions) and rerun the command."
+3. **Restricted mode:** If the current permission mode does not allow both Bash and edits, STOP: "`/vbw:todo` needs Bash plus write access to update `.vbw-planning/STATE.md` and run the planning git boundary. If you're in read-only or another restricted mode, switch to a mode that allows both and rerun the command."
 
 ## Steps
 
 1. **Resolve context:** Always use `.vbw-planning/STATE.md` for todos — project-level data lives at the root, not in milestone subdirectories. If `.vbw-planning/STATE.md` does not exist, STOP: "STATE.md not found. Session startup normally recovers archived state automatically — try restarting your Claude session, or run /vbw:init to set up your project."
 2. **Parse args:** Description (non-flag text), --priority (default: normal). Format: high=`[HIGH]`, normal=plain, low=`[low]`. Append `(added {YYYY-MM-DD})`.
 3. **Add plain todo to STATE.md:** Find `## Todos` section. Replace "None." / placeholder or append after last item.
-4. **Capture extended detail (conditional).** Check whether the description from step 2 contains any of these: file paths, reproduction steps, stack traces, code references, error messages, or multi-sentence design rationale. Only evaluate the current `$ARGUMENTS` text — do not scan prior conversation history.
+4. **Resolve plugin root.** Determine the plugin root path for helper-backed follow-up work. Always quote derived paths (they may contain spaces). Try in order:
+   (a) The `local/` subdirectory under the plugin cache root (i.e. `"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/vbw-marketplace/vbw/local/"`), if it exists and contains `scripts/hook-wrapper.sh`.
+   (b) The numerically highest versioned directory under the plugin cache root — list subdirectories matching a dotted-version pattern (e.g. `1.30.0`), sort by each numeric component (major, minor, patch), pick the highest, and accept it only if it contains `scripts/hook-wrapper.sh`.
+   (c) Any other (non-versioned) subdirectory under the plugin cache root — pick the newest by name, accept only if it contains `scripts/hook-wrapper.sh`. This covers non-standard cache layouts.
+   (d) The session symlink `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`, or any existing `/tmp/.vbw-plugin-root-link-*` symlink whose target contains `scripts/hook-wrapper.sh`.
+   (e) Extract `--plugin-dir <path>` from the process tree (`ps axww`) and use that path if it contains `scripts/hook-wrapper.sh`.
+   Store the resolved path as `PLUGIN_ROOT` for subsequent helper calls. If none of the fallbacks resolve, leave `PLUGIN_ROOT` empty and continue — extended detail and the planning git boundary will degrade gracefully later.
+5. **Capture extended detail (conditional).** Check whether the description from step 2 contains any of these: file paths, reproduction steps, stack traces, code references, error messages, or multi-sentence design rationale. Only evaluate the current `$ARGUMENTS` text — do not scan prior conversation history.
    - **If triggered:** The todo has rich context worth preserving for later execution.
-     1. **Resolve plugin root.** Determine the plugin root path. Always quote derived paths (they may contain spaces). Try in order:
-        (a) The `local/` subdirectory under the plugin cache root (i.e. `"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/vbw-marketplace/vbw/local/"`), if it exists and contains `scripts/hook-wrapper.sh`.
-        (b) The numerically highest versioned directory under the plugin cache root — list subdirectories matching a dotted-version pattern (e.g. `1.30.0`), sort by each numeric component (major, minor, patch), pick the highest, and accept it only if it contains `scripts/hook-wrapper.sh`.
-        (c) Any other (non-versioned) subdirectory under the plugin cache root — pick the newest by name, accept only if it contains `scripts/hook-wrapper.sh`. This covers non-standard cache layouts.
-        (d) The session symlink `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}`, or any existing `/tmp/.vbw-plugin-root-link-*` symlink whose target contains `scripts/hook-wrapper.sh`.
-        (e) Extract `--plugin-dir <path>` from the process tree (`ps axww`) and use that path if it contains `scripts/hook-wrapper.sh`.
-        Store the resolved path as `PLUGIN_ROOT` for subsequent helper calls.
-     2. If plugin root cannot be resolved, leave the plain todo line from step 3 unchanged, do not append a ref tag, do not write `.vbw-planning/todo-details/HASH.json` yourself, and continue to step 5 with a warning that extended detail was not saved.
-     3. Extract a brief one-line summary (first sentence or the user's explicit title) — this is already the `STATE.md` bullet text from step 3.
-     4. Compute a hash: `printf '%s' "<summary text>" | shasum | cut -c1-8`
-     5. Build a JSON detail object: `{"summary": "<brief summary>", "context": "<full description, max 2000 chars>", "files": ["<any file paths mentioned>"], "added": "<YYYY-MM-DD>", "source": "user"}`
-     6. Store it through the canonical helper — pipe JSON via heredoc to avoid shell-quoting issues with apostrophes or special characters in user text:
+     1. If `PLUGIN_ROOT` is empty, leave the plain todo line from step 3 unchanged, do not append a ref tag, do not write `.vbw-planning/todo-details/HASH.json` yourself, and continue to step 6 with a warning that extended detail was not saved.
+     2. Extract a brief one-line summary (first sentence or the user's explicit title) — this is already the `STATE.md` bullet text from step 3.
+     3. Compute a hash: `printf '%s' "<summary text>" | shasum | cut -c1-8`
+     4. Build a JSON detail object: `{"summary": "<brief summary>", "context": "<full description, max 2000 chars>", "files": ["<any file paths mentioned>"], "added": "<YYYY-MM-DD>", "source": "user"}`
+     5. Store it through the canonical helper — pipe JSON via heredoc to avoid shell-quoting issues with apostrophes or special characters in user text:
         ```bash
         bash "${PLUGIN_ROOT}/scripts/todo-details.sh" add HASH - <<'DETAIL_JSON'
         <json>
         DETAIL_JSON
         ```
-     7. Parse the helper's stdout JSON. Only when the parsed stdout is valid JSON with `status="ok"` may you:
+     6. Parse the helper's stdout JSON. Only when the parsed stdout is valid JSON with `status="ok"` may you:
         - edit the exact todo line you just added in `STATE.md` to append `(ref:HASH)` after the `(added YYYY-MM-DD)` tag
         - later report `Extended detail saved (ref:HASH).`
-     8. If the helper's stdout is not valid JSON or the parsed `status` is anything other than `ok`, leave the plain todo line from step 3 unchanged, do not append a ref tag, and do not write `.vbw-planning/todo-details/HASH.json` yourself.
+     7. If the helper's stdout is not valid JSON or the parsed `status` is anything other than `ok`, leave the plain todo line from step 3 unchanged, do not append a ref tag, and do not write `.vbw-planning/todo-details/HASH.json` yourself.
    - **If not triggered** (simple one-liner with no structural context): skip — no ref tag, no detail storage. Brief bullets keep STATE.md scannable and token-efficient for context compilation. The detail file preserves context that would otherwise be lost when the todo is executed in a later session.
-5. **Confirm:** Display ✓ + formatted item + Next Up (/vbw:status). If detail was captured successfully after step 4.7, also display: `Extended detail saved (ref:HASH).` If step 4 triggered but helper-backed storage did not succeed, warn that the plain todo was added but extended detail was not saved.
+6. **Run planning git boundary.** This step only happens after the plain `STATE.md` write from step 3 succeeded. For simple one-line todos, run it after step 3 using the shared `PLUGIN_ROOT` from step 4. For rich-detail todos, run it only after step 5 completes — after the `(ref:HASH)` update on detail-save success, or after the failed-detail/no-ref branch on helper failure. If `PLUGIN_ROOT` is non-empty and `${PLUGIN_ROOT}/scripts/planning-git.sh` exists, run:
+   ```bash
+   bash "${PLUGIN_ROOT}/scripts/planning-git.sh" commit-boundary "add todo item" .vbw-planning/config.json
+   ```
+   If `PLUGIN_ROOT` is empty or the helper is unavailable, keep the todo write intact and warn with the literal existing message:
+   ```text
+   VBW: planning-git.sh unavailable; skipping planning git boundary commit
+   ```
+   Do not add bespoke staging, commit, or push logic here — the helper owns that behavior.
+   - `planning_tracking=commit`: the helper stages `.vbw-planning/` + `CLAUDE.md` and commits if there are changes.
+   - `planning_tracking=manual|ignore`: the helper no-ops.
+   - `auto_push=always`: the helper pushes when the branch already has an upstream.
+7. **Confirm:** Display ✓ + formatted item + Next Up (/vbw:status). If detail was captured successfully after step 5.6, also display: `Extended detail saved (ref:HASH).` If step 5 triggered but helper-backed storage did not succeed, warn that the plain todo was added but extended detail was not saved. If step 6 emitted the planning-git warning, surface it too.
 
 ## Output Format
 

--- a/scripts/verify-init-todo.sh
+++ b/scripts/verify-init-todo.sh
@@ -14,6 +14,8 @@ TODO_CMD="$ROOT/commands/todo.md"
 LIST_CMD="$ROOT/commands/list-todos.md"
 BOOTSTRAP="$ROOT/scripts/bootstrap/bootstrap-state.sh"
 TODO_HARDCODED_HELPER_NEEDLE='/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/todo-details.sh'
+TODO_HARDCODED_PLANNING_GIT_NEEDLE='/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh'
+TODO_PLANNING_GIT_CMD='bash "${PLUGIN_ROOT}/scripts/planning-git.sh" commit-boundary "add todo item" .vbw-planning/config.json'
 
 TOTAL_PASS=0
 TOTAL_FAIL=0
@@ -37,7 +39,7 @@ check "INIT-02" "template has no ### Pending Todos subsection (flat)" test ! "$(
 check "TODO-01" "todo command anchors insertion on ## Todos" grep -q 'Find `## Todos`' "$TODO_CMD"
 check "TODO-02" "todo command does not reference Pending Todos" test ! "$(grep -c 'Pending Todos' "$TODO_CMD")" -gt 0
 check "TODO-03" "todo command avoids preflight plugin-root resolver shell block" test ! "$(grep -c 'VBW_CACHE_ROOT=' "$TODO_CMD")" -gt 0
-check "TODO-04" "todo command explains write-access requirement in restricted modes" grep -qi 'write access.*restricted\|restricted.*write access' "$TODO_CMD"
+check "TODO-04" "todo command explains Bash + write-access requirement in restricted modes" grep -qi 'bash.*write access\|write access.*bash' "$TODO_CMD"
 # TODO-05: Contract: file contains a STOP for missing STATE.md with restart guidance.
 # Heading-agnostic — greps the whole file for the stop-message keywords.
 check "TODO-05" "todo command STOPs with restart guidance when STATE.md missing" \
@@ -54,6 +56,29 @@ check "TODO-10" "todo command requires status ok before Extended detail saved co
   bash -c 'grep -Fq "parsed stdout is valid JSON with" "$1" && grep -Fq "Extended detail saved (ref:HASH)." "$1"' _ "$TODO_CMD"
 check "TODO-11" "todo command forbids direct per-file fallback writes" \
   grep -Fq '.vbw-planning/todo-details/HASH.json' "$TODO_CMD"
+check "TODO-12" "todo command uses planning git boundary helper via PLUGIN_ROOT" \
+  grep -Fq "$TODO_PLANNING_GIT_CMD" "$TODO_CMD"
+check "TODO-13" "todo command never hard-codes the session symlink planning-git path" \
+  bash -c '! grep -Fq "$2" "$1"' _ "$TODO_CMD" "$TODO_HARDCODED_PLANNING_GIT_NEEDLE"
+check "TODO-14" "todo command forbids bespoke git staging or commit instructions" \
+  bash -c '! grep -qE "(^|[^[:alnum:]_])git (add|commit|push)([^[:alnum:]_]|$)" "$1"' _ "$TODO_CMD"
+check "TODO-15" "todo command reuses the planning-git unavailable warning" \
+  grep -Fq 'VBW: planning-git.sh unavailable; skipping planning git boundary commit' "$TODO_CMD"
+
+write_line=$(grep -nF '3. **Add plain todo to STATE.md:**' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+ref_line=$(grep -nF 'edit the exact todo line you just added in `STATE.md` to append `(ref:HASH)`' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+detail_failure_line=$(grep -nF "If the helper's stdout is not valid JSON or the parsed \`status\` is anything other than \`ok\`" "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+planning_line=$(grep -nF "$TODO_PLANNING_GIT_CMD" "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+confirm_line=$(grep -nF '7. **Confirm:**' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+
+check "TODO-16" "planning boundary step appears after the plain todo write step" \
+  bash -c '[ -n "$1" ] && [ -n "$2" ] && [ "$1" -lt "$2" ]' _ "$write_line" "$planning_line"
+check "TODO-17" "planning boundary step appears after rich-detail ref append instructions" \
+  bash -c '[ -n "$1" ] && [ -n "$2" ] && [ "$1" -lt "$2" ]' _ "$ref_line" "$planning_line"
+check "TODO-18" "planning boundary step appears after the rich-detail failure branch" \
+  bash -c '[ -n "$1" ] && [ -n "$2" ] && [ "$1" -lt "$2" ]' _ "$detail_failure_line" "$planning_line"
+check "TODO-19" "planning boundary step appears before final confirmation" \
+  bash -c '[ -n "$1" ] && [ -n "$2" ] && [ "$1" -lt "$2" ]' _ "$planning_line" "$confirm_line"
 check "LIST-01" "list-todos command avoids preflight plugin-root resolver shell block" test ! "$(grep -c 'VBW_CACHE_ROOT=' "$LIST_CMD")" -gt 0
 check "LIST-02" "list-todos command explains restricted-mode requirement" grep -qi 'restricted mode\|restricted.*permission' "$LIST_CMD"
 # LIST-03: Contract: file contains a STOP for failed plugin root resolution with restart guidance.

--- a/scripts/verify-init-todo.sh
+++ b/scripts/verify-init-todo.sh
@@ -39,7 +39,8 @@ check "INIT-02" "template has no ### Pending Todos subsection (flat)" test ! "$(
 check "TODO-01" "todo command anchors insertion on ## Todos" grep -q 'Find `## Todos`' "$TODO_CMD"
 check "TODO-02" "todo command does not reference Pending Todos" test ! "$(grep -c 'Pending Todos' "$TODO_CMD")" -gt 0
 check "TODO-03" "todo command avoids preflight plugin-root resolver shell block" test ! "$(grep -c 'VBW_CACHE_ROOT=' "$TODO_CMD")" -gt 0
-check "TODO-04" "todo command explains Bash + write-access requirement in restricted modes" grep -qi 'bash.*write access\|write access.*bash' "$TODO_CMD"
+check "TODO-04" "todo command explains Bash + write-access requirement in restricted modes" \
+  bash -c 'grep -qi "restricted" "$1" && grep -qi "bash" "$1" && grep -qi "write access" "$1"' _ "$TODO_CMD"
 # TODO-05: Contract: file contains a STOP for missing STATE.md with restart guidance.
 # Heading-agnostic — greps the whole file for the stop-message keywords.
 check "TODO-05" "todo command STOPs with restart guidance when STATE.md missing" \

--- a/testing/verify-plugin-root-resolution.sh
+++ b/testing/verify-plugin-root-resolution.sh
@@ -486,6 +486,12 @@ else
   fail "todo.md missing canonical helper add command shape via PLUGIN_ROOT"
 fi
 
+if grep -Fq 'bash "${PLUGIN_ROOT}/scripts/planning-git.sh" commit-boundary "add todo item" .vbw-planning/config.json' "$TODO_CMD"; then
+  pass "todo.md uses canonical planning-git command shape via PLUGIN_ROOT"
+else
+  fail "todo.md missing canonical planning-git command shape via PLUGIN_ROOT"
+fi
+
 if grep -Fq 'Store the resolved path as `PLUGIN_ROOT`' "$TODO_CMD"; then
   pass "todo.md defines a PLUGIN_ROOT resolver step before helper writes"
 else
@@ -494,6 +500,7 @@ fi
 
 resolver_line=$(grep -nF 'Store the resolved path as `PLUGIN_ROOT`' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
 add_line=$(grep -nF 'bash "${PLUGIN_ROOT}/scripts/todo-details.sh" add HASH -' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
+planning_line=$(grep -nF 'bash "${PLUGIN_ROOT}/scripts/planning-git.sh" commit-boundary "add todo item" .vbw-planning/config.json' "$TODO_CMD" | head -1 | cut -d: -f1 || true)
 if [ -n "$resolver_line" ] && [ -n "$add_line" ]; then
   if [ "$resolver_line" -lt "$add_line" ]; then
     pass "todo.md places the PLUGIN_ROOT resolver before helper add usage"
@@ -502,6 +509,16 @@ if [ -n "$resolver_line" ] && [ -n "$add_line" ]; then
   fi
 else
   fail "todo.md ordering check missing resolver or helper add anchor"
+fi
+
+if [ -n "$resolver_line" ] && [ -n "$planning_line" ]; then
+  if [ "$resolver_line" -lt "$planning_line" ]; then
+    pass "todo.md places the PLUGIN_ROOT resolver before planning-git usage"
+  else
+    fail "todo.md places planning-git usage before the PLUGIN_ROOT resolver"
+  fi
+else
+  fail "todo.md ordering check missing resolver or planning-git anchor"
 fi
 
 for needle in \
@@ -522,6 +539,12 @@ if grep -Fq '/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/to
   fail "todo.md still hard-codes the session symlink helper path"
 else
   pass "todo.md no longer hard-codes the session symlink helper path"
+fi
+
+if grep -Fq '/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh' "$TODO_CMD"; then
+  fail "todo.md still hard-codes the session symlink planning-git path"
+else
+  pass "todo.md no longer hard-codes the session symlink planning-git path"
 fi
 
 case " $NON_PREAMBLE_COMMANDS " in

--- a/tests/planning-git-callsites.bats
+++ b/tests/planning-git-callsites.bats
@@ -19,6 +19,12 @@ load test_helper
   [ "$count" -ge 6 ]
 }
 
+@test "todo command is the sanctioned non-preamble PLUGIN_ROOT planning-git callsite" {
+  run bash -c "grep -cF 'bash \"\${PLUGIN_ROOT}/scripts/planning-git.sh\" commit-boundary \"add todo item\" .vbw-planning/config.json' \"$PROJECT_ROOT/commands/todo.md\""
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
 @test "planning-git callsites support VBW_PLUGIN_ROOT fallback" {
   local count
   count=$(grep -R -c 'VBW_PLUGIN_ROOT.*/scripts/planning-git.sh' "$PROJECT_ROOT/commands" "$PROJECT_ROOT/references" 2>/dev/null | awk -F: '{s+=$NF} END{print s}')


### PR DESCRIPTION
Fixes #501

## What

This updates `/vbw:todo` so successful backlog writes participate in VBW’s existing planning-artifact git boundary instead of leaving `.vbw-planning/` dirty. The command now resolves `PLUGIN_ROOT` for both helper-backed follow-up paths, runs `planning-git.sh commit-boundary` only after the todo write succeeds, and keeps commit/push behavior inside the existing helper contract. Supporting contract coverage was extended in the todo-specific verifier, the plugin-root resolver contract, and the planning-git callsite suite. User-facing planning-tracking wording was aligned in `README.md` and `commands/init.md`.

## Why

The root cause in #501 was architectural, not a missing one-line reminder. `/vbw:todo` mutated planning artifacts but skipped the repo’s canonical `scripts/planning-git.sh` boundary helper, so it bypassed the single source of truth for `planning_tracking` and `auto_push`. Reusing that helper is the durable fix because it preserves one owner for staging, commit, and optional push behavior instead of teaching `todo.md` its own git workflow.

## How

- `commands/todo.md` — hoisted the inline `PLUGIN_ROOT` resolver so both rich-detail storage and the new planning boundary can reuse it; tightened the guard to require Bash plus edits; added a post-write `planning-git.sh commit-boundary "add todo item" .vbw-planning/config.json` step; and kept the boundary after the rich-detail success/failure branches.
- `scripts/verify-init-todo.sh` — added checks for the planning-boundary helper call, no hard-coded planning-git path, no bespoke git logic in the command, and the required post-write ordering.
- `testing/verify-plugin-root-resolution.sh` — expanded the `todo.md` non-preamble resolver contract to cover the new `planning-git.sh` call shape and forbid hard-coded planning-git symlink use.
- `tests/planning-git-callsites.bats` — added the sanctioned non-preamble `todo.md` `PLUGIN_ROOT` planning-git callsite assertion.
- `README.md` — updated the `planning_tracking=commit` description to reflect helper-backed planning boundaries, including todo additions.
- `commands/init.md` — updated the planning-tracking choice text so init matches the real helper-backed scope.

## Acceptance criteria verification

1. `/vbw:todo` invokes the canonical planning git boundary after successful backlog writes.
   - Satisfied by `commands/todo.md:52-64`.
2. The implementation reuses `scripts/planning-git.sh commit-boundary ...` instead of inventing todo-specific git logic.
   - Satisfied by `commands/todo.md:54` and helper behavior in `scripts/planning-git.sh:163-184`.
3. With `planning_tracking="commit"`, the helper stages planning artifacts and creates a `chore(vbw): ...` commit.
   - Satisfied by delegation at `commands/todo.md:54` and helper staging/commit behavior in `scripts/planning-git.sh:171-183`.
4. With `planning_tracking` set to `manual` or `ignore`, `/vbw:todo` does not create a commit.
   - Satisfied by helper early exit in `scripts/planning-git.sh:165-167`.
5. `auto_push="always"` remains helper-owned; `/vbw:todo` adds no separate push logic.
   - Satisfied by `commands/todo.md:60-63` and helper push handling in `scripts/planning-git.sh:117-126,183-184`.
6. The planning boundary is not attempted before the todo write succeeds.
   - Satisfied by `commands/todo.md:27-64`; ordering enforced by `scripts/verify-init-todo.sh:73-81`.
7. Contract coverage exists.
   - Satisfied by `scripts/verify-init-todo.sh:59-81`, `testing/verify-plugin-root-resolution.sh:474-568`, and `tests/planning-git-callsites.bats:22-26`.
8. Relevant command-contract checks pass.
   - Verified by `bash scripts/verify-init-todo.sh`, `bash testing/verify-plugin-root-resolution.sh`, and `bats tests/planning-git-callsites.bats`.
9. `bash testing/run-all.sh` passes.
   - Verified locally and in GitHub Actions on commit `c5257a54ac67feb7605d82decd582475354ebec9`.

## Testing

- [x] `bash scripts/verify-init-todo.sh`
- [x] `bash testing/verify-plugin-root-resolution.sh`
- [x] `bats tests/planning-git-callsites.bats`
- [x] `bash testing/run-all.sh`
- [x] GitHub Actions checks green on `c5257a54ac67feb7605d82decd582475354ebec9`

## QA summary

- Primary QA rounds completed: 3 via `qa-investigator`; findings fixed: 0; false positives: 0.
- Cross-model QA rounds completed: 1 via `qa-investigator-gpt-54` (GPT-5.4); findings fixed: 0; false positives: 0.
- Copilot PR review rounds completed: 3.
  - Round 1: 1 legitimate finding fixed in `c5257a54ac67feb7605d82decd582475354ebec9`.
  - Round 2: 1 false positive (quoted grep pattern in `tests/planning-git-callsites.bats`) resolved with reviewer evidence; no code change required.
  - Round 3: fresh Copilot review on `c5257a54ac67feb7605d82decd582475354ebec9` returned no new comments.
- Remaining unresolved review threads: 0.
