### PR TITLE
fix: sync transient planning ignores in all tracking modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ VBW generates 15+ files in `.vbw-planning/` during bootstrap, planning, executio
 #### `planning_tracking`
 
 Controls whether `.vbw-planning/` artifacts are committed, gitignored, or left for you to manage.
+VBW writes `.vbw-planning/.gitignore` in all three modes so transient runtime files stay excluded; the selected mode only changes whether the whole planning directory is root-ignored and/or auto-committed.
 
 ```text
 /vbw:config planning_tracking commit
@@ -714,8 +715,8 @@ Controls whether `.vbw-planning/` artifacts are committed, gitignored, or left f
 
 | Value | What It Does | When To Use It |
 | :--- | :--- | :--- |
-| **`manual`** | Default. No commits, no gitignore. Planning files accumulate as untracked in `git status`. You manage them yourself. | When you want full control, or aren't sure yet. |
-| **`ignore`** | Adds `.vbw-planning/` to `.gitignore` during `/vbw:init`. Planning files exist locally but never enter version control. Clean `git status`. | Solo projects, prototyping, or when planning history doesn't matter. |
+| **`manual`** | Default. No auto-commits and no root ignore for the whole `.vbw-planning/` directory. Durable planning files accumulate as untracked in `git status`, while transient runtime files stay excluded via `.vbw-planning/.gitignore`. | When you want full control, or aren't sure yet. |
+| **`ignore`** | Adds `.vbw-planning/` to `.gitignore` during `/vbw:init` or `/vbw:config planning_tracking ignore`. Planning files exist locally but never enter version control. Clean `git status`. | Solo projects, prototyping, or when planning history doesn't matter. |
 | **`commit`** | Auto-commits `.vbw-planning/` artifacts (and `CLAUDE.md` when present) at helper-backed planning boundaries — for example after bootstrap, planning/discussion checkpoints, todo additions, and archive. Commit format: `chore(vbw): {action}`. Transient files (`.execution-state.json`, `.contracts/`, `.locks/`, `.token-state/`, compiled context) are excluded via `.vbw-planning/.gitignore`. | Teams that want an audit trail of planning decisions in version control. |
 
 #### `auto_push`

--- a/commands/config.md
+++ b/commands/config.md
@@ -265,7 +265,7 @@ If `setting=planning_tracking`, after writing config run:
   fi
 ```
 
-This keeps root `.gitignore` and `.vbw-planning/.gitignore` aligned with the selected tracking mode.
+This applies any mode-specific root `.gitignore` behavior and keeps `.vbw-planning/.gitignore` current for transient runtime files in every tracking mode.
 
 ### Skill-hook wiring: `skill_hook <skill> <event> <tools>`
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -145,8 +145,8 @@ Create `.vbw-planning/phases/`. Ensure config.json includes `"prefer_teams": "au
 
 AskUserQuestion (single select):
 - "How should VBW planning artifacts be tracked in git?"
-  - `manual` (default): don't auto-ignore or auto-commit planning files
-  - `ignore`: keep `.vbw-planning/` ignored in root `.gitignore`
+  - `manual` (default): don't auto-ignore the whole `.vbw-planning/` directory or auto-commit planning files
+  - `ignore`: keep the whole `.vbw-planning/` directory ignored in root `.gitignore`
   - `commit`: track `.vbw-planning/` + `CLAUDE.md` at helper-backed planning boundaries (bootstrap, planning checkpoints, todo adds, archive)
 
 AskUserQuestion (single select):
@@ -171,6 +171,8 @@ else
   echo "VBW: planning-git.sh unavailable; skipping .gitignore sync" >&2
 fi
 ```
+
+This applies any mode-specific root `.gitignore` behavior and keeps `.vbw-planning/.gitignore` current for transient runtime files in every tracking mode.
 
 ### Step 1.5: Install git hooks
 

--- a/scripts/planning-git.sh
+++ b/scripts/planning-git.sh
@@ -141,10 +141,7 @@ case "$COMMAND" in
 
     read_config "$CONFIG_FILE"
     sync_root_ignore "$CFG_PLANNING_TRACKING"
-
-    if [ "$CFG_PLANNING_TRACKING" = "commit" ]; then
-      ensure_transient_ignore
-    fi
+    ensure_transient_ignore
     ;;
 
   commit-boundary)

--- a/tests/planning-git.bats
+++ b/tests/planning-git.bats
@@ -32,6 +32,44 @@ EOF
 
   run grep -qx '\.vbw-planning/' .gitignore
   [ "$status" -eq 0 ]
+
+  run grep -Fqx '.execution-state.json' .vbw-planning/.gitignore
+  [ "$status" -eq 0 ]
+}
+
+@test "sync-ignore writes transient planning ignore in manual mode without hiding durable planning artifacts" {
+  cat > .vbw-planning/config.json <<'EOF'
+{
+  "planning_tracking": "manual",
+  "auto_push": "never"
+}
+EOF
+
+  run bash "$SCRIPTS_DIR/planning-git.sh" sync-ignore .vbw-planning/config.json
+  [ "$status" -eq 0 ]
+
+  if [ -f .gitignore ]; then
+    run grep -qx '\.vbw-planning/' .gitignore
+    [ "$status" -ne 0 ]
+  fi
+
+  run grep -Fqx '.execution-state.json' .vbw-planning/.gitignore
+  [ "$status" -eq 0 ]
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+Tracked by user
+EOF
+
+  echo '12345' > .vbw-planning/.agent-pids
+  echo '{"status":"running"}' > .vbw-planning/.execution-state.json
+
+  run git status --short --untracked-files=all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *".vbw-planning/STATE.md"* ]]
+  [[ "$output" != *".vbw-planning/.agent-pids"* ]]
+  [[ "$output" != *".vbw-planning/.execution-state.json"* ]]
 }
 
 @test "sync-ignore removes root ignore and writes transient planning ignore when commit mode" {


### PR DESCRIPTION
Fixes #506

## What
This change makes `planning-git.sh sync-ignore` materialize `.vbw-planning/.gitignore` in every `planning_tracking` mode instead of only in `commit` mode. It updates the runtime script, adds regression coverage for `manual` and `ignore`, and aligns `commands/init.md`, `commands/config.md`, and `README.md` with the corrected behavior.

## Why
The bug came from conflating two separate concerns in `sync-ignore`: root-level tracking policy for `.vbw-planning/` and nested ignore rules for transient runtime artifacts. The root policy is mode-dependent, but the transient ignore rules are not. Gating `ensure_transient_ignore` behind `planning_tracking=commit` meant the default `manual` flow leaked `.agent-pids`, `.cost-ledger.json`, `.execution-state.json`, and similar runtime files into `git status`.

## How
- `scripts/planning-git.sh`: call `ensure_transient_ignore` unconditionally after `sync_root_ignore`, while preserving the existing git-repo guard and the helper's no-op behavior when `.vbw-planning/` does not exist.
- `tests/planning-git.bats`: add regression coverage for:
  - `ignore` mode keeping root `.gitignore` behavior while also writing the nested transient ignore file
  - `manual` mode keeping durable planning artifacts visible in `git status` while hiding transient runtime files
  - existing `commit` behavior remaining intact
- `commands/init.md`, `commands/config.md`, `README.md`: document that `.vbw-planning/.gitignore` is maintained in all modes and that only the root-ignore / auto-commit policy varies by `planning_tracking`.

## Acceptance criteria verification
1. `scripts/planning-git.sh sync-ignore` writes `.vbw-planning/.gitignore` in all three modes.
   - Satisfied by `scripts/planning-git.sh:31-89` and `scripts/planning-git.sh:143-144`.
   - Covered by `tests/planning-git.bats:22-93`.
2. In `manual` mode, root `.gitignore` stays untouched while transient runtime files are ignored via the nested file.
   - Covered by `tests/planning-git.bats:40-74`.
3. In `ignore` mode, root `.gitignore` still hides the whole planning directory and the nested transient ignore file is also written.
   - Covered by `tests/planning-git.bats:22-39` and `scripts/planning-git.sh:93-111`.
4. In `commit` mode, durable planning artifacts still commit while transient runtime files stay excluded.
   - Preserved by `scripts/planning-git.sh:147-179`.
   - Covered by `tests/planning-git.bats:75-180`.
5. Regression coverage exists for manual/ignore/commit behavior.
   - Added in `tests/planning-git.bats:22-180`.

## Testing
- [x] `bats tests/planning-git.bats`
- [x] `bats tests/planning-git-callsites.bats`
- [x] `bash testing/verify-plugin-root-resolution.sh`
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/verify-readme-config-reference.sh`
- [x] `bash testing/run-all.sh`
- [ ] Local plugin smoke test against a real consumer repo
- [ ] Direct command smoke test through `claude --plugin-dir` in a consumer repo

## QA summary
- Primary QA rounds completed: 3 (`qa-investigator`)
  - Round 1: 0 legitimate findings — `6a957580d7186ebc4f0df1fb77bb9d0fcc1de025`
  - Round 2: 0 legitimate findings — `75526c63e081894c0ab3fc46bba5b5c23da0697d`
  - Round 3: 0 legitimate findings — `d3faa65841256c32ab8aa2104c848e49c561ff91`
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54`, GPT-5.4)
  - Round 1: 0 legitimate findings — `dbddbc242d88835c8519ecd995eba0f163cd0643`
- Copilot PR review rounds completed: pending (starts after draft PR opens and is marked ready)
- False positives across QA phases: none

## Notes
- Scope remains intentionally narrow: this PR does not change cleanup of a pre-existing root `.gitignore` entry when switching from `ignore` back to `manual`.
