### PR TITLE
fix(debug): commit debug completion artifacts

### DIFF
--- a/.github/skills/running-ccr-smoke-tests/SKILL.md
+++ b/.github/skills/running-ccr-smoke-tests/SKILL.md
@@ -44,6 +44,7 @@ CCR Smoke Test Progress:
 - [ ] Resolve real consumer repo path
 - [ ] Create or enter the consumer smoke worktree
 - [ ] Decide consumer worktree vs sandbox per flow
+- [ ] Run a no-side-effect CCR preflight
 - [ ] Run smoke command(s) with `ccr code`
 - [ ] Capture visible `Skills:` evidence when needed
 - [ ] Capture `.skill-decisions.log` deltas
@@ -109,6 +110,15 @@ Use a **sandbox repo** when the real consumer repo cannot exercise a phase-route
 
 When you split coverage this way, say so explicitly in the verification summary.
 
+### 4.5. Split routing coverage from completion coverage when the consumer repo is heavyweight
+
+If the real consumer repo needs repo-specific prerequisites before the target command can reach the behavior you need to verify — for example package installs, service startup, credentials, proprietary toolchains, or flaky network fetches — do not force a single smoke run to prove everything.
+
+- Use the **consumer smoke worktree** to verify provenance, routing, and that the command starts correctly in a real consumer repo.
+- Use a **sandbox repo** to verify command-layer completion behavior when the real consumer repo's prerequisites are likely to block completion for reasons unrelated to the plugin.
+- Report the split explicitly in the summary.
+- If the command never reaches the lifecycle point you needed to verify, report the real-consumer run as **inconclusive for completion behavior**, not as a plugin regression.
+
 ### 5. Always invoke `ccr code`, not plain `claude`
 
 Use the router entrypoint the user actually runs:
@@ -118,6 +128,23 @@ ccr code --help
 ```
 
 Do not assume the plain `claude` binary is the right executable in this environment.
+
+### 5.5. Run a no-side-effect preflight first
+
+Before a longer smoke run, verify the router, auth, and provider path with a trivial prompt from the same cwd and `--plugin-dir`, but **without** `--append-system-prompt`:
+
+```bash
+cd /absolute/path/to/consumer-smoke-worktree && \
+printf '%s\n' 'Smoke test preflight. Reply with OK. Do not modify files.' \
+  | ccr code -p --dangerously-skip-permissions --plugin-dir /absolute/path/to/candidate-plugin-checkout
+```
+
+Use this to catch problems early:
+- not logged in / expired auth
+- router or provider validation failures
+- wrong cwd or wrong `--plugin-dir`
+
+If the preflight fails, fix that first instead of starting the real smoke command.
 
 ### 6. Run `ccr code` from the consumer smoke worktree or sandbox
 
@@ -155,19 +182,28 @@ printf '%s\n' '/vbw:fix Investigate a SwiftData save failure during tests.' \
 
 Use `printf '%s\n'` instead of `echo` so punctuation and backslashes are preserved in a shell-portable way.
 
-### 8. Add a smoke-test system prompt
+### 8. Prefer inline smoke instructions; use `--append-system-prompt` only when proven compatible
 
-For normal smoke checks, append a short system prompt that reduces side effects and keeps output easy to inspect:
+Default to putting the smoke-test constraints directly into the piped prompt text. Some router/provider combinations reject extra system inputs and fail with errors such as `context_management: Extra inputs are not permitted`.
+
+Use inline prompt text first:
 
 ```text
 Smoke test only. Avoid code edits. Keep output concise. Focus on diagnosis and reporting.
 ```
 
-For routing-only probes, make the stop condition explicit:
+For routing-only probes, make the stop condition explicit in the prompt text:
 
 ```text
 Smoke test only. Stop after choosing skills and mode. Do not modify project files. Keep output concise.
 ```
+
+Only use `--append-system-prompt` if you already know the active router/provider accepts extra system inputs.
+
+If a run fails with a validation/provider error mentioning extra inputs, `context_management`, or rejected system prompts:
+- re-run immediately **without** `--append-system-prompt`
+- keep the smoke constraints inline for the rest of that run
+- do not treat that failure as evidence about the VBW command itself
 
 ### 9. Capture the right evidence
 
@@ -178,16 +214,17 @@ Always capture:
 Then capture the claim-matched evidence you actually need:
 - **Visible-selection claim** → capture a visible `Skills:` line
 - **Activation/logging claim** → capture `.vbw-planning/.skill-decisions.log` deltas
-- **Domain-skill claim** → capture task-specific keyword matches when relevant, such as `SwiftData` / `swiftdata`
+- **Domain-skill claim** → capture task-specific keyword matches when relevant, such as the framework, database, or failure term named in the prompt
 
 #### Standard smoke pattern
 
 ```bash
 cd /absolute/path/to/consumer-smoke-worktree && \
-printf '%s\n' '/vbw:research Research SwiftData persistence failures.' \
+printf '%s\n' \
+  'Smoke test only. Avoid code edits. Keep output concise. Focus on diagnosis and reporting.' \
+  '/vbw:research Research a persistence or startup failure during tests.' \
   | ccr code -p --dangerously-skip-permissions \
-      --plugin-dir /absolute/path/to/candidate-plugin-checkout \
-      --append-system-prompt 'Smoke test only. Avoid code edits. Keep output concise. Focus on diagnosis and reporting.'
+      --plugin-dir /absolute/path/to/candidate-plugin-checkout
 ```
 
 #### Visible `Skills:` capture pattern
@@ -196,10 +233,11 @@ If plain output does not surface the `Skills:` line, use this dedicated stream-c
 
 ```bash
 cd /absolute/path/to/consumer-smoke-worktree && \
-printf '%s\n' '/vbw:fix Investigate a SwiftData save or schema failure.' \
+printf '%s\n' \
+  'Smoke test only. Avoid code edits. Keep output concise. Focus on diagnosis and reporting.' \
+  '/vbw:fix Investigate a persistence or schema failure during tests.' \
   | ccr code -p --verbose --dangerously-skip-permissions \
       --plugin-dir /absolute/path/to/candidate-plugin-checkout \
-      --append-system-prompt 'Smoke test only. Avoid code edits. Keep output concise. Focus on diagnosis and reporting.' \
       --output-format stream-json --include-partial-messages
 ```
 
@@ -211,10 +249,11 @@ Use this when you only need mode/skill-selection behavior and do not want the wo
 
 ```bash
 cd /absolute/path/to/sandbox-repo && \
-printf '%s\n' '/vbw:vibe --execute 1' \
+printf '%s\n' \
+  'Smoke test only. Stop after choosing skills and mode. Do not modify project files. Keep output concise.' \
+  '/vbw:vibe --execute 1' \
   | ccr code -p --permission-mode plan --dangerously-skip-permissions \
-      --plugin-dir /absolute/path/to/candidate-plugin-checkout \
-      --append-system-prompt 'Smoke test only. Stop after choosing skills and mode. Do not modify project files. Keep output concise.'
+      --plugin-dir /absolute/path/to/candidate-plugin-checkout
 ```
 
 ### 10. Verify provenance before trusting the result
@@ -244,7 +283,9 @@ Expected smoke artifacts belong in the **consumer smoke worktree** or **sandbox*
 - **`resolve-debug-target.sh repo` fails and you need real consumer coverage** → ask for the consumer repo path instead of guessing.
 - **Need real consumer coverage** → create or reuse the consumer smoke worktree before running any `ccr code` command.
 - **Real consumer repo cannot exercise `/vbw:vibe` or `/vbw:qa`** → use a sandbox for those flows and keep the consumer smoke worktree for `/vbw:debug`, `/vbw:fix`, `/vbw:research`, and `/vbw:map`.
+- **Real consumer repo requires heavy repo-specific setup before the target behavior can complete** → split coverage: use the consumer smoke worktree for provenance/routing/startup and a sandbox repo for command-layer completion behavior.
 - **Plain `-p` invocation reports missing input** → switch to stdin and keep it that way.
+- **`--append-system-prompt` triggers a validation/provider error** → retry without it and move the smoke constraints inline into the piped prompt.
 - **Need visible `Skills:` output** → use stream-json + `--verbose` and grep the capture.
 - **Need routing proof without side effects** → use `--permission-mode plan` plus the routing-only smoke prompt.
 - **Base consumer repo checkout, candidate plugin checkout, or main plugin repo shows unexpected `.vbw-planning` changes** → stop and investigate provenance before writing the verification summary.
@@ -257,6 +298,7 @@ A smoke run is ready to cite only when all are true:
 - Required command outputs were captured for the claim being made.
 - Provenance evidence was captured.
 - `.skill-decisions.log` and/or visible `Skills:` evidence supports the specific claim being made.
+- For completion-path claims, the command actually reached the lifecycle point being claimed; if repo-specific prerequisites blocked earlier, the result is only routing/provenance coverage or an inconclusive completion check.
 - The base consumer repo checkout did not become the smoke cwd or collect smoke artifacts.
 - Any sandbox use is called out explicitly.
 - The plugin repo is not being misrepresented as the smoke-test cwd.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -266,7 +266,7 @@ If resuming a session with `session_status=complete`: STOP "This debug session i
      "plan": "{chosen fix approach}",
      "implementation": "{summary of changes, or branch-specific text: fixed_now = changes applied now; already_fixed = no new changes were required because the current branch already contained the fix; no_fix_yet = investigation completed without applying a new fix in this run}",
      "changed_files": ["{file1}", "{file2}"],
-    "commit": "{fixed_now = commit hash and message; already_fixed = 'Already fixed before this investigation — no new fix commit was required. If planning_tracking=commit, this completion path may create a planning-artifact commit.'; no_fix_yet = 'No new commit created during this investigation.'}"
+     "commit": "{fixed_now = commit hash and message; already_fixed = 'Already fixed before this investigation — no new fix commit was required. If planning_tracking=commit, this completion path may create a planning-artifact commit.'; no_fix_yet = 'No new commit created during this investigation.'}"
    }
    ENDJSON
    )
@@ -304,7 +304,7 @@ If resuming a session with `session_status=complete`: STOP "This debug session i
      Issue:      {one-line summary}
      Root Cause: {from report}
      Outcome:    {fixed_now | already_fixed | no_fix_yet}
-    Resolution: {fixed_now = "Applied now in {commit hash + message}" | already_fixed = "Already fixed on the current branch — no new fix commit was required; this completion path may still create a planning-artifact commit when planning_tracking=commit" | no_fix_yet = "No new commit created — further implementation still required"}
+     Resolution: {fixed_now = "Applied now in {commit hash + message}" | already_fixed = "Already fixed on the current branch — no new fix commit was required; this completion path may still create a planning-artifact commit when planning_tracking=commit" | no_fix_yet = "No new commit created — further implementation still required"}
 
      Files Modified: {list}
    ```

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -279,6 +279,12 @@ If resuming a session with `status=complete`: STOP "This debug session is alread
    For `already_fixed`, mark the investigation complete using the existing completed-session workflow:
    ```bash
    bash "{plugin-root}/scripts/debug-session-state.sh" set-status .vbw-planning complete
+   PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"
+   if [ -f "$PG_SCRIPT" ]; then
+     bash "$PG_SCRIPT" commit-boundary "complete debug session" .vbw-planning/config.json
+   else
+     echo "VBW: planning-git.sh unavailable; skipping planning git boundary commit" >&2
+   fi
    ```
    For `no_fix_yet`, do **not** set `fix_applied`; keep the session status as `investigating`.
    </debug_session_persistence>
@@ -534,7 +540,16 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
    ```
 
 5. Update session status:
-   - All checkpoints pass (no issues) → `bash .../debug-session-state.sh set-status .vbw-planning complete`
+   - All checkpoints pass (no issues):
+     ```bash
+     bash "{plugin-root}/scripts/debug-session-state.sh" set-status .vbw-planning complete
+     PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"
+     if [ -f "$PG_SCRIPT" ]; then
+       bash "$PG_SCRIPT" commit-boundary "complete debug session" .vbw-planning/config.json
+     else
+       echo "VBW: planning-git.sh unavailable; skipping planning git boundary commit" >&2
+     fi
+     ```
    - Any issues found → `bash .../debug-session-state.sh set-status .vbw-planning uat_failed`
 
 6. Present debug-session UAT result:

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -266,7 +266,7 @@ If resuming a session with `session_status=complete`: STOP "This debug session i
      "plan": "{chosen fix approach}",
      "implementation": "{summary of changes, or branch-specific text: fixed_now = changes applied now; already_fixed = no new changes were required because the current branch already contained the fix; no_fix_yet = investigation completed without applying a new fix in this run}",
      "changed_files": ["{file1}", "{file2}"],
-     "commit": "{fixed_now = commit hash and message; already_fixed = 'Already fixed before this investigation — no new commit created.'; no_fix_yet = 'No new commit created during this investigation.'}"
+    "commit": "{fixed_now = commit hash and message; already_fixed = 'Already fixed before this investigation — no new fix commit was required. If planning_tracking=commit, this completion path may create a planning-artifact commit.'; no_fix_yet = 'No new commit created during this investigation.'}"
    }
    ENDJSON
    )
@@ -304,7 +304,7 @@ If resuming a session with `session_status=complete`: STOP "This debug session i
      Issue:      {one-line summary}
      Root Cause: {from report}
      Outcome:    {fixed_now | already_fixed | no_fix_yet}
-     Resolution: {fixed_now = "Applied now in {commit hash + message}" | already_fixed = "Already fixed on the current branch — no new commit created" | no_fix_yet = "No new commit created — further implementation still required"}
+    Resolution: {fixed_now = "Applied now in {commit hash + message}" | already_fixed = "Already fixed on the current branch — no new fix commit was required; this completion path may still create a planning-artifact commit when planning_tracking=commit" | no_fix_yet = "No new commit created — further implementation still required"}
 
      Files Modified: {list}
    ```

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -255,6 +255,20 @@ else
   fail "debug.md completion paths missing ordered planning boundary commit after set-status complete"
 fi
 
+if grep -Fq "already_fixed = 'Already fixed before this investigation — no new fix commit was required." "$DEBUG_CMD" 2>/dev/null \
+  && grep -Fq 'already_fixed = "Already fixed on the current branch — no new fix commit was required;' "$DEBUG_CMD" 2>/dev/null; then
+  pass "debug.md already_fixed wording distinguishes fix commits from planning-artifact commits"
+else
+  fail "debug.md already_fixed wording still blurs fix commits and planning-artifact commits"
+fi
+
+if grep -Fq "already_fixed = 'Already fixed before this investigation — no new commit created.'" "$DEBUG_CMD" 2>/dev/null \
+  || grep -Fq 'already_fixed = "Already fixed on the current branch — no new commit created"' "$DEBUG_CMD" 2>/dev/null; then
+  fail "debug.md still contains stale already_fixed wording that claims no commit was created"
+else
+  pass "debug.md removes stale already_fixed no-new-commit wording"
+fi
+
 if grep -qF 'For `no_fix_yet`' "$DEBUG_CMD" 2>/dev/null && \
    grep -qF '`investigating`' "$DEBUG_CMD" 2>/dev/null; then
   pass "debug.md no_fix_yet path keeps the session investigating"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -154,6 +154,38 @@ else
   fail "debug.md already_fixed path missing set-status complete workflow"
 fi
 
+debug_complete_matches=$(grep -nF 'bash "{plugin-root}/scripts/debug-session-state.sh" set-status .vbw-planning complete' "$DEBUG_CMD" 2>/dev/null || true)
+debug_pg_matches=$(grep -nF 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"' "$DEBUG_CMD" 2>/dev/null || true)
+debug_commit_matches=$(grep -nF 'bash "$PG_SCRIPT" commit-boundary "complete debug session" .vbw-planning/config.json' "$DEBUG_CMD" 2>/dev/null || true)
+debug_warning_matches=$(grep -nF 'VBW: planning-git.sh unavailable; skipping planning git boundary commit' "$DEBUG_CMD" 2>/dev/null || true)
+
+debug_complete_first=$(printf '%s\n' "$debug_complete_matches" | sed -n '1s/:.*//p')
+debug_complete_second=$(printf '%s\n' "$debug_complete_matches" | sed -n '2s/:.*//p')
+debug_complete_third=$(printf '%s\n' "$debug_complete_matches" | sed -n '3s/:.*//p')
+
+debug_pg_first=$(printf '%s\n' "$debug_pg_matches" | sed -n '1s/:.*//p')
+debug_pg_second=$(printf '%s\n' "$debug_pg_matches" | sed -n '2s/:.*//p')
+debug_pg_third=$(printf '%s\n' "$debug_pg_matches" | sed -n '3s/:.*//p')
+
+debug_commit_first=$(printf '%s\n' "$debug_commit_matches" | sed -n '1s/:.*//p')
+debug_commit_second=$(printf '%s\n' "$debug_commit_matches" | sed -n '2s/:.*//p')
+debug_commit_third=$(printf '%s\n' "$debug_commit_matches" | sed -n '3s/:.*//p')
+
+debug_warning_first=$(printf '%s\n' "$debug_warning_matches" | sed -n '1s/:.*//p')
+debug_warning_second=$(printf '%s\n' "$debug_warning_matches" | sed -n '2s/:.*//p')
+debug_warning_third=$(printf '%s\n' "$debug_warning_matches" | sed -n '3s/:.*//p')
+
+if [ -n "$debug_complete_first" ] && [ -n "$debug_complete_second" ] && [ -z "$debug_complete_third" ] && \
+   [ -n "$debug_pg_first" ] && [ -n "$debug_pg_second" ] && [ -z "$debug_pg_third" ] && \
+   [ -n "$debug_commit_first" ] && [ -n "$debug_commit_second" ] && [ -z "$debug_commit_third" ] && \
+   [ -n "$debug_warning_first" ] && [ -n "$debug_warning_second" ] && [ -z "$debug_warning_third" ] && \
+   [ "$debug_complete_first" -lt "$debug_pg_first" ] && [ "$debug_pg_first" -lt "$debug_commit_first" ] && [ "$debug_commit_first" -lt "$debug_warning_first" ] && \
+   [ "$debug_complete_second" -lt "$debug_pg_second" ] && [ "$debug_pg_second" -lt "$debug_commit_second" ] && [ "$debug_commit_second" -lt "$debug_warning_second" ]; then
+  pass "debug.md completion paths run planning boundary commit immediately after set-status complete"
+else
+  fail "debug.md completion paths missing ordered planning boundary commit after set-status complete"
+fi
+
 if grep -qF 'For `no_fix_yet`' "$DEBUG_CMD" 2>/dev/null && \
    grep -qF '`investigating`' "$DEBUG_CMD" 2>/dev/null; then
   pass "debug.md no_fix_yet path keeps the session investigating"

--- a/testing/verify-issue-157-migration-contract.sh
+++ b/testing/verify-issue-157-migration-contract.sh
@@ -82,10 +82,11 @@ fi
 
 if contains "$DEBUG_FILE" 'bash "{plugin-root}/scripts/debug-session-state.sh"' \
   && contains "$DEBUG_FILE" 'bash "{plugin-root}/scripts/write-debug-session.sh"' \
-  && contains "$DEBUG_FILE" '{plugin-root}/references/handoff-schemas.md'; then
-  pass "debug: uses safe {plugin-root} session and handoff references"
+  && contains "$DEBUG_FILE" '{plugin-root}/references/handoff-schemas.md' \
+  && contains "$DEBUG_FILE" 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"'; then
+  pass "debug: uses safe {plugin-root} session/handoff references plus deterministic planning-git path"
 else
-  fail "debug: missing migrated {plugin-root} session/handoff references"
+  fail "debug: missing migrated {plugin-root} session/handoff/planning-git references"
 fi
 
 if contains "$FIX_FILE" 'bash "{plugin-root}/scripts/todo-details.sh" get <hash>' \

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -102,7 +102,7 @@ assert_no_repeated_blank_lines() {
   SESSION_FILE=$(start_session)
   [ -f "$SESSION_FILE" ]
 
-  echo '{"mode":"investigation","issue":"Guard already present","hypotheses":[{"description":"Fix landed earlier","status":"confirmed","evidence_for":"Current branch already includes the guard","evidence_against":"None","conclusion":"Bug was already fixed before this session"}],"root_cause":"Missing guard was fixed earlier in scripts/example.sh","plan":"No new changes required","implementation":"No new changes were required because the current branch already contained the fix.","changed_files":["scripts/example.sh"],"commit":"Already fixed before this investigation — no new commit created."}' \
+  echo '{"mode":"investigation","issue":"Guard already present","hypotheses":[{"description":"Fix landed earlier","status":"confirmed","evidence_for":"Current branch already includes the guard","evidence_against":"None","conclusion":"Bug was already fixed before this session"}],"root_cause":"Missing guard was fixed earlier in scripts/example.sh","plan":"No new changes required","implementation":"No new changes were required because the current branch already contained the fix.","changed_files":["scripts/example.sh"],"commit":"Already fixed before this investigation — no new fix commit was required. If planning_tracking=commit, this completion path may create a planning-artifact commit."}' \
     | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
 
   bash "$SCRIPTS_DIR/debug-session-state.sh" set-status "$PLANNING_DIR" complete > /dev/null
@@ -111,7 +111,7 @@ assert_no_repeated_blank_lines() {
   [ -f "$SESSION_FILE" ]
   [[ "$SESSION_FILE" == *"/debugging/completed/"* ]]
   grep -q '^status: complete$' "$SESSION_FILE"
-  grep -q 'Already fixed before this investigation — no new commit created\.' "$SESSION_FILE"
+  grep -q 'Already fixed before this investigation — no new fix commit was required\. If planning_tracking=commit, this completion path may create a planning-artifact commit\.' "$SESSION_FILE"
   grep -q 'No new changes were required because the current branch already contained the fix\.' "$SESSION_FILE"
   ! grep -q '### Round 1 — PASS' "$SESSION_FILE"
   ! grep -q '### Round 1 — pass' "$SESSION_FILE"

--- a/tests/planning-git-callsites.bats
+++ b/tests/planning-git-callsites.bats
@@ -55,6 +55,8 @@ load test_helper
   [ "$c" -eq 12 ]
   c=$(grep -c 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"' "$PROJECT_ROOT/commands/discuss.md")
   [ "$c" -eq 1 ]
+  c=$(grep -c 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"' "$PROJECT_ROOT/commands/debug.md")
+  [ "$c" -eq 2 ]
   c=$(grep -c 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/planning-git.sh"' "$PROJECT_ROOT/commands/verify.md")
   [ "$c" -eq 1 ]
   c=$(grep -c 'PG_SCRIPT="${VBW_PLUGIN_ROOT}/scripts/planning-git.sh"' "$PROJECT_ROOT/references/execute-protocol.md")
@@ -70,7 +72,7 @@ load test_helper
 @test "planning-git callsite count is exact" {
   local fallback_count
   fallback_count=$(grep -R -cE 'PG_SCRIPT="/tmp/.vbw-plugin-root-link-\$\{CLAUDE_SESSION_ID:-default\}/scripts/planning-git.sh"|PG_SCRIPT="\$\{VBW_PLUGIN_ROOT\}/scripts/planning-git.sh"' "$PROJECT_ROOT/commands" "$PROJECT_ROOT/references" 2>/dev/null | awk -F: '{s+=$NF} END{print s}')
-  [ "$fallback_count" -eq 19 ] || { echo "Unexpected planning-git callsite count: $fallback_count"; false; }
+  [ "$fallback_count" -eq 21 ] || { echo "Unexpected planning-git callsite count: $fallback_count"; false; }
 }
 
 @test "planning-git callsites do not use sort -V fallback resolver" {


### PR DESCRIPTION
Fixes #510
Related: #511 (flaky verification issue observed during development; not reproduced in the final suite)

## What
This updates `/vbw:debug` so both successful completion paths run the same planning-artifact boundary commit used elsewhere in VBW. `commands/debug.md` now commits planning artifacts immediately after marking the debug session complete in the `already_fixed` branch and the inline-UAT all-pass branch, and the contract tests were extended to lock in ordering, deterministic `PG_SCRIPT` resolution, and repo-wide callsite counts. A follow-up wording fix keeps the `already_fixed` path honest: no new fix commit is required, but `planning_tracking=commit` may still create a planning-artifact commit.

## Why
Issue #510 was caused by a command-layer omission: `/vbw:debug` stopped after `debug-session-state.sh set-status .vbw-planning complete` and never called `scripts/planning-git.sh commit-boundary`. The correct architectural fix is to keep `debug-session-state.sh` focused on state transitions and put the planning-artifact boundary in `commands/debug.md`, matching other VBW lifecycle commands and preserving the `planning_tracking=commit` / `auto_push` semantics already centralized in `scripts/planning-git.sh`.

## How
- `commands/debug.md` — adds deterministic `planning-git.sh commit-boundary` blocks to the two completion paths and updates `already_fixed` wording to distinguish fix commits from planning-artifact commits.
- `testing/verify-debug-session-contract.sh` — adds ordering checks, deterministic resolver checks, and the corrected `already_fixed` wording guard.
- `tests/planning-git-callsites.bats` — adds the `commands/debug.md` per-file count and bumps the aggregate exact count.
- `testing/verify-issue-157-migration-contract.sh` — enforces deterministic `PG_SCRIPT` coverage for `commands/debug.md`.
- `tests/debug-session-lifecycle.bats` — updates the already-fixed lifecycle fixture to match the corrected wording. This file was touched for a QA-found regression, not for the original bug mechanics.

## Acceptance criteria verification
1. Criterion 1: satisfied by `commands/debug.md:280-287` (`already_fixed` sets `complete` and then runs `commit-boundary "complete debug session"`).
2. Criterion 2: satisfied by `commands/debug.md:543-551` (inline-UAT all-pass path does the same).
3. Criterion 3: satisfied by `commands/debug.md:283-287` and `commands/debug.md:547-551` (exact deterministic `PG_SCRIPT` resolver and standard warning text).
4. Criterion 4: satisfied by `testing/verify-debug-session-contract.sh:226-269`, which asserts the ordered `set-status complete` -> `PG_SCRIPT` -> `commit-boundary` -> warning sequence for both completion paths.
5. Criterion 5: satisfied by `tests/planning-git-callsites.bats:58-75`, which requires `commands/debug.md` count `2` and aggregate planning-git count `21`.
6. Criterion 6: satisfied by `testing/verify-issue-157-migration-contract.sh:83-89`, which requires the deterministic `PG_SCRIPT` pattern in `commands/debug.md`.
7. Criterion 7: satisfied by local verification with `bash testing/run-all.sh` on the final branch tip.
8. Criterion 8: satisfied by consumer-repo smoke evidence in a `planning_tracking=commit` repo: a completed debug session produced `chore(vbw): complete debug session` and did not leave the completed debug-session doc or `STATE.md` unstaged.

## Testing
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bash testing/verify-issue-157-migration-contract.sh`
- [x] `bats tests/planning-git-callsites.bats`
- [x] `bats tests/debug-session-state.bats`
- [x] `bats tests/debug-session-lifecycle.bats`
- [x] `bats tests/suggest-next-debug-session.bats`
- [x] `bash testing/run-all.sh`
- [x] Manual consumer smoke in a `planning_tracking=commit` repo for the completed debug-session path

## QA summary
- Primary QA rounds completed: 3 (`qa-investigator`)
  - Round 1: 1 contract finding fixed (missing real-consumer completion proof)
  - Round 2: clean
  - Round 3: clean
  - False positives: 0
- Cross-model QA rounds completed: 2 (`qa-investigator-gpt-54`, GPT-5.4)
  - Round 1: 1 medium regression fixed (`already_fixed` wording misreported commit state)
  - Round 2: clean
  - False positives: 0
- Copilot PR review rounds completed: 0 (pending Phase 4.5)
- Secondary issue filed during verification: #511 (`Flaky test: list-with-snapshot returns full metadata and writes the exact snapshot`) — observed during an intermediate rerun, not reproduced in the final suite.
