### PR TITLE
fix(todo-debug): harden todo-to-debug pickup

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -42,11 +42,11 @@ If the selected item has a non-null `ref`, load detail immediately — before se
 ```bash
 bash "{plugin-root}/scripts/todo-details.sh" get {hash}
 ```
-If `status` is `"ok"`, store `DETAIL_STATUS=ok`, `detail.context`, and `detail.files` for later use. If `status` is `"not_found"` or `"error"`, record the matching `DETAIL_STATUS` value and run:
+If `status` is `"ok"`, store `DETAIL_STATUS=ok`, store the exact helper stdout as `TODO_DETAIL_RESULT_JSON`, and store `detail.context` plus `detail.files` for later use. If `status` is `"not_found"` or `"error"`, clear `TODO_DETAIL_RESULT_JSON`, record the matching `DETAIL_STATUS` value, and run:
 ```bash
 bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
 ```
-Continue without detail.
+Continue without detail. If the selected item has no ref, use `DETAIL_STATUS=none` and `TODO_DETAIL_RESULT_JSON=""`.
 
 If `status` is `"error"`, STOP with the resolver's `message` value.
 
@@ -72,9 +72,29 @@ Resolve or create the debug session before any investigation. Order of precedenc
    ```bash
    BUG_DESC=$(printf '%s' "$ARGUMENTS" | sed -E 's/[[:space:]]*\(ref:[^)]+\)//g' | sed -E 's/(^|[[:space:]])--(competing|parallel|serial)([[:space:]]|$)/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -s '[:space:]' ' ')
    SLUG=$(printf '%s' "$BUG_DESC" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | head -c 50)
-  eval "$(printf '%s' "$SOURCE_TODO_JSON" | bash "{plugin-root}/scripts/debug-session-state.sh" start-with-source-todo .vbw-planning "$SLUG")"
+   if [ "${TODO_SELECTED:-false}" = "true" ]; then
+     eval "$(printf '%s' "$TODO_SELECTED_JSON" | TODO_DETAIL_RESULT_JSON="${TODO_DETAIL_RESULT_JSON:-}" bash "{plugin-root}/scripts/debug-session-state.sh" start-with-selected-todo .vbw-planning "$SLUG" "${DETAIL_STATUS:-none}")"
+   else
+     MANUAL_REF="${REF_HASH:-none}"
+     MANUAL_DETAIL_CONTEXT=""
+     MANUAL_DETAIL_FILES='[]'
+     if [ "${DETAIL_STATUS:-none}" = "ok" ] && [ -n "${TODO_DETAIL_RESULT_JSON:-}" ]; then
+       MANUAL_DETAIL_CONTEXT=$(printf '%s' "$TODO_DETAIL_RESULT_JSON" | jq -r '.detail.context // empty' 2>/dev/null || echo "")
+       MANUAL_DETAIL_FILES=$(printf '%s' "$TODO_DETAIL_RESULT_JSON" | jq -c '(.detail.files // []) | if type == "array" then . else [] end' 2>/dev/null || printf '[]')
+     fi
+     eval "$(jq -cn \
+       --arg mode "source-todo" \
+       --arg text "$BUG_DESC" \
+       --arg raw_line "none" \
+       --arg ref "$MANUAL_REF" \
+       --arg detail_status "${DETAIL_STATUS:-none}" \
+       --argjson related_files "$MANUAL_DETAIL_FILES" \
+       --arg detail_context "$MANUAL_DETAIL_CONTEXT" \
+       '{mode:$mode, text:$text, raw_line:$raw_line, ref:$ref, detail_status:$detail_status, related_files:$related_files, detail_context:$detail_context}' \
+       | bash "{plugin-root}/scripts/debug-session-state.sh" start-with-source-todo .vbw-planning "$SLUG")"
+   fi
    ```
-  Build `SOURCE_TODO_JSON` deterministically before this call. It must include at minimum the normalized todo text, raw todo line, ref (or `none`), detail-load status, related files, and persisted detail context when available. The helper owns session creation, `## Source Todo` persistence, and rollback on source-todo write failure.
+   The selected-todo helper owns the numbered `/vbw:list-todos` source-todo payload normalization, `## Source Todo` persistence, and rollback on write failure. Keep manual/freeform debug starts on the existing `start-with-source-todo` path.
 
   Only after the source-todo write succeeds, and only when `TODO_SELECTED=true`, pipe `TODO_SELECTED_JSON` into:
   ```bash
@@ -100,20 +120,20 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
 </debug_session_routing>
 
 ## Steps
-1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`) from $ARGUMENTS and store them separately for Step 2 routing. If `TODO_SELECTED_JSON` already exists from the numeric-selection path above, reuse its `command_text` as the bug description, reuse its `ref`, and reuse the already-loaded `DETAIL_STATUS`, `detail.context`, and `detail.files` values — do not call `todo-details.sh` a second time. Otherwise, if the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
-    ```bash
-    bash "{plugin-root}/scripts/todo-details.sh" get {hash}
-    ```
-  Parse the JSON output. If `status` is `"ok"`, store `detail.context` and `detail.files` for use in Step 4. If `status` is `"not_found"` or `"error"`, run:
-  ```bash
-  bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
-  ```
-  In all cases, continue without detail.
-    If no ref suffix, $ARGUMENTS minus flags = bug description.
-    **Post-parse validation:** If the bug description is empty or whitespace-only after stripping flags and ref, check whether a ref was found AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the investigation context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:debug \"description of the bug or error message\" [--competing|--parallel|--serial]"`.
-    Map effort: thorough=high, balanced/fast=medium, turbo=low.
-    Keep effort profile as `EFFORT_PROFILE` (thorough|balanced|fast|turbo).
-    Read `{plugin-root}/references/effort-profile-{profile}.md`.
+1. **Parse + effort:** Strip any known flags (`--competing`, `--parallel`, `--serial`) from $ARGUMENTS and store them separately for Step 2 routing. If `TODO_SELECTED_JSON` already exists from the numeric-selection path above, reuse its `command_text` as the bug description, reuse its `ref`, and reuse the already-loaded `DETAIL_STATUS`, `TODO_DETAIL_RESULT_JSON`, `detail.context`, and `detail.files` values — do not call `todo-details.sh` a second time. Otherwise, if the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash as `REF_HASH` and strip the ref tag. Store remaining text (minus flags and ref) as the bug description. If a ref was found, load extended detail:
+   ```bash
+   bash "{plugin-root}/scripts/todo-details.sh" get {hash}
+   ```
+   Parse the JSON output. If `status` is `"ok"`, store `DETAIL_STATUS=ok`, store the exact helper stdout as `TODO_DETAIL_RESULT_JSON`, and store `detail.context` plus `detail.files` for use in Step 4. If `status` is `"not_found"` or `"error"`, clear `TODO_DETAIL_RESULT_JSON`, record the matching `DETAIL_STATUS` value, and run:
+   ```bash
+   bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
+   ```
+   In all cases, continue without detail.
+   If no ref suffix, $ARGUMENTS minus flags = bug description, `DETAIL_STATUS=none`, and `TODO_DETAIL_RESULT_JSON=""`.
+   **Post-parse validation:** If the bug description is empty or whitespace-only after stripping flags and ref, check whether a ref was found AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the investigation context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:debug \"description of the bug or error message\" [--competing|--parallel|--serial]"`.
+   Map effort: thorough=high, balanced/fast=medium, turbo=low.
+   Keep effort profile as `EFFORT_PROFILE` (thorough|balanced|fast|turbo).
+   Read `{plugin-root}/references/effort-profile-{profile}.md`.
 
 2. **Classify ambiguity:** 2+ signals = ambiguous.
   Keywords: "intermittent/sometimes/random/unclear/inconsistent/flaky/sporadic/nondeterministic",
@@ -122,20 +142,20 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
   `--serial` = never.
 
 3. **Routing decision + delegation marker:** Read prefer_teams config:
-    ```bash
-  PREFER_TEAMS=$(bash "{plugin-root}/scripts/normalize-prefer-teams.sh" .vbw-planning/config.json 2>/dev/null || echo "auto")
-    ```
+   ```bash
+   PREFER_TEAMS=$(bash "{plugin-root}/scripts/normalize-prefer-teams.sh" .vbw-planning/config.json 2>/dev/null || echo "auto")
+   ```
 
-    Before spawning any agent, activate the delegation guard:
-    ```bash
-    bash "{plugin-root}/scripts/delegated-workflow.sh" set debug "$EFFORT_PROFILE"
-    ```
+   Before spawning any agent, activate the delegation guard:
+   ```bash
+   bash "{plugin-root}/scripts/delegated-workflow.sh" set debug "$EFFORT_PROFILE"
+   ```
 
-    Decision tree:
+   Decision tree:
 
-    - `prefer_teams='always'`: Use Path A (team) for ALL bugs, regardless of effort or ambiguity
-    - `prefer_teams='auto'`: Use Path A (team) only if effort=high AND ambiguous, else Path B
-    - `prefer_teams='never'`: Always use Path B (single debugger, no team). Overrides effort and ambiguity.
+   - `prefer_teams='always'`: Use Path A (team) for ALL bugs, regardless of effort or ambiguity
+   - `prefer_teams='auto'`: Use Path A (team) only if effort=high AND ambiguous, else Path B
+   - `prefer_teams='never'`: Always use Path B (single debugger, no team). Overrides effort and ambiguity.
 
 4. **Spawn investigation:**
     **Path A: Competing Hypotheses** (prefer_teams='always' OR (prefer_teams!='never' AND effort=high AND ambiguous)):
@@ -292,23 +312,23 @@ fi
 **QA orchestration (absorbed from /vbw:qa debug-session mode):**
 
 1. Compile QA context:
-   ```bash
+  ```bash
   QA_CONTEXT=$(bash "{plugin-root}/scripts/compile-debug-session-context.sh" "$session_file" qa)
-   ```
+  ```
 
-2. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo:
-   ```bash
+1. Resolve tier from effort profile: fast=quick, balanced=standard, thorough=deep. Store as `ACTIVE_TIER`. If turbo:
+  ```bash
   bash "{plugin-root}/scripts/debug-session-state.sh" set-status .vbw-planning uat_pending
-   ```
+  ```
    Then jump directly to `<debug_inline_uat>` below — skip all remaining QA steps (do not increment QA round).
 
-3. Increment QA round:
-   ```bash
+1. Increment QA round:
+  ```bash
   eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" increment-qa .vbw-planning)"
-   ```
+  ```
 
-4. Resolve QA model and max turns:
-   ```bash
+1. Resolve QA model and max turns:
+  ```bash
   if ! AGENT_SETTINGS=$(bash "{plugin-root}/scripts/resolve-agent-settings.sh" qa .vbw-planning/config.json "{plugin-root}/config/model-profiles.json" "$EFFORT_PROFILE"); then
     echo "$AGENT_SETTINGS" >&2
     exit 1
@@ -316,9 +336,9 @@ fi
   eval "$AGENT_SETTINGS"
   QA_MODEL="$RESOLVED_MODEL"
   QA_MAX_TURNS="$RESOLVED_MAX_TURNS"
-   ```
+  ```
 
-5. Spawn vbw-qa as subagent via Task tool for debug-session verification. **Set `subagent_type: "vbw:vbw-qa"` and `model: "${QA_MODEL}"` in the Task tool invocation. If `QA_MAX_TURNS` is non-empty, also pass `maxTurns: ${QA_MAX_TURNS}`.**
+1. Spawn vbw-qa as subagent via Task tool for debug-session verification. **Set `subagent_type: "vbw:vbw-qa"` and `model: "${QA_MODEL}"` in the Task tool invocation. If `QA_MAX_TURNS` is non-empty, also pass `maxTurns: ${QA_MAX_TURNS}`.**
 
    Task description for debug-session QA:
    ```text
@@ -342,28 +362,30 @@ fi
    Format each check as: ID | Description | Status (PASS/FAIL) | Evidence
    ```
 
-6. Process the QA result:
-   - Parse the verdict (PASS/FAIL/PARTIAL) from the QA agent's response.
-   - Write the QA round to the session file:
-     ```bash
-     QA_RESULT_JSON=$(cat <<'ENDJSON'
-     {
-       "mode": "qa",
-       "round": {qa_round},
-       "result": "{PASS|FAIL|PARTIAL}",
-       "checks": [
-         {"id": "{check-id}", "description": "{check description}", "status": "{PASS|FAIL}", "evidence": "{evidence}"}
-       ]
-     }
-     ENDJSON
-     )
-    echo "$QA_RESULT_JSON" | bash "{plugin-root}/scripts/write-debug-session.sh" "$session_file"
-     ```
-   - Update session status based on result:
-     - PASS → `bash .../debug-session-state.sh set-status .vbw-planning uat_pending`
-     - FAIL or PARTIAL → `bash .../debug-session-state.sh set-status .vbw-planning qa_failed`
+2. Process the QA result:
+   Parse the verdict (PASS/FAIL/PARTIAL) from the QA agent's response.
 
-7. Present debug-session QA result:
+   Write the QA round to the session file:
+   ```bash
+   QA_RESULT_JSON=$(cat <<'ENDJSON'
+   {
+     "mode": "qa",
+     "round": {qa_round},
+     "result": "{PASS|FAIL|PARTIAL}",
+     "checks": [
+       {"id": "{check-id}", "description": "{check description}", "status": "{PASS|FAIL}", "evidence": "{evidence}"}
+     ]
+   }
+   ENDJSON
+   )
+   echo "$QA_RESULT_JSON" | bash "{plugin-root}/scripts/write-debug-session.sh" "$session_file"
+   ```
+
+   Update session status based on result:
+   - PASS → `bash .../debug-session-state.sh set-status .vbw-planning uat_pending`
+   - FAIL or PARTIAL → `bash .../debug-session-state.sh set-status .vbw-planning qa_failed`
+
+3. Present debug-session QA result:
    Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
    ```text
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -419,23 +441,23 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 **UAT orchestration (absorbed from /vbw:verify debug-session mode):**
 
 1. Compile UAT context:
-   ```bash
+  ```bash
   UAT_CONTEXT=$(bash "{plugin-root}/scripts/compile-debug-session-context.sh" "$session_file" uat)
-   ```
+  ```
 
-2. Increment UAT round:
-   ```bash
+1. Increment UAT round:
+  ```bash
   eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" increment-uat .vbw-planning)"
-   ```
+  ```
 
-3. Generate 1-3 UAT checkpoints from the session context. These must require HUMAN judgment:
+1. Generate 1-3 UAT checkpoints from the session context. These must require HUMAN judgment:
    - Reproduce the original bug — is it fixed?
    - Check related workflows — any regressions visible?
    - Verify the fix from the user's perspective
 
    **Guardrails:** Never ask the user to run automated checks (tests, lint, build commands) — those belong in QA. If the fix is purely internal (test-infra, script-only, non-user-facing), fall back to a single lightweight checkpoint: "Does the app still work as expected from your perspective?" rather than generating inapplicable user-facing scenarios.
 
-4. Present checkpoints one at a time using CHECKPOINT + AskUserQuestion:
+2. Present checkpoints one at a time using CHECKPOINT + AskUserQuestion:
 
    Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
    ```text
@@ -460,12 +482,12 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 
    **AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, YAML, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the checkpoint will not be presented to the user and the session will end prematurely. **STOP HERE and wait for the user to respond.** Process one checkpoint at a time.
 
-5. Response mapping (same rules as /vbw:verify; AskUserQuestion automatically provides a freeform "Other" option):
+3. Response mapping (same rules as /vbw:verify; AskUserQuestion automatically provides a freeform "Other" option):
    - "Pass" → record as passed
    - "Skip" → record as skipped
    - Freeform text via "Other" → treat as issue description, infer severity from keywords (crash/broken/error=critical, wrong/missing/bug=major, minor/cosmetic=minor, default=major)
 
-6. After all checkpoints, persist the UAT round:
+4. After all checkpoints, persist the UAT round:
    ```bash
    UAT_RESULT_JSON=$(cat <<'ENDJSON'
    {
@@ -481,14 +503,14 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
    }
    ENDJSON
    )
-  echo "$UAT_RESULT_JSON" | bash "{plugin-root}/scripts/write-debug-session.sh" "$session_file"
+   echo "$UAT_RESULT_JSON" | bash "{plugin-root}/scripts/write-debug-session.sh" "$session_file"
    ```
 
-7. Update session status:
+5. Update session status:
    - All checkpoints pass (no issues) → `bash .../debug-session-state.sh set-status .vbw-planning complete`
    - Any issues found → `bash .../debug-session-state.sh set-status .vbw-planning uat_failed`
 
-8. Present debug-session UAT result:
+6. Present debug-session UAT result:
    Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
    ```text
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/commands/list-todos.md
+++ b/commands/list-todos.md
@@ -30,23 +30,21 @@ allowed-tools: Read, Edit, Bash
    (e) Extract `--plugin-dir <path>` from the process tree (`ps axww`) and use that path if it contains `scripts/hook-wrapper.sh`.
    If none resolves to a valid directory, STOP: "Plugin root not found. The session startup hook may not have run. Try restarting your Claude session." Store the resolved path as `PLUGIN_ROOT` for subsequent steps.
 
-2. **Load todos:** Run `bash "${PLUGIN_ROOT}/scripts/list-todos.sh" {priority-filter}` (omit filter arg if none provided). Parse the JSON output.
+2. **Load todos through the snapshot helper:** Run:
+   ```bash
+   bash "${PLUGIN_ROOT}/scripts/todo-lifecycle.sh" list-with-snapshot {priority-filter}
+   ```
+   Omit the filter arg if none is provided. Parse the JSON output. This helper owns both the fresh `list-todos.sh` lookup and the exact last-view snapshot write. If snapshot persistence fails, it returns the helper error JSON instead of a partial success.
 
-3. **Persist the exact last-view snapshot:** Before any branching on status, pipe the exact JSON output from step 2 into:
-    ```bash
-    bash "${PLUGIN_ROOT}/scripts/todo-lifecycle.sh" snapshot-save
-    ```
-    If snapshot persistence returns `status="error"`, STOP with the helper's `message` value. Each new `/vbw:list-todos` invocation replaces the previous session snapshot.
-
-4. **Handle status:**
+3. **Handle status:**
    - `"error"`: STOP with the `message` value.
    - `"empty"`: Display the `display` value. Run `bash "${PLUGIN_ROOT}/scripts/suggest-next.sh" list-todos empty` and display. Exit.
    - `"no-match"`: Display the `display` value. Run `bash "${PLUGIN_ROOT}/scripts/suggest-next.sh" list-todos empty` and display. Exit.
-    - `"ok"`: Continue to step 5.
+   - `"ok"`: Continue to step 4.
 
-5. **Display list:** Show the `display` value from the script output exactly as returned (do not append any additional prompt text).
+4. **Display list:** Show the `display` value from the script output exactly as returned (do not append any additional prompt text).
 
-6. **Display action hints and STOP.** Do NOT prompt the user for input — display one of the following as plain text after the todo list, then STOP:
+5. **Display action hints and STOP.** Do NOT prompt the user for input — display one of the following as plain text after the todo list, then STOP:
 
     - **Unfiltered view (`filter=null`):**
        ```text

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -4,6 +4,8 @@
 # Usage:
 #   debug-session-state.sh start           <planning-dir> <slug>         → creates session, prints session_id
 #   debug-session-state.sh start-with-source-todo <planning-dir> <slug>  → creates session, writes Source Todo from stdin, rolls back on failure
+#   debug-session-state.sh start-with-selected-todo <planning-dir> <slug> <detail-status>
+#                                                               → creates session from selected todo JSON + detail helper output
 #   debug-session-state.sh get             <planning-dir>                → prints active session metadata
 #   debug-session-state.sh get-or-latest   <planning-dir>                → active session or latest unresolved
 #   debug-session-state.sh resume          <planning-dir> <session-id>   → sets active pointer to session
@@ -42,6 +44,7 @@ ACTIVE_FILE="$DEBUG_DIR/.active-session"
 
 # Valid status values
 VALID_STATUSES="investigating fix_applied qa_pending qa_failed uat_pending uat_failed complete"
+VALID_DETAIL_STATUSES="ok not_found error none"
 
 validate_status() {
   local s="$1"
@@ -49,6 +52,15 @@ validate_status() {
     [ "$s" = "$v" ] && return 0
   done
   echo "Error: invalid status '$s'. Valid: $VALID_STATUSES" >&2
+  return 1
+}
+
+validate_detail_status() {
+  local s="$1"
+  for v in $VALID_DETAIL_STATUSES; do
+    [ "$s" = "$v" ] && return 0
+  done
+  echo "Error: invalid detail status '$s'. Valid: $VALID_DETAIL_STATUSES" >&2
   return 1
 }
 
@@ -415,6 +427,57 @@ ENDSESSION
   printf 'session_file=%q\n' "$session_file"
 }
 
+build_source_todo_from_selected() {
+  local detail_status="$1"
+  local selected_json detail_result_json text raw_line ref related_files detail_context detail_result_status
+
+  validate_detail_status "$detail_status" || return 1
+
+  selected_json=$(cat)
+  if ! printf '%s' "$selected_json" | jq empty >/dev/null 2>&1; then
+    echo "Error: invalid selected todo JSON" >&2
+    return 1
+  fi
+
+  detail_result_json="${TODO_DETAIL_RESULT_JSON:-}"
+  if [ -n "$detail_result_json" ] && ! printf '%s' "$detail_result_json" | jq empty >/dev/null 2>&1; then
+    echo "Error: invalid TODO_DETAIL_RESULT_JSON payload" >&2
+    return 1
+  fi
+
+  text=$(printf '%s' "$selected_json" | jq -r '.command_text // .normalized_text // .text // "none"')
+  raw_line=$(printf '%s' "$selected_json" | jq -r '.line // .text // "none"')
+  ref=$(printf '%s' "$selected_json" | jq -r '.ref // "none"')
+  related_files='[]'
+  detail_context=''
+
+  if [ "$detail_status" = "ok" ]; then
+    if [ -z "$detail_result_json" ]; then
+      echo "Error: detail status ok requires TODO_DETAIL_RESULT_JSON" >&2
+      return 1
+    fi
+
+    detail_result_status=$(printf '%s' "$detail_result_json" | jq -r '.status // empty')
+    if [ "$detail_result_status" != "ok" ]; then
+      echo "Error: detail status ok requires todo-details.sh get output with status=ok" >&2
+      return 1
+    fi
+
+    related_files=$(printf '%s' "$detail_result_json" | jq -c '(.detail.files // []) | if type == "array" then . else [] end')
+    detail_context=$(printf '%s' "$detail_result_json" | jq -r '.detail.context // empty')
+  fi
+
+  jq -cn \
+    --arg mode "source-todo" \
+    --arg text "$text" \
+    --arg raw_line "$raw_line" \
+    --arg ref "$ref" \
+    --arg detail_status "$detail_status" \
+    --argjson related_files "$related_files" \
+    --arg detail_context "$detail_context" \
+    '{mode:$mode, text:$text, raw_line:$raw_line, ref:$ref, detail_status:$detail_status, related_files:$related_files, detail_context:$detail_context}'
+}
+
 start_with_source_todo() {
   local slug_input="$1"
   local source_todo_json session_output session_id session_file previous_active_pointer had_previous_pointer=0
@@ -446,6 +509,21 @@ start_with_source_todo() {
   printf '%s\n' "$session_output"
 }
 
+start_with_selected_todo() {
+  local slug_input="$1"
+  local detail_status="${2:-none}"
+  local selected_json source_todo_json
+
+  validate_detail_status "$detail_status" || return 1
+
+  selected_json=$(cat)
+  if ! source_todo_json=$(build_source_todo_from_selected "$detail_status" <<< "$selected_json"); then
+    return 1
+  fi
+
+  printf '%s' "$source_todo_json" | start_with_source_todo "$slug_input"
+}
+
 case "$CMD" in
   start)
     SLUG="${3:-}"
@@ -463,6 +541,16 @@ case "$CMD" in
       exit 1
     fi
     start_with_source_todo "$SLUG"
+    ;;
+
+  start-with-selected-todo)
+    SLUG="${3:-}"
+    DETAIL_STATUS="${4:-none}"
+    if [ -z "$SLUG" ]; then
+      echo "Usage: debug-session-state.sh start-with-selected-todo <planning-dir> <slug> <detail-status>" >&2
+      exit 1
+    fi
+    start_with_selected_todo "$SLUG" "$DETAIL_STATUS"
     ;;
 
   get)
@@ -698,7 +786,7 @@ case "$CMD" in
 
   *)
     echo "Error: unknown command '$CMD'" >&2
-    echo "Commands: start, get, get-or-latest, resume, set-status, increment-qa, increment-uat, clear-active, list" >&2
+    echo "Commands: start, start-with-source-todo, start-with-selected-todo, get, get-or-latest, resume, set-status, increment-qa, increment-uat, clear-active, list" >&2
     exit 1
     ;;
 esac

--- a/scripts/todo-lifecycle.sh
+++ b/scripts/todo-lifecycle.sh
@@ -67,15 +67,84 @@ make_temp_with_suffix() {
 snapshot_validate_schema() {
   local json_input="$1"
   printf '%s' "$json_input" | jq -e '
+    def non_empty_string: type == "string" and length > 0;
+    def positive_integer: type == "number" and floor == . and . > 0;
+    def valid_section: . == "## Todos" or . == "### Pending Todos";
+    def maybe_filter: . == null or (type == "string" and length > 0);
+    def maybe_ref: . == null or (type == "string" and test("^[a-f0-9]{8}$"));
+    def maybe_known_issue_signature:
+      . == null
+      or (
+        type == "object"
+        and ((keys_unsorted - ["phase", "phase_dir", "test", "file", "error", "source_kind", "disposition", "source_path"]) | length == 0)
+        and ([.phase, .phase_dir, .test, .file, .error, .source_kind, .disposition, .source_path] | all(. == null or (type == "string")))
+      );
+    def valid_item($state_path; $section):
+      type == "object"
+      and (.state_path | non_empty_string)
+      and (.state_path == $state_path)
+      and (.section | valid_section)
+      and (.section == $section)
+      and (.line | non_empty_string)
+      and (.normalized_text | non_empty_string)
+      and (.section_index | positive_integer)
+      and (.num | positive_integer)
+      and (.identity_occurrence | positive_integer)
+      and (.identity_total | positive_integer)
+      and (.ref | maybe_ref)
+      and (.known_issue_signature | maybe_known_issue_signature);
+    def identity_of:
+      {
+        normalized_text: (.normalized_text // ""),
+        ref: (.ref // null),
+        known_issue_signature: (.known_issue_signature // null)
+      };
+    def item_nums_are_sequential:
+      . as $items
+      | to_entries
+      | all(.value.num == (.key + 1));
+    def unfiltered_identity_ordinals_match:
+      . as $items
+      | to_entries
+      | all(
+          (.key + 1) as $num
+          | (.value | identity_of) as $id
+          | (.value.identity_occurrence == ([range(0; $num) as $j | $items[$j] | select(identity_of == $id)] | length))
+            and (.value.identity_total == ([ $items[] | select(identity_of == $id) ] | length))
+        );
+
     type == "object"
     and (.status | type == "string")
     and (
       if .status == "error" then
         (.message | type == "string")
+        and (if has("filter") then (.filter | maybe_filter) else true end)
+        and (if has("items") then (.items | type == "array") else true end)
+      elif .status == "empty" then
+        (has("state_path") and (.state_path | non_empty_string))
+        and (has("section") and .section == null)
+        and (has("count") and .count == 0)
+        and (has("filter") and .filter == null)
+        and (has("items") and (.items | type == "array") and (.items | length == 0))
+      elif .status == "no-match" then
+        (has("state_path") and (.state_path | non_empty_string))
+        and (has("section") and (.section | valid_section))
+        and (has("count") and .count == 0)
+        and (has("filter") and (.filter | type == "string" and length > 0))
+        and (has("items") and (.items | type == "array") and (.items | length == 0))
+      elif .status == "ok" then
+        . as $snapshot
+        | (has("state_path") and (.state_path | non_empty_string))
+          and (has("section") and (.section | valid_section))
+          and (has("count") and (.count | positive_integer))
+          and (has("filter") and (.filter | maybe_filter))
+          and (has("items") and (.items | type == "array") and (.items | length > 0))
+          and (.count == (.items | length))
+          and ([.items[] | valid_item($snapshot.state_path; $snapshot.section)] | all)
+          and (.items | item_nums_are_sequential)
+          and (if .filter == null then (.items | unfiltered_identity_ordinals_match) else true end)
       else
-        (.state_path? | type == "string" or .state_path == null)
-        and (.section? | type == "string" or .section == null)
-        and (.items | type == "array")
+        false
       end
     )
   ' >/dev/null 2>&1

--- a/scripts/todo-lifecycle.sh
+++ b/scripts/todo-lifecycle.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # todo-lifecycle.sh — shared deterministic todo snapshot, validation, and mutation helper.
 #
 # Commands:
+#   list-with-snapshot [filter]   Run list-todos.sh, persist last-view snapshot, return original JSON
 #   snapshot-save                 Read list-todos JSON from stdin and persist last-view snapshot
 #   snapshot-show                 Print persisted snapshot JSON
 #   snapshot-select <N> [--require-unfiltered]
@@ -50,7 +51,7 @@ ok_json() {
 }
 
 usage() {
-  error_json "usage" "Usage: todo-lifecycle.sh <snapshot-save|snapshot-show|snapshot-select|validate-item|detail-warning|pickup|remove> [args]"
+  error_json "usage" "Usage: todo-lifecycle.sh <list-with-snapshot|snapshot-save|snapshot-show|snapshot-select|validate-item|detail-warning|pickup|remove> [args]"
 }
 
 read_stdin() {
@@ -113,6 +114,20 @@ snapshot_save() {
     return 0
   fi
   ok_json --arg status "ok" --arg path "$SNAPSHOT_PATH" '{status:$status, path:$path}'
+}
+
+list_with_snapshot() {
+  local output_json snapshot_result snapshot_status
+
+  output_json=$(bash "$SCRIPT_DIR/list-todos.sh" "$@" 2>/dev/null || true)
+  snapshot_result=$(snapshot_save <<< "$output_json")
+  snapshot_status=$(printf '%s' "$snapshot_result" | jq -r '.status // "error"' 2>/dev/null || echo 'error')
+  if [ "$snapshot_status" != "ok" ]; then
+    printf '%s\n' "$snapshot_result"
+    return 0
+  fi
+
+  printf '%s\n' "$output_json"
 }
 
 snapshot_show() {
@@ -330,13 +345,19 @@ validate_item_against_live() {
 }
 
 validate_item_cmd() {
-  local item_json
+  local item_json validated_json validated_status
   item_json=$(read_stdin)
   if ! printf '%s' "$item_json" | jq empty >/dev/null 2>&1; then
     error_json "invalid_item" "Todo selection payload is invalid. Rerun /vbw:list-todos."
     return 0
   fi
-  validate_item_against_live "$item_json"
+  validated_json=$(validate_item_against_live "$item_json")
+  validated_status=$(printf '%s' "$validated_json" | jq -r '.status // "ok"' 2>/dev/null || echo 'error')
+  if [ "$validated_status" = "error" ]; then
+    printf '%s\n' "$validated_json"
+    return 0
+  fi
+  printf '%s' "$validated_json" | jq -c '. + {status:"ok"}'
 }
 
 append_activity_line_to_file() {
@@ -700,6 +721,9 @@ mutate_item() {
 }
 
 case "$CMD" in
+  list-with-snapshot)
+    list_with_snapshot "$@"
+    ;;
   snapshot-save)
     snapshot_save
     ;;

--- a/scripts/todo-lifecycle.sh
+++ b/scripts/todo-lifecycle.sh
@@ -124,7 +124,7 @@ snapshot_validate_schema() {
         (has("state_path") and (.state_path | non_empty_string))
         and (has("section") and .section == null)
         and (has("count") and .count == 0)
-        and (has("filter") and .filter == null)
+        and (has("filter") and (.filter | maybe_filter))
         and (has("items") and (.items | type == "array") and (.items | length == 0))
       elif .status == "no-match" then
         (has("state_path") and (.state_path | non_empty_string))

--- a/scripts/write-debug-session.sh
+++ b/scripts/write-debug-session.sh
@@ -571,7 +571,7 @@ case "$MODE" in
     ;;
 
   *)
-    echo "Error: unknown mode '$MODE'. Valid: investigation, qa, uat, status" >&2
+    echo "Error: unknown mode '$MODE'. Valid: source-todo, investigation, qa, uat, status" >&2
     exit 1
     ;;
 esac

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -63,7 +63,7 @@ else
   fail "debug-session-state.sh missing"
 fi
 
-for cmd in start start-with-source-todo get get-or-latest resume set-status increment-qa increment-uat clear-active list; do
+for cmd in start start-with-source-todo start-with-selected-todo get get-or-latest resume set-status increment-qa increment-uat clear-active list; do
   if grep -q "\"$cmd\"\\|'$cmd'\\|${cmd})" "$STATE_SCRIPT" 2>/dev/null; then
     pass "state script handles command: $cmd"
   else
@@ -120,6 +120,12 @@ if grep -q "debug_session_routing" "$DEBUG_CMD" 2>/dev/null; then
   pass "debug.md has debug_session_routing section"
 else
   fail "debug.md missing debug_session_routing section"
+fi
+
+if grep -q 'start-with-selected-todo' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md uses start-with-selected-todo for numbered todo sessions"
+else
+  fail "debug.md missing start-with-selected-todo numbered todo integration"
 fi
 
 QA_CMD="$ROOT/commands/qa.md"

--- a/testing/verify-todo-pickup-contract.sh
+++ b/testing/verify-todo-pickup-contract.sh
@@ -57,12 +57,14 @@ require_grep "list-todos.sh emits command_text metadata" 'command_text' "$LIST_S
 require_grep "resolve-todo-item.sh supports session snapshots" 'session-snapshot' "$RESOLVE_SCRIPT"
 require_grep "todo-lifecycle.sh supports pickup command" 'pickup\)' "$LIFECYCLE_SCRIPT"
 require_grep "todo-lifecycle.sh supports remove command" 'remove\)' "$LIFECYCLE_SCRIPT"
+require_grep "todo-lifecycle.sh supports list-with-snapshot" 'list-with-snapshot' "$LIFECYCLE_SCRIPT"
 require_grep "todo-lifecycle.sh supports snapshot-save" 'snapshot-save' "$LIFECYCLE_SCRIPT"
 require_grep "track-known-issues.sh supports suppress" 'suppress\)' "$TRACK_SCRIPT"
 require_grep "compile-context.sh reads Recent Activity" 'Recent Activity\|Activity Log\|Activity' "$COMPILE_SCRIPT"
 
 # list-todos command surface
-require_grep "list-todos persists last-view snapshot" 'todo-lifecycle\.sh" snapshot-save' "$LIST_CMD"
+require_grep "list-todos uses helper-backed snapshot capture" 'todo-lifecycle\.sh" list-with-snapshot' "$LIST_CMD"
+require_absent "list-todos no longer asks markdown to pipe JSON into snapshot-save" 'todo-lifecycle\.sh" snapshot-save' "$LIST_CMD"
 require_grep "list-todos remove uses snapshot resolver" 'resolve-todo-item\.sh" <N> --session-snapshot' "$LIST_CMD"
 require_grep "list-todos remove delegates to lifecycle helper" 'todo-lifecycle\.sh" remove' "$LIST_CMD"
 require_grep "list-todos filtered view rerun-unfiltered hint exists" 'rerun unfiltered /vbw:list-todos' "$LIST_CMD"
@@ -71,9 +73,10 @@ require_absent "list-todos no longer advertises /vbw:research N" '/vbw:research 
 # debug command surface
 require_grep "debug uses snapshot-backed todo resolver" 'resolve-todo-item\.sh" <N> --session-snapshot --require-unfiltered --validate-live' "$DEBUG_CMD"
 require_grep "debug writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning' "$DEBUG_CMD"
-require_grep "debug delegates Source Todo persistence to debug-session-state helper" 'debug-session-state\.sh" start-with-source-todo' "$DEBUG_CMD"
+require_grep "debug delegates numbered Source Todo persistence to selected-todo helper" 'debug-session-state\.sh" start-with-selected-todo' "$DEBUG_CMD"
+require_absent "debug no longer mentions manual SOURCE_TODO_JSON construction" 'SOURCE_TODO_JSON' "$DEBUG_CMD"
 require_grep "debug pickup uses lifecycle helper" 'todo-lifecycle\.sh" pickup /vbw:debug' "$DEBUG_CMD"
-require_grep "debug documents helper-owned Source Todo rollback boundary" 'helper owns session creation, `## Source Todo` persistence, and rollback' "$DEBUG_CMD"
+require_grep "debug documents helper-owned numbered Source Todo rollback boundary" 'selected-todo helper owns the numbered `/vbw:list-todos` source-todo payload normalization' "$DEBUG_CMD"
 
 # fix command surface
 require_grep "fix uses snapshot-backed todo resolver" 'resolve-todo-item\.sh" <N> --session-snapshot --require-unfiltered --validate-live' "$FIX_CMD"

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -90,6 +90,38 @@ teardown() {
   [ -f "$VBW_PLANNING_DIR/debugging/active/$first_session_name" ]
 }
 
+@test "start-with-selected-todo builds Source Todo from selected todo without detail" {
+  run bash -lc 'printf %s "$1" | bash "$2" start-with-selected-todo "$3" "selected-todo-no-detail" none' -- \
+    '{"command_text":"Investigate parser crash","normalized_text":"Investigate parser crash","line":"- [HIGH] Investigate parser crash (added 2026-04-01) (ref:abcd1234)","ref":"abcd1234"}' \
+    "$SCRIPTS_DIR/debug-session-state.sh" \
+    "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  eval "$output"
+  [ -f "$session_file" ]
+  grep -q '\*\*Text:\*\* Investigate parser crash' "$session_file"
+  grep -q '\*\*Raw Line:\*\* - \[HIGH\] Investigate parser crash' "$session_file"
+  grep -q '\*\*Ref:\*\* abcd1234' "$session_file"
+  grep -q '\*\*Detail Status:\*\* none' "$session_file"
+  grep -q 'None recorded\.' "$session_file"
+  grep -q 'No persisted detail context\.' "$session_file"
+}
+
+@test "start-with-selected-todo builds Source Todo from selected todo and detail helper output" {
+  run env TODO_DETAIL_RESULT_JSON='{"status":"ok","detail":{"context":"Persisted detail context","files":["src/parser.sh","tests/parser.bats"]}}' \
+    bash -lc 'printf %s "$1" | bash "$2" start-with-selected-todo "$3" "selected-todo-with-detail" ok' -- \
+    '{"command_text":"Investigate parser crash","line":"- Investigate parser crash (ref:abcd1234)","ref":"abcd1234"}' \
+    "$SCRIPTS_DIR/debug-session-state.sh" \
+    "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  eval "$output"
+  [ -f "$session_file" ]
+  grep -q '\*\*Text:\*\* Investigate parser crash' "$session_file"
+  grep -q '\*\*Detail Status:\*\* ok' "$session_file"
+  grep -q 'src/parser.sh' "$session_file"
+  grep -q 'tests/parser.bats' "$session_file"
+  grep -q 'Persisted detail context' "$session_file"
+}
+
 # ── get ──────────────────────────────────────────────────
 
 @test "get returns none when no active session" {

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -81,6 +81,29 @@ select_snapshot_item() {
   bash "$RESOLVE_SCRIPT" "$selection" --session-snapshot
 }
 
+write_raw_snapshot() {
+  printf '%s' "$1" > "/tmp/.vbw-last-list-view-${CLAUDE_SESSION_ID}.json"
+}
+
+assert_snapshot_invalid_everywhere() {
+  local selection="${1:-1}"
+
+  run bash "$SCRIPT" snapshot-show
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "error" ]
+  [ "$(echo "$output" | jq -r '.code')" = "snapshot_invalid" ]
+
+  run bash "$SCRIPT" snapshot-select "$selection"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "error" ]
+  [ "$(echo "$output" | jq -r '.code')" = "snapshot_invalid" ]
+
+  run bash "$RESOLVE_SCRIPT" "$selection" --session-snapshot --require-unfiltered --validate-live
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "error" ]
+  [ "$(echo "$output" | jq -r '.code')" = "snapshot_invalid" ]
+}
+
 @test "todo-lifecycle: snapshot-show fails closed when missing" {
   run bash "$SCRIPT" snapshot-show
   [ "$status" -eq 0 ]
@@ -145,6 +168,46 @@ select_snapshot_item() {
   [ "$status" -eq 0 ]
   [ "$(echo "$output" | jq -r '.status')" = "ok" ]
   [ "$(echo "$output" | jq -r '.normalized_text')" = "Fix parser bug" ]
+}
+
+@test "todo-lifecycle: snapshot-show accepts valid empty snapshot payloads" {
+  write_raw_snapshot '{"status":"empty","state_path":".vbw-planning/STATE.md","section":null,"count":0,"filter":null,"display":"No pending todos.","items":[]}'
+
+  run bash "$SCRIPT" snapshot-show
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "empty" ]
+}
+
+@test "todo-lifecycle: snapshot-show accepts valid no-match snapshot payloads" {
+  write_raw_snapshot '{"status":"no-match","state_path":".vbw-planning/STATE.md","section":"## Todos","count":0,"filter":"high","display":"No high-priority todos found.","items":[]}'
+
+  run bash "$SCRIPT" snapshot-show
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "no-match" ]
+}
+
+@test "todo-lifecycle: snapshot schema rejects bogus top-level status" {
+  write_raw_snapshot '{"status":"bogus","state_path":".vbw-planning/STATE.md","section":"## Todos","count":1,"filter":null,"items":[{"num":1,"section_index":1,"line":"- Test todo","normalized_text":"Test todo","state_path":".vbw-planning/STATE.md","section":"## Todos","line_no":12,"identity_occurrence":1,"identity_total":1,"ref":null,"known_issue_signature":null}]}'
+
+  assert_snapshot_invalid_everywhere
+}
+
+@test "todo-lifecycle: snapshot schema rejects ok snapshots missing filter" {
+  write_raw_snapshot '{"status":"ok","state_path":".vbw-planning/STATE.md","section":"## Todos","count":1,"items":[{"num":1,"section_index":1,"line":"- Test todo","normalized_text":"Test todo","state_path":".vbw-planning/STATE.md","section":"## Todos","line_no":12,"identity_occurrence":1,"identity_total":1,"ref":null,"known_issue_signature":null}]}'
+
+  assert_snapshot_invalid_everywhere
+}
+
+@test "todo-lifecycle: snapshot schema rejects no-match snapshots with null filter" {
+  write_raw_snapshot '{"status":"no-match","state_path":".vbw-planning/STATE.md","section":"## Todos","count":0,"filter":null,"display":"No matching todos.","items":[]}'
+
+  assert_snapshot_invalid_everywhere
+}
+
+@test "todo-lifecycle: snapshot schema rejects invalid item ref metadata" {
+  write_raw_snapshot '{"status":"ok","state_path":".vbw-planning/STATE.md","section":"## Todos","count":1,"filter":null,"items":[{"num":1,"section_index":1,"line":"- Test todo","normalized_text":"Test todo","state_path":".vbw-planning/STATE.md","section":"## Todos","line_no":12,"identity_occurrence":1,"identity_total":1,"ref":"not-a-ref","known_issue_signature":null}]}'
+
+  assert_snapshot_invalid_everywhere
 }
 
 @test "resolve-todo-item: validate-live returns status ok for a matching selection" {

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -118,6 +118,47 @@ select_snapshot_item() {
   [ "$(echo "$output" | jq -r '.status')" = "ok" ]
 }
 
+@test "todo-lifecycle: list-with-snapshot returns full metadata and writes the exact snapshot" {
+  write_state_with_recent_activity
+
+  run bash "$LIST_SCRIPT" high
+  [ "$status" -eq 0 ]
+  EXPECTED_JSON="$output"
+
+  run bash "$SCRIPT" list-with-snapshot high
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
+  [ "$(printf '%s' "$output" | jq -r '.items[0].command_text')" = "Refactor auth module" ]
+  [ "$(printf '%s' "$output" | jq -r '.items[0].section_index')" = "2" ]
+
+  run bash "$SCRIPT" snapshot-show
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
+}
+
+@test "todo-lifecycle: validate-item returns status ok for a matching live selection" {
+  write_state_with_recent_activity
+  save_snapshot
+  ITEM_JSON=$(select_snapshot_item 1)
+
+  run bash -lc 'printf "%s" "$1" | bash "$2" validate-item' -- "$ITEM_JSON" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "ok" ]
+  [ "$(echo "$output" | jq -r '.normalized_text')" = "Fix parser bug" ]
+}
+
+@test "resolve-todo-item: validate-live returns status ok for a matching selection" {
+  write_state_with_recent_activity
+
+  run bash "$SCRIPT" list-with-snapshot
+  [ "$status" -eq 0 ]
+
+  run bash "$RESOLVE_SCRIPT" 1 --session-snapshot --validate-live
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "ok" ]
+  [ "$(echo "$output" | jq -r '.selection_source')" = "snapshot" ]
+}
+
 @test "todo-lifecycle: snapshot-select preserves filtered numbering and section index" {
   write_state_with_recent_activity
   save_snapshot high

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -47,6 +47,18 @@ None.
 EOF
 }
 
+write_state_with_no_todos() {
+  cat > "$VBW_PLANNING_DIR/STATE.md" <<'EOF'
+# Project State
+
+## Todos
+None.
+
+## Blockers
+None.
+EOF
+}
+
 write_legacy_state() {
   cat > "$VBW_PLANNING_DIR/STATE.md" <<'EOF'
 # Project State
@@ -176,6 +188,25 @@ assert_snapshot_invalid_everywhere() {
   run bash "$SCRIPT" snapshot-show
   [ "$status" -eq 0 ]
   [ "$(echo "$output" | jq -r '.status')" = "empty" ]
+}
+
+@test "todo-lifecycle: list-with-snapshot preserves valid filtered empty snapshots" {
+  write_state_with_no_todos
+
+  run bash "$SCRIPT" list-with-snapshot high
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.status')" = "empty" ]
+  [ "$(echo "$output" | jq -r '.section')" = "null" ]
+  [ "$(echo "$output" | jq -r '.count')" = "0" ]
+  [ "$(echo "$output" | jq -r '.filter')" = "high" ]
+  [ "$(echo "$output" | jq -r '.display')" = "No pending todos." ]
+  [ "$(echo "$output" | jq -r '.items | length')" = "0" ]
+
+  EXPECTED_JSON="$output"
+
+  run bash "$SCRIPT" snapshot-show
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
 }
 
 @test "todo-lifecycle: snapshot-show accepts valid no-match snapshot payloads" {

--- a/tests/write-debug-session.bats
+++ b/tests/write-debug-session.bats
@@ -185,6 +185,18 @@ teardown() {
   [[ "$output" == *"invalid JSON"* ]]
 }
 
+@test "fails when mode field is missing" {
+  run bash -c 'echo '"'"'{"status":"qa_pending"}'"'"' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing required field 'mode'"* ]]
+}
+
+@test "rejects source_todo alias to keep source-todo contract strict" {
+  run bash -c 'echo '"'"'{"mode":"source_todo","text":"Investigate parser crash"}'"'"' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown mode 'source_todo'"* ]]
+}
+
 @test "fails on missing session file" {
   run bash -c 'echo '"'"'{"mode":"status","status":"investigating"}'"'"' | bash "$SCRIPTS_DIR/write-debug-session.sh" "/nonexistent/file.md"'
   [ "$status" -eq 1 ]

--- a/tests/write-debug-session.bats
+++ b/tests/write-debug-session.bats
@@ -195,6 +195,7 @@ teardown() {
   run bash -c 'echo '"'"'{"mode":"source_todo","text":"Investigate parser crash"}'"'"' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"'
   [ "$status" -eq 1 ]
   [[ "$output" == *"unknown mode 'source_todo'"* ]]
+  [[ "$output" == *"Valid: source-todo, investigation, qa, uat, status"* ]]
 }
 
 @test "fails on missing session file" {


### PR DESCRIPTION
Fixes #496

## What

This PR hardens the two remaining prompt-compliance seams in the numbered todo → debug path. `commands/list-todos.md` now delegates list + snapshot persistence to a deterministic bash helper in `scripts/todo-lifecycle.sh`, and `commands/debug.md` now delegates numbered source-todo normalization to `scripts/debug-session-state.sh` instead of assembling the strict writer payload in prompt text. It also tightens persisted snapshot schema validation so corrupted snapshots fail closed before selection proceeds, and adds regression coverage in the contract and Bats suites.

## Why

Issue #496 is a broad lifecycle umbrella; this branch implements the narrower scope clarified in the follow-up issue comment. The root cause in both failing seams was the same: command markdown was still depending on model-authored JSON for stateful handoffs that should have been deterministic helper contracts. The durable fix is to move those JSON boundaries into bash-owned helpers, keep `todo-lifecycle.sh` fail-closed, and keep `write-debug-session.sh` strict about `mode:"source-todo"` instead of widening the writer.

## How

- `commands/list-todos.md` — replaces the two-step `list-todos.sh` + `snapshot-save` prompt choreography with a single `list-with-snapshot` helper call.
- `commands/debug.md` — routes numbered selections through `start-with-selected-todo`, keeps manual/freeform starts on the existing path, and reuses raw detail-helper output instead of manual selected-todo payload construction.
- `scripts/todo-lifecycle.sh` — adds `list-with-snapshot`; makes `validate-item` return explicit `status:"ok"` on success; tightens persisted snapshot schema validation by status and item metadata so malformed snapshots fail closed.
- `scripts/debug-session-state.sh` — adds selected-todo normalization helper and subcommand that build the strict `source-todo` payload internally while reusing the rollback boundary.
- `scripts/write-debug-session.sh` — keeps writer behavior strict and updates the invalid-mode diagnostic to include `source-todo`.
- `testing/verify-todo-pickup-contract.sh` / `testing/verify-debug-session-contract.sh` — assert the new helper surfaces and the removal of the old prompt-built paths.
- `tests/todo-lifecycle.bats` / `tests/debug-session-state.bats` / `tests/write-debug-session.bats` — add regression coverage for helper-backed snapshot capture, selected-todo source persistence, malformed snapshot rejection, filtered-empty snapshot compatibility, and strict writer mode handling.

## Acceptance criteria verification

1. `commands/list-todos.md` calls the new snapshot helper directly and no longer pipes model-held JSON into `snapshot-save`
   - Satisfied by `commands/list-todos.md` calling `scripts/todo-lifecycle.sh list-with-snapshot`
   - Covered by `testing/verify-todo-pickup-contract.sh`
   - Covered by `tests/todo-lifecycle.bats` test `todo-lifecycle: list-with-snapshot returns full metadata and writes the exact snapshot`
2. `commands/debug.md` uses the new selected-todo helper for numeric todo pickup and no longer relies on manual `SOURCE_TODO_JSON` construction
   - Satisfied by `commands/debug.md` calling `scripts/debug-session-state.sh start-with-selected-todo`
   - Covered by `testing/verify-todo-pickup-contract.sh` and `testing/verify-debug-session-contract.sh`
   - Covered by `tests/debug-session-state.bats` selected-todo helper tests
3. `todo-lifecycle.sh` remains fail-closed on malformed snapshots
   - Satisfied by stricter `snapshot_validate_schema()` and explicit `snapshot_invalid` propagation through `snapshot-show`, `snapshot-select`, and `resolve-todo-item.sh --validate-live`
   - Covered by `tests/todo-lifecycle.bats` malformed snapshot regression tests
4. `write-debug-session.sh` remains strict about `mode:"source-todo"` (no `source_todo`, no mode-less payload)
   - Satisfied by keeping only the existing `source-todo` mode branch and rejecting all other invalid modes
   - Covered by `tests/write-debug-session.bats` tests `fails when mode field is missing` and `rejects source_todo alias to keep source-todo contract strict`
5. Contract checks, relevant Bats suites, and `bash testing/run-all.sh` pass
   - Verified locally with targeted contract + Bats runs and the full suite
   - Verified remotely with green GitHub Actions checks on commit `3750130536268aa4d1fab546d7ed5ec5a613e7f4`

## Testing

- [x] `bash testing/verify-todo-pickup-contract.sh`
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bats tests/todo-lifecycle.bats`
- [x] `bats tests/list-todos.bats`
- [x] `bats tests/debug-session-state.bats`
- [x] `bats tests/write-debug-session.bats`
- [x] `bats tests/debug-session-lifecycle.bats`
- [x] `bash testing/run-all.sh`
- [x] helper-driven smoke in a real VBW consumer repo for the numbered todo → debug flow
- [x] required GitHub Actions checks green on commit `3750130536268aa4d1fab546d7ed5ec5a613e7f4`

## QA summary

- Primary QA rounds completed: 4 (`qa-investigator`)
  - Round 1: clean
  - Round 2: 1 low observation fixed (`scripts/write-debug-session.sh` invalid-mode diagnostic)
  - Round 3: 1 medium contract finding fixed (`todo-lifecycle.sh` snapshot schema hardening)
  - Round 4: clean
- Cross-model rounds completed: 1 (`qa-investigator-gpt-54`)
  - Round 1: clean
- Copilot PR review rounds completed: 2
  - Round 1: 1 review comment fixed (`status:"empty"` filtered snapshot compatibility in `snapshot_validate_schema()` plus regression coverage)
  - Round 2: clean fresh re-review with no new comments
- CI status: all 18 required checks green on commit `3750130536268aa4d1fab546d7ed5ec5a613e7f4`