### PR TITLE
Fix debug-session resume export contract

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -3,7 +3,7 @@ name: vbw:debug
 category: supporting
 disable-model-invocation: true
 description: Investigate a bug using the Debugger agent's scientific method protocol.
-argument-hint: "<bug description or error message>"
+argument-hint: "bug description | todo number | --resume | --session ID"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, Agent, TeamCreate, TaskCreate, SendMessage, TeamDelete, Skill, LSP, AskUserQuestion
 ---
 
@@ -28,7 +28,7 @@ Store the plugin root path output above as `{plugin-root}` for use in script inv
 
 ## Guard
 - Not initialized (no .vbw-planning/ dir): STOP "Run /vbw:init first."
-- No $ARGUMENTS and no `--resume` flag and no `--session` flag: STOP "Usage: /vbw:debug \"description of the bug or error message\""
+- No $ARGUMENTS and no `--resume` flag and no `--session` flag: STOP "Usage: `/vbw:debug \"description of the bug or error message\" [--competing|--parallel|--serial]` | `/vbw:debug <todo-number> [--competing|--parallel|--serial]` | `/vbw:debug --resume` | `/vbw:debug --session <id>`"
 
 ## Resolve todo number
 
@@ -65,8 +65,9 @@ Resolve or create the debug session before any investigation. Order of precedenc
    ```bash
   eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" get-or-latest .vbw-planning)"
    ```
-   - If `active_session=none`: STOP "No active debug session to resume. Start one with: /vbw:debug \"bug description\""
-   - If `active_session=fallback`: inform user which session was auto-selected (no `.active-session` pointer was set, so the latest unresolved session was chosen automatically).
+  If `active_session=none`, STOP "No active debug session to resume. Use `/vbw:debug --session <id>` to open a specific session, or start one with `/vbw:debug \"description of the bug or error message\"` or `/vbw:debug <todo-number>`."
+  If `active_session=fallback`, inform user which session was auto-selected (no `.active-session` pointer was set, so the latest unresolved session was chosen automatically).
+  For metadata-read helper calls (`resume`, `get-or-latest`), use `active_session`, `session_id`, `session_file`, and `session_status` after `eval`. Use `session_status` for lifecycle checks after `eval`; do not rely on a bare `status` variable.
 
 3. **New session (no --resume, no --session):** Create a fresh session from $ARGUMENTS. Strip known flags (`--competing`, `--parallel`, `--serial`) and any `(ref:HASH)` suffix from $ARGUMENTS before computing the slug — these are routing/ref metadata, not part of the bug description.
    ```bash
@@ -104,19 +105,19 @@ Resolve or create the debug session before any investigation. Order of precedenc
 
 Store the resolved `session_id` and `session_file` for use in Steps below.
 
-If resuming a session with `status=qa_pending` or `status=fix_applied`: skip investigation, jump directly to `<debug_inline_qa>` below to run QA inline.
-If resuming a session with `status=qa_failed`: load failure context:
+If resuming a session with `session_status=qa_pending` or `session_status=fix_applied`: skip investigation, jump directly to `<debug_inline_qa>` below to run QA inline.
+If resuming a session with `session_status=qa_failed`: load failure context:
   ```bash
   FAILURE_CONTEXT=$(bash "{plugin-root}/scripts/compile-debug-session-context.sh" "$session_file" qa 2>/dev/null || echo "")
   ```
   Update status to `investigating` via `write-debug-session.sh` (mode=status), then continue investigation from Step 3. When composing the debugger task prompt in Step 4, prepend the compiled `FAILURE_CONTEXT` to the bug report so the debugger has the specific failed QA checks and findings. Use this format in the task prompt: `Previous QA failed. Failure context:\n{FAILURE_CONTEXT}\n\nOriginal bug report: {description}`.
-If resuming a session with `status=uat_pending`: skip investigation, jump directly to `<debug_inline_uat>` below to run UAT inline.
-If resuming a session with `status=uat_failed`: load failure context:
+If resuming a session with `session_status=uat_pending`: skip investigation, jump directly to `<debug_inline_uat>` below to run UAT inline.
+If resuming a session with `session_status=uat_failed`: load failure context:
   ```bash
   FAILURE_CONTEXT=$(bash "{plugin-root}/scripts/compile-debug-session-context.sh" "$session_file" uat 2>/dev/null || echo "")
   ```
   Update status to `investigating` via `write-debug-session.sh` (mode=status), then continue investigation from Step 3. When composing the debugger task prompt in Step 4, prepend the compiled `FAILURE_CONTEXT` to the bug report so the debugger has the specific failed UAT issues and findings. Use this format in the task prompt: `Previous UAT failed. Failure context:\n{FAILURE_CONTEXT}\n\nOriginal bug report: {description}`.
-If resuming a session with `status=complete`: STOP "This debug session is already complete. Start a new one with: /vbw:debug \"bug description\""
+If resuming a session with `session_status=complete`: STOP "This debug session is already complete. Use `/vbw:debug --session <id>` to inspect another session, or start a new one with `/vbw:debug \"description of the bug or error message\"` or `/vbw:debug <todo-number>`."
 </debug_session_routing>
 
 ## Steps
@@ -130,7 +131,7 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
    ```
    In all cases, continue without detail.
    If no ref suffix, $ARGUMENTS minus flags = bug description, `DETAIL_STATUS=none`, and `TODO_DETAIL_RESULT_JSON=""`.
-   **Post-parse validation:** If the bug description is empty or whitespace-only after stripping flags and ref, check whether a ref was found AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the investigation context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:debug \"description of the bug or error message\" [--competing|--parallel|--serial]"`.
+  **Post-parse validation:** If the bug description is empty or whitespace-only after stripping flags and ref, check whether a ref was found AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the investigation context. If no ref was found, or the ref detail failed to load, STOP: "Usage: `/vbw:debug \"description of the bug or error message\" [--competing|--parallel|--serial]` | `/vbw:debug <todo-number> [--competing|--parallel|--serial]` | `/vbw:debug --resume` | `/vbw:debug --session <id>`".
    Map effort: thorough=high, balanced/fast=medium, turbo=low.
    Keep effort profile as `EFFORT_PROFILE` (thorough|balanced|fast|turbo).
    Read `{plugin-root}/references/effort-profile-{profile}.md`.

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -106,7 +106,8 @@ fi`
   ```bash
   eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" get-or-latest .vbw-planning 2>/dev/null)" 2>/dev/null || true
   ```
-  If `active_session != none` AND session `status` is `qa_pending` or `qa_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → skip ALL remaining guards and jump directly to `<debug_session_qa>` below.
+  The helper exports `active_session`, `session_id`, `session_file`, and `session_status`; use `session_status` for lifecycle checks after `eval`.
+  If `active_session != none` AND exported `session_status` is `qa_pending` or `qa_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → skip ALL remaining guards and jump directly to `<debug_session_qa>` below.
   If phases exist (`phase_count > 0`) AND `$ARGUMENTS` does NOT contain `--session`, skip this override — standard phase QA takes priority.
 - **Brownfield normalization:** If Phase state (from Context above) contains `misnamed_plans=true`, normalize all phase directories before proceeding:
   ```bash
@@ -134,16 +135,18 @@ fi`
 ## Debug Session Routing
 
 <debug_session_qa>
-**Before resolving phase target**, check for an active debug session. This handles the case where phase_count=0 but a debug session with `status=qa_pending` or `status=qa_failed` exists.
+**Before resolving phase target**, check for an active debug session. This handles the case where phase_count=0 but a debug session with `session_status=qa_pending` or `session_status=qa_failed` exists.
 
 ```bash
 eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" get-or-latest .vbw-planning)"
 ```
 
+The helper exports `active_session`, `session_id`, `session_file`, and `session_status`; use `session_status` for routing after `eval`.
+
 **Routing decision:**
 - If `$ARGUMENTS` contains an explicit phase number AND no `--session` flag → skip debug-session routing, use standard phase QA flow below.
-- If `active_session != none` AND session `status` is `qa_pending` or `qa_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → enter debug-session QA mode (below). If `phase_count > 0` and no `--session` flag, skip debug-session routing — standard phase QA takes priority.
-- If `active_session != none` but session `status` is NOT `qa_pending`/`qa_failed` → skip debug-session routing. Session is in a different lifecycle stage.
+- If `active_session != none` AND exported `session_status` is `qa_pending` or `qa_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → enter debug-session QA mode (below). If `phase_count > 0` and no `--session` flag, skip debug-session routing — standard phase QA takes priority.
+- If `active_session != none` but exported `session_status` is NOT `qa_pending`/`qa_failed` → skip debug-session routing. Session is in a different lifecycle stage.
 - If `active_session = none` → skip debug-session routing, continue to standard phase QA.
 
 **Debug-session QA mode:**

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -255,7 +255,8 @@ QA verification summary (pre-extracted from VERIFICATION.md):
   ```bash
   eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" get-or-latest .vbw-planning 2>/dev/null)" 2>/dev/null || true
   ```
-  If `active_session != none` AND session `status` is `uat_pending` or `uat_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → skip ALL remaining guards and jump directly to `<debug_session_uat>` below.
+  The helper exports `active_session`, `session_id`, `session_file`, and `session_status`; use `session_status` for lifecycle checks after `eval`.
+  If `active_session != none` AND exported `session_status` is `uat_pending` or `uat_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → skip ALL remaining guards and jump directly to `<debug_session_uat>` below.
   If phases exist (`phase_count > 0`) AND `$ARGUMENTS` does NOT contain `--session`, skip this override — standard phase UAT takes priority.
 - **Phase-detect error guard (NON-NEGOTIABLE):** If Phase state (from Context above) contains `phase_detect_error=true`, display: "⚠ Phase detection failed. Run `bash \"{plugin-root}/scripts/phase-detect.sh\"` manually to debug." STOP. Do NOT fall back to phase-dir scanning or ad-hoc `VERIFICATION.md` checks when phase-detect failed.
 - **Verify-context error guard (NON-NEGOTIABLE):** If the pre-computed verify context block contains `verify_context_error=true` or `verify_context=unavailable`, display: "⚠ Verify context compilation failed. Run `bash "{plugin-root}/scripts/compile-verify-context.sh" .vbw-planning/phases/{NN}-{slug}` manually to debug." STOP. Do NOT improvise by reading individual PLAN/SUMMARY files unless the user explicitly targeted a different phase number (see Step 1).
@@ -354,9 +355,11 @@ QA verification summary (pre-extracted from VERIFICATION.md):
 eval "$(bash "{plugin-root}/scripts/debug-session-state.sh" get-or-latest .vbw-planning)"
 ```
 
+The helper exports `active_session`, `session_id`, `session_file`, and `session_status`; use `session_status` for routing after `eval`.
+
 **Routing decision:**
 - If `$ARGUMENTS` contains an explicit phase number AND no `--session` flag → skip debug-session routing, use standard phase UAT flow below.
-- If `active_session != none` AND session `status` is `uat_pending` or `uat_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → enter debug-session UAT mode (below). If `phase_count > 0` and no `--session` flag, skip debug-session routing — standard phase UAT takes priority.
+- If `active_session != none` AND exported `session_status` is `uat_pending` or `uat_failed` AND (`phase_count=0` OR `$ARGUMENTS` contains `--session`) → enter debug-session UAT mode (below). If `phase_count > 0` and no `--session` flag, skip debug-session routing — standard phase UAT takes priority.
 - Otherwise → skip debug-session routing, continue to standard phase UAT Steps.
 
 **Debug-session UAT mode:**

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -334,7 +334,7 @@ print_session_metadata() {
   local session_id="${session_name%.md}"
   printf 'session_id=%q\n' "$session_id"
   printf 'session_file=%q\n' "$session_path"
-  printf 'status=%q\n' "$(read_field "$session_path" "status")"
+  printf 'session_status=%q\n' "$(read_field "$session_path" "status")"
   printf 'title=%q\n' "$(read_field "$session_path" "title")"
   printf 'qa_round=%q\n' "$(read_field "$session_path" "qa_round")"
   printf 'qa_last_result=%q\n' "$(read_field "$session_path" "qa_last_result")"

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -164,6 +164,55 @@ safe_move_session() {
   echo "$dest"
 }
 
+# Reconcile a session's physical location with its frontmatter status.
+# - complete sessions belong in completed/
+# - all other statuses belong in active/
+# Echoes the canonicalized path on success.
+reconcile_session_location() {
+  local file="$1"
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+
+  local file_status target_dir current_dir fname moved pointer collision_file
+  file_status=$(read_field "$file" "status")
+  if [ "$file_status" = "complete" ]; then
+    target_dir="$COMPLETED_DIR"
+  else
+    target_dir="$ACTIVE_DIR"
+  fi
+
+  current_dir=$(dirname "$file")
+  if [ "$current_dir" = "$target_dir" ]; then
+    echo "$file"
+    return 0
+  fi
+
+  fname=$(basename "$file")
+  if moved=$(safe_move_session "$file" "$target_dir" 2>/dev/null); then
+    echo "$moved"
+    return 0
+  fi
+
+  if [ "$target_dir" = "$ACTIVE_DIR" ]; then
+    collision_file="$ACTIVE_DIR/$fname"
+    if [ -f "$collision_file" ] && [ ! -L "$collision_file" ] && [ "$(read_field "$collision_file" "status")" = "complete" ]; then
+      if safe_move_session "$collision_file" "$COMPLETED_DIR" > /dev/null 2>&1; then
+        if [ -f "$ACTIVE_FILE" ]; then
+          pointer=$(cat "$ACTIVE_FILE" 2>/dev/null | tr -d '[:space:]')
+          if [ "$pointer" = "$fname" ]; then
+            rm -f "$ACTIVE_FILE"
+          fi
+        fi
+        if moved=$(safe_move_session "$file" "$target_dir" 2>/dev/null); then
+          echo "$moved"
+          return 0
+        fi
+      fi
+    fi
+  fi
+
+  return 1
+}
+
 # Migrate a legacy flat-path session to the correct subdirectory based on its status.
 # Moves complete sessions to completed/, all others to active/.
 # Returns the new path. No-op if the file is already in a subdirectory.
@@ -223,15 +272,16 @@ get_active_session_path() {
   # Search active/ first (canonical location)
   local session_path="$ACTIVE_DIR/$session_name"
   if [ -f "$session_path" ] && [ ! -L "$session_path" ]; then
-    # Self-heal: if active/ session has complete status, move to completed/
-    local file_status
-    file_status=$(read_field "$session_path" "status")
-    if [ "$file_status" = "complete" ]; then
-      safe_move_session "$session_path" "$COMPLETED_DIR" > /dev/null 2>&1 || true
+    local reconciled
+    if reconciled=$(reconcile_session_location "$session_path"); then
+      if [[ "$reconciled" == "$ACTIVE_DIR/"* ]]; then
+        echo "$reconciled"
+        return
+      fi
       rm -f "$ACTIVE_FILE"
       return
     fi
-    echo "$session_path"
+    rm -f "$ACTIVE_FILE"
     return
   fi
   # Check legacy flat location and migrate if found
@@ -249,10 +299,15 @@ get_active_session_path() {
     # Migration failed or session landed in completed/ — fall through
   fi
   # Check completed/ (session was completed but pointer not cleared)
-  # Do not return completed/ path — completed sessions are not active.
-  # Clear stale pointer so next call doesn't repeat the lookup.
   local completed_path="$COMPLETED_DIR/$session_name"
   if [ -f "$completed_path" ] && [ ! -L "$completed_path" ]; then
+    local reconciled
+    if reconciled=$(reconcile_session_location "$completed_path"); then
+      if [[ "$reconciled" == "$ACTIVE_DIR/"* ]]; then
+        echo "$reconciled"
+        return
+      fi
+    fi
     rm -f "$ACTIVE_FILE"
     return
   fi
@@ -290,6 +345,21 @@ find_latest_unresolved() {
       fi
     fi
   done
+  # Self-heal canonical active/completed placement before selecting candidates.
+  if [ -d "$ACTIVE_DIR" ]; then
+    for f in "$ACTIVE_DIR"/*.md; do
+      [ -f "$f" ] && [ ! -L "$f" ] || continue
+      reconcile_session_location "$f" > /dev/null 2>&1 || true
+    done
+  fi
+  if [ -d "$COMPLETED_DIR" ]; then
+    for f in "$COMPLETED_DIR"/*.md; do
+      [ -f "$f" ] && [ ! -L "$f" ] || continue
+      if [ "$(read_field "$f" "status")" != "complete" ]; then
+        reconcile_session_location "$f" > /dev/null 2>&1 || true
+      fi
+    done
+  fi
   # Collect candidates from active/ and any unmigrated legacy files
   local all_candidates=() f
   if [ -d "$ACTIVE_DIR" ]; then
@@ -619,9 +689,16 @@ case "$CMD" in
       echo "Error: refusing to resume symlink session file: $SESSION_PATH" >&2
       exit 1
     fi
-    # If found in completed/, move back to active/ (re-activating)
-    if [[ "$SESSION_PATH" == "$COMPLETED_DIR/"* ]]; then
-      SESSION_PATH=$(safe_move_session "$SESSION_PATH" "$ACTIVE_DIR") || exit 1
+    session_file_status=$(read_field "$SESSION_PATH" "status")
+    if [ "$session_file_status" != "complete" ]; then
+      SESSION_PATH=$(reconcile_session_location "$SESSION_PATH") || exit 1
+    fi
+    # Explicit resume currently re-activates complete sessions, but preserves
+    # the stored status for unresolved sessions that were stranded in completed/.
+    if [ "$session_file_status" = "complete" ]; then
+      if [[ "$SESSION_PATH" == "$COMPLETED_DIR/"* ]]; then
+        SESSION_PATH=$(safe_move_session "$SESSION_PATH" "$ACTIVE_DIR") || exit 1
+      fi
       update_field "$SESSION_PATH" "status" "investigating"
     fi
     echo "$SESSION_NAME" > "$ACTIVE_FILE"
@@ -724,27 +801,22 @@ case "$CMD" in
     if [ -d "$ACTIVE_DIR" ]; then
       for f in "$ACTIVE_DIR"/*.md; do
         [ -f "$f" ] && [ ! -L "$f" ] || continue
-        local_id=$(read_field "$f" "session_id")
-        local_status=$(read_field "$f" "status")
-        local_title=$(read_field "$f" "title")
-        # Self-heal: if active/ session has complete status, move to completed/
-        if [ "$local_status" = "complete" ]; then
-          local_fname=$(basename "$f")
-          heal_location="active"
-          if safe_move_session "$f" "$COMPLETED_DIR" > /dev/null 2>&1; then
+        reconciled="$f"
+        if reconciled=$(reconcile_session_location "$f"); then
+          if [[ "$reconciled" == "$COMPLETED_DIR/"* ]]; then
+            local_fname=$(basename "$reconciled")
             HEALED_FILES="${HEALED_FILES}${local_fname}:"
-            heal_location="completed"
+            local_id=$(read_field "$reconciled" "session_id")
+            local_status=$(read_field "$reconciled" "status")
+            local_title=$(read_field "$reconciled" "title")
+            echo "session=${local_id}|${local_status}|${local_title}|completed"
+            COUNT=$((COUNT + 1))
+            continue
           fi
-          if [ -f "$ACTIVE_FILE" ]; then
-            pointer=$(cat "$ACTIVE_FILE" 2>/dev/null | tr -d '[:space:]')
-            if [ "$pointer" = "$local_fname" ]; then
-              rm -f "$ACTIVE_FILE"
-            fi
-          fi
-          echo "session=${local_id}|${local_status}|${local_title}|${heal_location}"
-          COUNT=$((COUNT + 1))
-          continue
         fi
+        local_id=$(read_field "$reconciled" "session_id")
+        local_status=$(read_field "$reconciled" "status")
+        local_title=$(read_field "$reconciled" "title")
         echo "session=${local_id}|${local_status}|${local_title}|active"
         COUNT=$((COUNT + 1))
       done
@@ -753,14 +825,25 @@ case "$CMD" in
     if [ -d "$COMPLETED_DIR" ]; then
       for f in "$COMPLETED_DIR"/*.md; do
         [ -f "$f" ] && [ ! -L "$f" ] || continue
+        reconciled="$f"
+        if reconciled=$(reconcile_session_location "$f"); then
+          if [[ "$reconciled" == "$ACTIVE_DIR/"* ]]; then
+            local_id=$(read_field "$reconciled" "session_id")
+            local_status=$(read_field "$reconciled" "status")
+            local_title=$(read_field "$reconciled" "title")
+            echo "session=${local_id}|${local_status}|${local_title}|active"
+            COUNT=$((COUNT + 1))
+            continue
+          fi
+        fi
         # Skip files already counted during self-heal from active/
-        local_fname=$(basename "$f")
+        local_fname=$(basename "$reconciled")
         if [ -n "$HEALED_FILES" ] && printf '%s' "$HEALED_FILES" | grep -qF "${local_fname}:"; then
           continue
         fi
-        local_id=$(read_field "$f" "session_id")
-        local_status=$(read_field "$f" "status")
-        local_title=$(read_field "$f" "title")
+        local_id=$(read_field "$reconciled" "session_id")
+        local_status=$(read_field "$reconciled" "status")
+        local_title=$(read_field "$reconciled" "title")
         echo "session=${local_id}|${local_status}|${local_title}|completed"
         COUNT=$((COUNT + 1))
       done

--- a/scripts/suggest-next.sh
+++ b/scripts/suggest-next.sh
@@ -589,7 +589,7 @@ case "$CMD" in
         eval "$_qa_ds_output" 2>/dev/null || true
         # shellcheck disable=SC2154
         if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
-          _qa_ds_status="${status:-}"
+          _qa_ds_status="${session_status:-}"
           case "$_qa_ds_status" in
             qa_pending|uat_pending|fix_applied)
               case "$effective_result" in
@@ -733,7 +733,7 @@ case "$CMD" in
         eval "$_fix_ds_output" 2>/dev/null || true
         # shellcheck disable=SC2154
         if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
-          _fix_ds_status="${status:-}"
+          _fix_ds_status="${session_status:-}"
           case "$_fix_ds_status" in
             qa_pending|fix_applied)
               suggest "/vbw:debug --resume -- Address remaining issues"
@@ -789,7 +789,7 @@ case "$CMD" in
         eval "$_verify_ds_output" 2>/dev/null || true
         # shellcheck disable=SC2154
         if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
-          _verify_ds_status="${status:-}"
+          _verify_ds_status="${session_status:-}"
           if [ "$_verify_ds_status" = "uat_failed" ]; then
             suggest "/vbw:debug --resume -- Address UAT issues"
             _verify_debug_handled=true
@@ -835,7 +835,7 @@ case "$CMD" in
         eval "$_ds_output" 2>/dev/null || true
         # shellcheck disable=SC2154
         if [ "${active_session:-none}" != "none" ] && [ -n "${session_file:-}" ] && [ -f "$session_file" ]; then
-          _ds_status="${status:-}"
+          _ds_status="${session_status:-}"
         fi
       fi
     fi

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -71,6 +71,25 @@ for cmd in start start-with-source-todo start-with-selected-todo get get-or-late
   fi
 done
 
+PRINT_METADATA_BLOCK="$(awk '/print_session_metadata\(\)/,/^}/' "$STATE_SCRIPT" 2>/dev/null || true)"
+if grep -Fq "printf 'session_status=%q\\n'" <<< "$PRINT_METADATA_BLOCK"; then
+  pass "debug-session-state.sh metadata-read contract exports session_status"
+else
+  fail "debug-session-state.sh metadata-read contract missing session_status export"
+fi
+
+if grep -Fq "printf 'status=%q\\n'" <<< "$PRINT_METADATA_BLOCK"; then
+  fail "debug-session-state.sh metadata-read contract still exports bare status"
+else
+  pass "debug-session-state.sh metadata-read contract no longer exports bare status"
+fi
+
+if awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -Fq 'echo "status=$STATUS"'; then
+  pass "debug-session-state.sh set-status keeps status output contract"
+else
+  fail "debug-session-state.sh set-status output contract drifted from status=..."
+fi
+
 # — Writer script checks —
 
 WRITER="$ROOT/scripts/write-debug-session.sh"
@@ -154,6 +173,56 @@ else
   fail "debug.md already_fixed path missing set-status complete workflow"
 fi
 
+DEBUG_HINT_LINE="$(awk '/^argument-hint:/{print; exit}' "$DEBUG_CMD" 2>/dev/null || true)"
+if printf '%s\n' "$DEBUG_HINT_LINE" | grep -Eq 'bug description' \
+  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Eq 'todo number' \
+  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Fq -- '--resume' \
+  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Fq -- '--session ID'; then
+  pass "debug.md argument-hint advertises bug text, todo number, --resume, and --session"
+else
+  fail "debug.md argument-hint missing one or more supported entry points"
+fi
+
+DEBUG_USAGE_LINES="$(grep -F 'Usage:' "$DEBUG_CMD" 2>/dev/null || true)"
+DEBUG_USAGE_COUNT=$(printf '%s\n' "$DEBUG_USAGE_LINES" | grep -c 'Usage:' || true)
+if [ "$DEBUG_USAGE_COUNT" -ge 2 ] \
+  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug <todo-number>' \
+  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug --resume' \
+  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug --session <id>' \
+  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '[--competing|--parallel|--serial]'; then
+  pass "debug.md keeps both expanded Usage strings with resume/session and ambiguity flags"
+else
+  fail "debug.md missing expanded Usage strings with resume/session and ambiguity flags"
+fi
+
+if grep -Fq 'No active debug session to resume. Use `/vbw:debug --session <id>` to open a specific session' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md resume stop message advertises session override and new-session entry points"
+else
+  fail "debug.md resume stop message still uses freeform-only guidance"
+fi
+
+if grep -Fq 'This debug session is already complete. Use `/vbw:debug --session <id>` to inspect another session' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md complete-session stop message advertises session override and new-session entry points"
+else
+  fail "debug.md complete-session stop message still uses freeform-only guidance"
+fi
+
+if grep -Fq 'Use `session_status` for lifecycle checks after `eval`; do not rely on a bare `status` variable.' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md names the safe debug-session helper contract explicitly"
+else
+  fail "debug.md missing explicit session_status helper contract"
+fi
+
+if grep -Fq 'session_status=qa_pending' "$DEBUG_CMD" 2>/dev/null \
+  && grep -Fq 'session_status=qa_failed' "$DEBUG_CMD" 2>/dev/null \
+  && grep -Fq 'session_status=uat_pending' "$DEBUG_CMD" 2>/dev/null \
+  && grep -Fq 'session_status=uat_failed' "$DEBUG_CMD" 2>/dev/null \
+  && grep -Fq 'session_status=complete' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md lifecycle routing keys off session_status for metadata-read helpers"
+else
+  fail "debug.md lifecycle routing not fully aligned to session_status contract"
+fi
+
 if grep -qF 'For `no_fix_yet`' "$DEBUG_CMD" 2>/dev/null && \
    grep -qF '`investigating`' "$DEBUG_CMD" 2>/dev/null; then
   pass "debug.md no_fix_yet path keeps the session investigating"
@@ -168,11 +237,27 @@ else
   fail "qa.md missing debug_session_qa section"
 fi
 
+if grep -Fq 'use `session_status` for lifecycle checks after `eval`.' "$QA_CMD" 2>/dev/null \
+  && grep -Fq 'use `session_status` for routing after `eval`.' "$QA_CMD" 2>/dev/null \
+  && grep -Fq 'exported `session_status` is `qa_pending` or `qa_failed`' "$QA_CMD" 2>/dev/null; then
+  pass "qa.md debug-session override uses the explicit session_status helper contract"
+else
+  fail "qa.md debug-session override missing explicit session_status helper contract"
+fi
+
 VERIFY_CMD="$ROOT/commands/verify.md"
 if grep -q "debug_session_uat" "$VERIFY_CMD" 2>/dev/null; then
   pass "verify.md has debug_session_uat section"
 else
   fail "verify.md missing debug_session_uat section"
+fi
+
+if grep -Fq 'use `session_status` for lifecycle checks after `eval`.' "$VERIFY_CMD" 2>/dev/null \
+  && grep -Fq 'use `session_status` for routing after `eval`.' "$VERIFY_CMD" 2>/dev/null \
+  && grep -Fq 'exported `session_status` is `uat_pending` or `uat_failed`' "$VERIFY_CMD" 2>/dev/null; then
+  pass "verify.md debug-session override uses the explicit session_status helper contract"
+else
+  fail "verify.md debug-session override missing explicit session_status helper contract"
 fi
 
 # — Agent integration checks —
@@ -381,7 +466,7 @@ else
   fail "debug.md resume routing for qa_pending/fix_applied missing inline QA entry"
 fi
 
-if grep -q 'status=uat_pending.*debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
+if grep -q 'session_status=uat_pending.*debug_inline_uat' "$ROOT/commands/debug.md" 2>/dev/null; then
   pass "debug.md resume routing for uat_pending enters inline UAT"
 else
   fail "debug.md resume routing for uat_pending missing inline UAT entry"

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -63,7 +63,7 @@ assert_no_repeated_blank_lines() {
 
   # Verify suggest-next recommends QA
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "qa_pending" ]
+  [ "$session_status" = "qa_pending" ]
 
   # Step 2: QA Pass
   echo '{"mode":"qa","round":1,"result":"PASS","checks":[{"id":"c1","description":"Null check present","status":"pass","evidence":"src/button.sh:42"}],"summary":"All checks pass."}' \
@@ -72,7 +72,7 @@ assert_no_repeated_blank_lines() {
 
   # Verify state
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "uat_pending" ]
+  [ "$session_status" = "uat_pending" ]
 
   # Step 3: UAT Pass
   echo '{"mode":"uat","round":1,"result":"pass","checkpoints":[{"description":"Button click works","result":"pass","user_response":"Verified"}],"summary":"All checkpoints pass."}' \
@@ -134,7 +134,7 @@ assert_no_repeated_blank_lines() {
 
   # Verify qa_failed state
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "qa_failed" ]
+  [ "$session_status" = "qa_failed" ]
 
   # Step 3: Resume with new investigation (remediation)
   echo '{"mode":"status","status":"investigating"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
@@ -159,7 +159,7 @@ assert_no_repeated_blank_lines() {
   grep -c "### Round" "$SESSION_FILE" | grep -q "3"  # 2 QA + 1 remediation round marker
 
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "uat_pending" ]
+  [ "$session_status" = "uat_pending" ]
   [ "$qa_round" = "2" ]
 }
 
@@ -182,7 +182,7 @@ assert_no_repeated_blank_lines() {
   echo '{"mode":"status","status":"uat_failed"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
 
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "uat_failed" ]
+  [ "$session_status" = "uat_failed" ]
 
   # Verify checkpoint details are preserved
   grep -q 'ISSUE' "$SESSION_FILE"
@@ -356,7 +356,7 @@ assert_no_repeated_blank_lines() {
 
   # During investigation, suggest-next for debug recommends nothing special (investigating)
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$PLANNING_DIR" 2>/dev/null)"
-  [ "$status" = "investigating" ]
+  [ "$session_status" = "investigating" ]
 
   # After fix → qa_pending: suggest-next for debug should recommend inline QA via resume
   echo '{"mode":"status","status":"qa_pending"}' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -533,6 +533,112 @@ teardown() {
   [[ "$output" == *"active_session=true"* ]]
 }
 
+@test "get-or-latest recovers pointer to unresolved session stranded in completed directory" {
+  local session_name="20240101-120000-stranded-qa.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-stranded-qa
+title: stranded-qa
+status: qa_failed
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:10:00
+qa_round: 1
+qa_last_result: fail
+uat_round: 0
+uat_last_result: pending
+---
+# Stranded session
+EOF
+  echo "$session_name" > "$VBW_PLANNING_DIR/debugging/.active-session"
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=qa_failed$'
+  [ -f "$VBW_PLANNING_DIR/debugging/active/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
+  [ "$(cat "$VBW_PLANNING_DIR/debugging/.active-session")" = "$session_name" ]
+}
+
+@test "get-or-latest fallback recovers unresolved session stranded in completed directory" {
+  local session_name="20240101-120000-stranded-uat.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-stranded-uat
+title: stranded-uat
+status: uat_pending
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:10:00
+qa_round: 1
+qa_last_result: pass
+uat_round: 0
+uat_last_result: pending
+---
+# Stranded session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=fallback"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=uat_pending$'
+  [ -f "$VBW_PLANNING_DIR/debugging/active/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
+  [ "$(cat "$VBW_PLANNING_DIR/debugging/.active-session")" = "$session_name" ]
+}
+
+@test "resume preserves unresolved status for session stranded in completed directory" {
+  local session_name="20240101-120000-stranded-resume.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-stranded-resume
+title: stranded-resume
+status: qa_failed
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:10:00
+qa_round: 2
+qa_last_result: fail
+uat_round: 0
+uat_last_result: pending
+---
+# Stranded session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$VBW_PLANNING_DIR" "$session_name"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=qa_failed$'
+  [ -f "$VBW_PLANNING_DIR/debugging/active/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
+}
+
+@test "list self-heals unresolved sessions stranded in completed directory" {
+  local session_name="20240101-120000-list-stranded.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-list-stranded
+title: list-stranded
+status: investigating
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:10:00
+qa_round: 0
+qa_last_result: pending
+uat_round: 0
+uat_last_result: pending
+---
+# Stranded session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" list "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"session=20240101-120000-list-stranded|investigating|list-stranded|active"* ]]
+  [ -f "$VBW_PLANNING_DIR/debugging/active/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
+}
+
 @test "list self-heals complete sessions stranded in active directory" {
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "stranded-done")"
   local fname

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -137,7 +137,8 @@ teardown() {
   run bash "$SCRIPTS_DIR/debug-session-state.sh" get "$VBW_PLANNING_DIR"
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=true"* ]]
-  [[ "$output" == *"status=investigating"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=investigating$'
+  ! printf '%s\n' "$output" | grep -Eq '^status='
   [[ "$output" == *"qa_round=0"* ]]
 }
 
@@ -157,7 +158,26 @@ teardown() {
   run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=fallback"* ]]
-  [[ "$output" == *"status=investigating"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=investigating$'
+  ! printf '%s\n' "$output" | grep -Eq '^status='
+}
+
+@test "get-or-latest metadata eval succeeds when status shell variable is readonly" {
+  eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "readonly-fallback")"
+  rm -f "$VBW_PLANNING_DIR/debugging/.active-session"
+
+  run bash -lc '
+    readonly status=0
+    helper_output=$("$1" get-or-latest "$2")
+    printf "%s\n" "$helper_output" | grep -Eq "^session_status=investigating$"
+    ! printf "%s\n" "$helper_output" | grep -Eq "^status="
+    eval "$helper_output"
+    printf "active_session=%s\nsession_status=%s\nsession_file=%s\n" "${active_session:-}" "${session_status:-}" "${session_file:-}"
+  ' -- "$SCRIPTS_DIR/debug-session-state.sh" "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=fallback"* ]]
+  [[ "$output" == *"session_status=investigating"* ]]
+  [[ "$output" == *"session_file=$VBW_PLANNING_DIR/debugging/active/"* ]]
 }
 
 @test "get-or-latest skips completed sessions in fallback" {
@@ -189,7 +209,28 @@ teardown() {
   run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$VBW_PLANNING_DIR" "$sid"
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=investigating$'
+  ! printf '%s\n' "$output" | grep -Eq '^status='
   [ -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
+}
+
+@test "resume metadata eval succeeds when status shell variable is readonly" {
+  eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "readonly-resume")"
+  local sid="$session_id"
+  bash "$SCRIPTS_DIR/debug-session-state.sh" clear-active "$VBW_PLANNING_DIR" > /dev/null
+
+  run bash -lc '
+    readonly status=0
+    helper_output=$("$1" resume "$2" "$3")
+    printf "%s\n" "$helper_output" | grep -Eq "^session_status=investigating$"
+    ! printf "%s\n" "$helper_output" | grep -Eq "^status="
+    eval "$helper_output"
+    printf "active_session=%s\nsession_status=%s\nsession_id=%s\n" "${active_session:-}" "${session_status:-}" "${session_id:-}"
+  ' -- "$SCRIPTS_DIR/debug-session-state.sh" "$VBW_PLANNING_DIR" "$sid"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=true"* ]]
+  [[ "$output" == *"session_status=investigating"* ]]
+  [[ "$output" == *"session_id=$sid"* ]]
 }
 
 @test "resume fails for nonexistent session" {
@@ -480,7 +521,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=true"* ]]
   # Resume should move file back to active/ and reset status
-  [[ "$output" == *"status=investigating"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=investigating$'
+  ! printf '%s\n' "$output" | grep -Eq '^status='
   [ -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
   [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
   # Pointer should reference the active session

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -168,7 +168,7 @@ teardown() {
 
   run bash -lc '
     readonly status=0
-    helper_output=$("$1" get-or-latest "$2")
+    helper_output=$(bash "$1" get-or-latest "$2")
     printf "%s\n" "$helper_output" | grep -Eq "^session_status=investigating$"
     ! printf "%s\n" "$helper_output" | grep -Eq "^status="
     eval "$helper_output"
@@ -221,7 +221,7 @@ teardown() {
 
   run bash -lc '
     readonly status=0
-    helper_output=$("$1" resume "$2" "$3")
+    helper_output=$(bash "$1" resume "$2" "$3")
     printf "%s\n" "$helper_output" | grep -Eq "^session_status=investigating$"
     ! printf "%s\n" "$helper_output" | grep -Eq "^status="
     eval "$helper_output"


### PR DESCRIPTION
Fixes #512

## What

This change hardens the debug-session helper contract by renaming the metadata-read export from `status` to `session_status`, updates the direct runtime and command-markdown consumers to use the safe name, expands `/vbw:debug` discoverability copy, and adds recovery for unresolved sessions stranded in `debugging/completed/` so resume flows follow frontmatter status instead of directory placement.

## Why

Issue #512 came from eval consumers choking on a bare `status=...` assignment in shells where `status` is readonly or special. The durable fix keeps the lightweight shell `key=value` contract but reserves the generic `status` key for the write path (`set-status`) and uses `session_status` for metadata reads. During QA, the touched helper also exposed an adjacent invariant break: unresolved sessions stranded in `debugging/completed/` could disappear from `get-or-latest`. The helper now treats frontmatter status as the source of truth and self-heals misplaced sessions.

## How

- `scripts/debug-session-state.sh` exports `session_status` from `print_session_metadata`, adds `reconcile_session_location()` so unresolved sessions stranded in `completed/` move back to `active/` without resetting `qa_failed` / `uat_pending`, and preserves the `set-status` output contract as `status=...`.
- `scripts/suggest-next.sh` switches all debug-session routing branches to read `session_status`.
- `commands/debug.md` expands the `argument-hint`, both `Usage:` strings, and stop-copy; it also names the post-`eval` helper contract explicitly so the model uses `session_status` instead of inferring a bare `status` variable.
- `commands/qa.md` and `commands/verify.md` explicitly document the safe helper-export contract in their debug-session override sections.
- `tests/debug-session-state.bats` adds readonly-eval regressions plus stranded-session recovery coverage for pointer recovery, fallback recovery, explicit resume preservation, and list self-heal.
- `tests/debug-session-lifecycle.bats` switches eval assertions to `session_status`.
- `testing/verify-debug-session-contract.sh` now guards both the metadata-read export contract and the `/vbw:debug` discoverability surfaces.

## Acceptance criteria verification

1. Metadata-read commands emit `session_status`, not bare `status` — satisfied by `scripts/debug-session-state.sh` lines 400-407; guarded by `testing/verify-debug-session-contract.sh` lines 75-90; exercised in `tests/debug-session-state.bats` lines 137-232.
2. `set-status` remains unchanged — satisfied by `scripts/debug-session-state.sh` lines 709-738; guarded by `testing/verify-debug-session-contract.sh` lines 87-90.
3. `scripts/suggest-next.sh` consumes `session_status` for all debug-session flows — satisfied by `scripts/suggest-next.sh` lines 592, 736, 792, and 838; covered by `tests/suggest-next-debug-session.bats` and `tests/debug-session-lifecycle.bats`.
4. `commands/debug.md`, `commands/qa.md`, and `commands/verify.md` explicitly align to the safe eval contract — satisfied by `commands/debug.md` lines 66-70 and 108-120, `commands/qa.md` lines 109-149, and `commands/verify.md` lines 258-362.
5. `/vbw:debug` `argument-hint` advertises bug text, todo number, `--resume`, and `--session ID` — satisfied by `commands/debug.md` line 6.
6. Both `Usage:` strings and stop/retry copy include resume/session entry points and ambiguity flags — satisfied by `commands/debug.md` lines 31, 68, 120, and 134; guarded by `testing/verify-debug-session-contract.sh` lines 176-208.
7. Helper-level readonly regression coverage exists — satisfied by `tests/debug-session-state.bats` lines 165-180 and 217-232.
8. Lifecycle/suggestion regression coverage uses `session_status` and still passes — satisfied by `tests/debug-session-lifecycle.bats` lines 66-75, 137-185, and 359 plus `tests/suggest-next-debug-session.bats`.
9. Contract verification fails if the safe export or discoverability surfaces regress — satisfied by `testing/verify-debug-session-contract.sh` lines 75-90 and 176-260.
10. Targeted checks plus `bash testing/run-all.sh` pass — satisfied by the runs listed below.
11. Runtime smoke avoids `(eval): read-only variable: status` for debug resume, debug-session QA, and debug-session UAT — satisfied by consumer smoke runs from a consumer smoke worktree while loading the candidate plugin checkout via `--plugin-dir`, plus a stranded-session recovery smoke.

## Testing

- `bats tests/debug-session-state.bats`
- `bats tests/debug-session-lifecycle.bats`
- `bats tests/suggest-next-debug-session.bats`
- `bash testing/verify-debug-session-contract.sh`
- `bash testing/verify-commands-contract.sh`
- `bash testing/run-all.sh`

## QA summary

- Primary QA rounds completed: 3 (`qa-investigator`)
  - Round 1: clean
  - Round 2: 1 medium observation in a touched file (`scripts/debug-session-state.sh` stranded unresolved sessions in `completed/` invisible to `get-or-latest`); fixed in `fix(debug): address QA round 2` (`730b3e45`)
  - Round 3: clean
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54`, GPT-5.4)
  - Round 1: clean
- Copilot PR review rounds completed: 0 (pending after PR creation)
- False positives:
  - zsh `readonly status=...` is a shell builtin / special-parameter quirk, not a remaining helper collision; the meaningful eval path is clean because metadata-read helpers now export `session_status`.
