### PR TITLE
fix(readme): sync config defaults reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Quick reference for every key in `config/defaults.json`, in order. Click the sec
 | `skill_suggestions` | `true` | [Skills and discovery](#skills-and-discovery) |
 | `auto_install_skills` | `false` | [Skills and discovery](#skills-and-discovery) |
 | `discovery_questions` | `true` | [Skills and discovery](#skills-and-discovery) |
+| `discussion_mode` | `"questions"` | [Skills and discovery](#skills-and-discovery) |
 | `context_compiler` | `true` | [Agent behavior](#agent-behavior) |
 | `visual_format` | `"unicode"` | [Display](#display) |
 | `max_tasks_per_plan` | `5` | [Agent behavior](#agent-behavior) |
@@ -577,6 +578,9 @@ Quick reference for every key in `config/defaults.json`, in order. Click the sec
 | `statusline_hide_agent_in_tmux` | `false` | [Display](#display) |
 | `statusline_collapse_agent_in_tmux` | `false` | [Display](#display) |
 | `debug_logging` | `false` | [Runtime features](#runtime-features) |
+| `caveman_style` | `"none"` | [Caveman language mode](#caveman-language-mode) |
+| `caveman_commit` | `false` | [Caveman language mode](#caveman-language-mode) |
+| `caveman_review` | `false` | [Caveman language mode](#caveman-language-mode) |
 | `bash_guard` | `true`* | [Safety](#safety) |
 
 *`bash_guard` is not in `defaults.json` — it's read directly from project config with a default of `true` when absent.
@@ -832,10 +836,12 @@ Lease locks are enabled by default because they add negligible overhead (one sma
 | `skill_suggestions` | boolean | `true` | `true` / `false` |
 | `auto_install_skills` | boolean | `false` | `true` / `false` |
 | `discovery_questions` | boolean | `true` | `true` / `false` |
+| `discussion_mode` | string | `questions` | `questions` / `assumptions` / `auto` |
 
 - **`skill_suggestions`** — When `true`, `/vbw:init` detects your tech stack and suggests relevant skills to install. When `false`, the entire skill suggestion flow is skipped during init.
 - **`auto_install_skills`** — When `true`, suggested skills are installed automatically without asking. When `false`, VBW shows the install commands but lets you run them yourself. Has no effect if `skill_suggestions` is `false`.
 - **`discovery_questions`** — When `true`, the discussion engine runs during bootstrap and `/vbw:discuss`, with depth controlled by your active profile (`default`→3–5 gray areas, `production`→4–6, `prototype`→2–3, `yolo`→skip). When `false`, skips the discussion engine entirely. Set this to `false` if you're bootstrapping projects where you already know what you want.
+- **`discussion_mode`** — Controls how the discussion engine starts. `questions` asks clarifying questions from scratch. `assumptions` uses existing codebase map data to propose evidence-backed assumptions first, then falls back to questions if no map exists. `auto` picks `assumptions` when `.vbw-planning/codebase/META.md` exists and otherwise uses `questions`.
 
 ### Model routing and cost
 

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -54,6 +54,7 @@ printf '%s\t%s\n' \
   debug-target-docs            testing/verify-debug-target-docs.sh \
   askuserquestion-contract     testing/verify-askuserquestion-contract.sh \
   research-storage-contract    testing/verify-research-storage-contract.sh \
+  readme-config-reference      testing/verify-readme-config-reference.sh \
   config-defaults-sync         testing/verify-config-defaults-sync.sh \
   caveman-contract             testing/verify-caveman-contract.sh \
   verify-vibe                  scripts/verify-vibe.sh

--- a/testing/verify-readme-config-reference.sh
+++ b/testing/verify-readme-config-reference.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-readme-config-reference.sh — Contract test for issue #513
+#
+# Validates that the README configuration reference stays in sync with
+# config/defaults.json and that linked detail sections cover the documented
+# settings semantics.
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+README="$ROOT/README.md"
+DEFAULTS_JSON="$ROOT/config/defaults.json"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== README Config Reference Contract (Issue #513) ==="
+
+if [ ! -f "$README" ]; then
+  fail "README.md missing"
+fi
+
+if [ ! -f "$DEFAULTS_JSON" ]; then
+  fail "config/defaults.json missing"
+fi
+
+extract_default_keys_in_source_order() {
+  grep -E '^  "[a-z0-9_]+": ' "$DEFAULTS_JSON" | sed -E 's/^  "([^"]+)": .*/\1/'
+}
+
+extract_readme_default_rows() {
+  sed -n '/^### All defaults$/,/^### Optional extension hooks$/p' "$README" |
+    awk -F'|' '
+      /^\| `[^`]+` \|/ {
+        key=$2
+        def=$3
+        section=$4
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", def)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", section)
+        gsub(/`/, "", key)
+        gsub(/`/, "", def)
+        print key "\t" def "\t" section
+      }
+    '
+}
+
+declare -a default_keys=()
+while IFS= read -r key; do
+  [ -n "$key" ] || continue
+  default_keys+=("$key")
+done < <(extract_default_keys_in_source_order)
+
+if [ "${#default_keys[@]}" -gt 0 ]; then
+  pass "Extracted defaults.json keys in source-file order"
+else
+  fail "Could not extract defaults.json keys in source-file order"
+fi
+
+declare -a table_keys=()
+declare -A table_defaults=()
+declare -A table_sections=()
+declare -A table_counts=()
+
+while IFS=$'\t' read -r key default_value section; do
+  [ -n "${key:-}" ] || continue
+  table_keys+=("$key")
+  table_defaults["$key"]="$default_value"
+  table_sections["$key"]="$section"
+  table_counts["$key"]=$(( ${table_counts["$key"]:-0} + 1 ))
+done < <(extract_readme_default_rows)
+
+if [ "${#table_keys[@]}" -gt 0 ]; then
+  pass "Extracted README All defaults table rows"
+else
+  fail "Could not extract README All defaults table rows"
+fi
+
+default_key_list="$(printf '%s\n' "${default_keys[@]}")"
+
+echo ""
+echo "--- Check: defaults.json keys appear exactly once in README table ---"
+for key in "${default_keys[@]}"; do
+  count="${table_counts[$key]:-0}"
+  if [ "$count" -eq 1 ]; then
+    pass "README All defaults includes '$key' exactly once"
+  else
+    fail "README All defaults includes '$key' $count times (expected exactly once)"
+  fi
+done
+
+echo ""
+echo "--- Check: README All defaults has no unexpected keys ---"
+for key in "${!table_counts[@]}"; do
+  if grep -Fxq "$key" <<< "$default_key_list"; then
+    pass "README key '$key' exists in defaults.json"
+  elif [ "$key" = "bash_guard" ]; then
+    pass "README-only key 'bash_guard' is the intentional exception"
+  else
+    fail "README All defaults contains unexpected key '$key'"
+  fi
+done
+
+echo ""
+echo "--- Check: README default values match defaults.json ---"
+for key in "${default_keys[@]}"; do
+  if [ "$key" = "agent_max_turns" ]; then
+    if [ "${table_defaults[$key]:-}" = "{...}" ]; then
+      pass "README uses documented shorthand for agent_max_turns"
+    else
+      fail "README agent_max_turns default must use '{...}' shorthand"
+    fi
+    continue
+  fi
+
+  if [ "${table_counts[$key]:-0}" -ne 1 ]; then
+    continue
+  fi
+
+  expected_value="$(jq -c --arg k "$key" '.[$k]' "$DEFAULTS_JSON")"
+  actual_value="${table_defaults[$key]}"
+
+  if [ "$expected_value" = "$actual_value" ]; then
+    pass "README default for '$key' matches defaults.json"
+  else
+    fail "README default mismatch for '$key': defaults.json='$expected_value' README='$actual_value'"
+  fi
+done
+
+echo ""
+echo "--- Check: README All defaults order matches defaults.json source order ---"
+expected_order="$(printf '%s\n' "${default_keys[@]}")"
+actual_order="$(printf '%s\n' "${table_keys[@]}" | grep -vx 'bash_guard' || true)"
+if [ "$expected_order" = "$actual_order" ]; then
+  pass "README All defaults order matches defaults.json source-file order"
+else
+  fail "README All defaults order does not match defaults.json source-file order"
+fi
+
+echo ""
+echo "--- Check: caveman rows link to the caveman section ---"
+for key in caveman_style caveman_commit caveman_review; do
+  if [ "${table_sections[$key]:-}" = "[Caveman language mode](#caveman-language-mode)" ]; then
+    pass "README row '$key' links to the caveman section"
+  else
+    fail "README row '$key' must link to [Caveman language mode](#caveman-language-mode)"
+  fi
+done
+
+echo ""
+echo "--- Check: Skills and discovery documents discussion_mode semantics ---"
+skills_section="$(sed -n '/^### Skills and discovery$/,/^### Model routing and cost$/p' "$README")"
+
+if grep -Fq '| `discussion_mode` | string | `questions` | `questions` / `assumptions` / `auto` |' <<< "$skills_section"; then
+  pass "Skills and discovery table documents discussion_mode"
+else
+  fail "Skills and discovery table missing discussion_mode row"
+fi
+
+if grep -Fq '`questions` asks clarifying questions from scratch.' <<< "$skills_section"; then
+  pass "discussion_mode prose documents questions mode"
+else
+  fail "discussion_mode prose missing questions mode semantics"
+fi
+
+if grep -Fq '`assumptions` uses existing codebase map data to propose evidence-backed assumptions first, then falls back to questions if no map exists.' <<< "$skills_section"; then
+  pass "discussion_mode prose documents assumptions fallback semantics"
+else
+  fail "discussion_mode prose missing assumptions fallback semantics"
+fi
+
+if grep -Fq '`auto` picks `assumptions` when `.vbw-planning/codebase/META.md` exists and otherwise uses `questions`.' <<< "$skills_section"; then
+  pass "discussion_mode prose documents auto mode semantics"
+else
+  fail "discussion_mode prose missing auto mode semantics"
+fi
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/testing/verify-readme-config-reference.sh
+++ b/testing/verify-readme-config-reference.sh
@@ -10,9 +10,16 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 README="$ROOT/README.md"
 DEFAULTS_JSON="$ROOT/config/defaults.json"
+TABLE_ROWS_TSV="$(mktemp "${TMPDIR:-/tmp}/verify-readme-config-reference.XXXXXX")"
 
 PASS=0
 FAIL=0
+
+cleanup() {
+  rm -f "$TABLE_ROWS_TSV"
+}
+
+trap cleanup EXIT
 
 pass() {
   echo "PASS  $1"
@@ -68,11 +75,35 @@ extract_readme_default_rows() {
     '
 }
 
+table_default_for_key() {
+  awk -F'\t' -v key="$1" '$1 == key { print $2; exit }' "$TABLE_ROWS_TSV"
+}
+
+table_section_for_key() {
+  awk -F'\t' -v key="$1" '$1 == key { print $3; exit }' "$TABLE_ROWS_TSV"
+}
+
+table_count_for_key() {
+  awk -F'\t' -v key="$1" '$1 == key { count++ } END { print count + 0 }' "$TABLE_ROWS_TSV"
+}
+
+table_unique_keys() {
+  awk -F'\t' '{ print $1 }' "$TABLE_ROWS_TSV" | awk '!seen[$0]++'
+}
+
 declare -a default_keys=()
-while IFS= read -r key; do
-  [ -n "$key" ] || continue
-  default_keys+=("$key")
-done < <(extract_default_keys_in_source_order)
+
+default_keys_output=""
+if ! default_keys_output="$(extract_default_keys_in_source_order 2>&1)"; then
+  fail "config/defaults.json could not be parsed by jq${default_keys_output:+: $default_keys_output}"
+else
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    default_keys+=("$key")
+  done <<EOF
+$default_keys_output
+EOF
+fi
 
 if [ "${#default_keys[@]}" -gt 0 ]; then
   pass "Extracted defaults.json keys in source-file order"
@@ -80,17 +111,16 @@ else
   fail "Could not extract defaults.json keys in source-file order"
 fi
 
+if [ "$FAIL" -gt 0 ]; then
+  finish
+fi
+
 declare -a table_keys=()
-declare -A table_defaults=()
-declare -A table_sections=()
-declare -A table_counts=()
 
 while IFS=$'\t' read -r key default_value section; do
   [ -n "${key:-}" ] || continue
   table_keys+=("$key")
-  table_defaults["$key"]="$default_value"
-  table_sections["$key"]="$section"
-  table_counts["$key"]=$(( ${table_counts["$key"]:-0} + 1 ))
+  printf '%s\t%s\t%s\n' "$key" "$default_value" "$section" >> "$TABLE_ROWS_TSV"
 done < <(extract_readme_default_rows)
 
 if [ "${#table_keys[@]}" -gt 0 ]; then
@@ -104,7 +134,7 @@ default_key_list="$(printf '%s\n' "${default_keys[@]}")"
 echo ""
 echo "--- Check: defaults.json keys appear exactly once in README table ---"
 for key in "${default_keys[@]}"; do
-  count="${table_counts[$key]:-0}"
+  count="$(table_count_for_key "$key")"
   if [ "$count" -eq 1 ]; then
     pass "README All defaults includes '$key' exactly once"
   else
@@ -114,7 +144,8 @@ done
 
 echo ""
 echo "--- Check: README All defaults has no unexpected keys ---"
-for key in "${!table_counts[@]}"; do
+while IFS= read -r key; do
+  [ -n "$key" ] || continue
   if grep -Fxq "$key" <<< "$default_key_list"; then
     pass "README key '$key' exists in defaults.json"
   elif [ "$key" = "bash_guard" ]; then
@@ -122,13 +153,13 @@ for key in "${!table_counts[@]}"; do
   else
     fail "README All defaults contains unexpected key '$key'"
   fi
-done
+done < <(table_unique_keys)
 
 echo ""
 echo "--- Check: README default values match defaults.json ---"
 for key in "${default_keys[@]}"; do
   if [ "$key" = "agent_max_turns" ]; then
-    if [ "${table_defaults[$key]:-}" = "{...}" ]; then
+    if [ "$(table_default_for_key "$key")" = "{...}" ]; then
       pass "README uses documented shorthand for agent_max_turns"
     else
       fail "README agent_max_turns default must use '{...}' shorthand"
@@ -136,12 +167,12 @@ for key in "${default_keys[@]}"; do
     continue
   fi
 
-  if [ "${table_counts[$key]:-0}" -ne 1 ]; then
+  if [ "$(table_count_for_key "$key")" -ne 1 ]; then
     continue
   fi
 
   expected_value="$(jq -c --arg k "$key" '.[$k]' "$DEFAULTS_JSON")"
-  actual_value="${table_defaults[$key]}"
+  actual_value="$(table_default_for_key "$key")"
 
   if [ "$expected_value" = "$actual_value" ]; then
     pass "README default for '$key' matches defaults.json"
@@ -163,7 +194,7 @@ fi
 echo ""
 echo "--- Check: caveman rows link to the caveman section ---"
 for key in caveman_style caveman_commit caveman_review; do
-  if [ "${table_sections[$key]:-}" = "[Caveman language mode](#caveman-language-mode)" ]; then
+  if [ "$(table_section_for_key "$key")" = "[Caveman language mode](#caveman-language-mode)" ]; then
     pass "README row '$key' links to the caveman section"
   else
     fail "README row '$key' must link to [Caveman language mode](#caveman-language-mode)"

--- a/testing/verify-readme-config-reference.sh
+++ b/testing/verify-readme-config-reference.sh
@@ -24,6 +24,15 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
+finish() {
+  echo ""
+  echo "==============================="
+  echo "TOTAL: $PASS PASS, $FAIL FAIL"
+  echo "==============================="
+
+  [ "$FAIL" -eq 0 ] || exit 1
+}
+
 echo "=== README Config Reference Contract (Issue #513) ==="
 
 if [ ! -f "$README" ]; then
@@ -34,8 +43,12 @@ if [ ! -f "$DEFAULTS_JSON" ]; then
   fail "config/defaults.json missing"
 fi
 
+if [ "$FAIL" -gt 0 ]; then
+  finish
+fi
+
 extract_default_keys_in_source_order() {
-  grep -E '^  "[a-z0-9_]+": ' "$DEFAULTS_JSON" | sed -E 's/^  "([^"]+)": .*/\1/'
+  jq -r 'keys_unsorted[]' "$DEFAULTS_JSON"
 }
 
 extract_readme_default_rows() {
@@ -185,9 +198,4 @@ else
   fail "discussion_mode prose missing auto mode semantics"
 fi
 
-echo ""
-echo "==============================="
-echo "TOTAL: $PASS PASS, $FAIL FAIL"
-echo "==============================="
-
-[ "$FAIL" -eq 0 ] || exit 1
+finish

--- a/testing/verify-readme-config-reference.sh
+++ b/testing/verify-readme-config-reference.sh
@@ -11,6 +11,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 README="$ROOT/README.md"
 DEFAULTS_JSON="$ROOT/config/defaults.json"
 TABLE_ROWS_TSV="$(mktemp "${TMPDIR:-/tmp}/verify-readme-config-reference.XXXXXX")"
+README_ONLY_EXCEPTIONS="bash_guard"
 
 PASS=0
 FAIL=0
@@ -91,6 +92,30 @@ table_unique_keys() {
   awk -F'\t' '{ print $1 }' "$TABLE_ROWS_TSV" | awk '!seen[$0]++'
 }
 
+is_readme_only_exception() {
+  local candidate="$1"
+  local exception
+
+  for exception in $README_ONLY_EXCEPTIONS; do
+    if [ "$candidate" = "$exception" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+filter_readme_only_exceptions() {
+  local key
+
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    if ! is_readme_only_exception "$key"; then
+      printf '%s\n' "$key"
+    fi
+  done
+}
+
 declare -a default_keys=()
 
 default_keys_output=""
@@ -143,13 +168,24 @@ for key in "${default_keys[@]}"; do
 done
 
 echo ""
+echo "--- Check: README-only exceptions appear exactly once ---"
+for key in $README_ONLY_EXCEPTIONS; do
+  count="$(table_count_for_key "$key")"
+  if [ "$count" -eq 1 ]; then
+    pass "README-only exception '$key' appears exactly once"
+  else
+    fail "README-only exception '$key' appears $count times (expected exactly once)"
+  fi
+done
+
+echo ""
 echo "--- Check: README All defaults has no unexpected keys ---"
 while IFS= read -r key; do
   [ -n "$key" ] || continue
   if grep -Fxq "$key" <<< "$default_key_list"; then
     pass "README key '$key' exists in defaults.json"
-  elif [ "$key" = "bash_guard" ]; then
-    pass "README-only key 'bash_guard' is the intentional exception"
+  elif is_readme_only_exception "$key"; then
+    pass "README-only key '$key' is the intentional exception"
   else
     fail "README All defaults contains unexpected key '$key'"
   fi
@@ -184,7 +220,7 @@ done
 echo ""
 echo "--- Check: README All defaults order matches defaults.json source order ---"
 expected_order="$(printf '%s\n' "${default_keys[@]}")"
-actual_order="$(printf '%s\n' "${table_keys[@]}" | grep -vx 'bash_guard' || true)"
+actual_order="$(printf '%s\n' "${table_keys[@]}" | filter_readme_only_exceptions || true)"
 if [ "$expected_order" = "$actual_order" ]; then
   pass "README All defaults order matches defaults.json source-file order"
 else


### PR DESCRIPTION
Fixes #513

## What
- Restore the missing caveman config rows in the README `All defaults` table: `caveman_style`, `caveman_commit`, and `caveman_review`.
- Document `discussion_mode` in `Skills and discovery`, including its default, valid values, and mode semantics.
- Add a dedicated contract test for README/config-reference drift and register it in the contract-test list.

## Why
- The README had drifted from `config/defaults.json` and the linked detail sections.
- Users could see `discussion_mode` in the defaults summary without any linked explanation, while the latest caveman flags were missing entirely.
- This change makes the README a reliable source of truth again and adds a regression tripwire for future releases.

## How
- Updated `README.md` so the `All defaults` table includes every shipped caveman default and links each one to `Caveman language mode`.
- Expanded `Skills and discovery` to include a `discussion_mode` row plus prose for `questions`, `assumptions`, and `auto`.
- Added `testing/verify-readme-config-reference.sh`, which checks:
  - every `config/defaults.json` key appears exactly once in README order
  - README default values match `config/defaults.json`
  - no unexpected README keys exist aside from the intentional `bash_guard` exception
  - caveman rows link to the caveman section
  - `discussion_mode` docs cover default, valid values, and fallback semantics
- Registered the new verifier in `testing/list-contract-tests.sh`.

## Acceptance criteria verification
- `All defaults` now lists every key from `config/defaults.json` exactly once in defaults-file order, with only the intentional `bash_guard` exception outside the JSON source of truth.
- `caveman_style`, `caveman_commit`, and `caveman_review` are present in the table and link to `Caveman language mode`.
- `Skills and discovery` now documents `discussion_mode`, its default value, valid values (`questions`, `assumptions`, `auto`), and what each mode does.
- The new README/config verification pass enforces missing-key, unexpected-key, order, value, and linkage drift checks.

## Testing
- `bash testing/verify-readme-config-reference.sh`
- `bash testing/verify-config-defaults-sync.sh`
- `bash testing/run-all.sh`

## QA summary
- Primary QA rounds completed: 3 (`qa-investigator`) — all clean.
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54`, GPT-5.4) — clean.
- Copilot PR review rounds completed: 0 so far — pending after draft PR creation.
- Scope is limited to README and contract coverage; no runtime behavior, config schema, or command implementation changes were introduced.