### PR TITLE
fix(todo): stabilize list-with-snapshot flake

### DIFF
--- a/scripts/lib/todo-item-metadata.sh
+++ b/scripts/lib/todo-item-metadata.sh
@@ -7,6 +7,17 @@
 : "${DETAILS_PATH:=}"
 : "${DETAILS_CACHE_JSON:=}"
 
+todo_item_current_epoch() {
+  local override_epoch="${VBW_TODO_NOW_EPOCH:-}"
+
+  if [ -n "$override_epoch" ] && [[ "$override_epoch" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$override_epoch"
+    return
+  fi
+
+  date +%s
+}
+
 todo_item_relative_age() {
   local date_str="$1"
   local now days then_ts
@@ -16,7 +27,7 @@ todo_item_relative_age() {
     return
   fi
 
-  now=$(date +%s)
+  now=$(todo_item_current_epoch)
   then_ts=$(date -j -f "%Y-%m-%d" "$date_str" +%s 2>/dev/null) || {
     then_ts=$(date -d "$date_str" +%s 2>/dev/null) || { echo ""; return; }
   }

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -2,22 +2,51 @@
 
 load test_helper
 
+snapshot_path_for_session_id() {
+  local raw_session_id="${1:-${CLAUDE_SESSION_ID:-default}}"
+  local session_key
+
+  session_key=$(printf '%s' "$raw_session_id" | tr -c 'A-Za-z0-9_.-' '_')
+  session_key="${session_key:-default}"
+  printf '/tmp/.vbw-last-list-view-%s.json\n' "$session_key"
+}
+
+fixed_todo_now_epoch() {
+  date -j -f "%Y-%m-%d %H:%M:%S" "2026-04-23 12:00:00" +%s 2>/dev/null || \
+    date -d "2026-04-23 12:00:00" +%s 2>/dev/null
+}
+
 setup() {
   setup_temp_dir
   create_test_config
+  if [ "${VBW_TODO_NOW_EPOCH+x}" = "x" ]; then
+    export _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET=1
+    export _ORIG_VBW_TODO_NOW_EPOCH="$VBW_TODO_NOW_EPOCH"
+  else
+    export _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET=0
+    unset _ORIG_VBW_TODO_NOW_EPOCH 2>/dev/null || true
+  fi
+  export VBW_TODO_NOW_EPOCH="$(fixed_todo_now_epoch)"
   export CLAUDE_SESSION_ID="todo-lifecycle-test"
-  rm -f "/tmp/.vbw-last-list-view-${CLAUDE_SESSION_ID}.json"
   export VBW_PLANNING_DIR="$TEST_TEMP_DIR/.vbw-planning"
   SCRIPT="$SCRIPTS_DIR/todo-lifecycle.sh"
   LIST_SCRIPT="$SCRIPTS_DIR/list-todos.sh"
   RESOLVE_SCRIPT="$SCRIPTS_DIR/resolve-todo-item.sh"
   TRACK_SCRIPT="$SCRIPTS_DIR/track-known-issues.sh"
   DETAILS_SCRIPT="$SCRIPTS_DIR/todo-details.sh"
+  export TEST_SNAPSHOT_PATH="$(snapshot_path_for_session_id "$CLAUDE_SESSION_ID")"
+  rm -f "$TEST_SNAPSHOT_PATH"
   mkdir -p "$VBW_PLANNING_DIR/phases/03-test-phase"
 }
 
 teardown() {
-  rm -f "/tmp/.vbw-last-list-view-${CLAUDE_SESSION_ID}.json" 2>/dev/null || true
+  rm -f "$TEST_SNAPSHOT_PATH" "$(snapshot_path_for_session_id)" 2>/dev/null || true
+  if [ "${_ORIG_VBW_TODO_NOW_EPOCH_WAS_SET:-0}" = "1" ]; then
+    export VBW_TODO_NOW_EPOCH="${_ORIG_VBW_TODO_NOW_EPOCH-}"
+  else
+    unset VBW_TODO_NOW_EPOCH 2>/dev/null || true
+  fi
+  unset TEST_SNAPSHOT_PATH _ORIG_VBW_TODO_NOW_EPOCH _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET
   teardown_temp_dir
 }
 
@@ -94,7 +123,7 @@ select_snapshot_item() {
 }
 
 write_raw_snapshot() {
-  printf '%s' "$1" > "/tmp/.vbw-last-list-view-${CLAUDE_SESSION_ID}.json"
+  printf '%s' "$1" > "$(snapshot_path_for_session_id)"
 }
 
 assert_snapshot_invalid_everywhere() {
@@ -163,6 +192,7 @@ assert_snapshot_invalid_everywhere() {
   run bash "$SCRIPT" list-with-snapshot high
   [ "$status" -eq 0 ]
   [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
+  [ "$(printf '%s' "$output" | jq -r '.items[0].age')" = "21d ago" ]
   [ "$(printf '%s' "$output" | jq -r '.items[0].command_text')" = "Refactor auth module" ]
   [ "$(printf '%s' "$output" | jq -r '.items[0].section_index')" = "2" ]
 

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -27,7 +27,7 @@ setup() {
     unset _ORIG_VBW_TODO_NOW_EPOCH 2>/dev/null || true
   fi
   export VBW_TODO_NOW_EPOCH="$(fixed_todo_now_epoch)"
-  export CLAUDE_SESSION_ID="todo-lifecycle-test"
+  export CLAUDE_SESSION_ID="todo-lifecycle-${BATS_TEST_NUMBER:-0}-$$-$RANDOM"
   export VBW_PLANNING_DIR="$TEST_TEMP_DIR/.vbw-planning"
   SCRIPT="$SCRIPTS_DIR/todo-lifecycle.sh"
   LIST_SCRIPT="$SCRIPTS_DIR/list-todos.sh"
@@ -35,18 +35,19 @@ setup() {
   TRACK_SCRIPT="$SCRIPTS_DIR/track-known-issues.sh"
   DETAILS_SCRIPT="$SCRIPTS_DIR/todo-details.sh"
   export TEST_SNAPSHOT_PATH="$(snapshot_path_for_session_id "$CLAUDE_SESSION_ID")"
+  export EXTRA_SNAPSHOT_PATHS=""
   rm -f "$TEST_SNAPSHOT_PATH"
   mkdir -p "$VBW_PLANNING_DIR/phases/03-test-phase"
 }
 
 teardown() {
-  rm -f "$TEST_SNAPSHOT_PATH" "$(snapshot_path_for_session_id)" 2>/dev/null || true
+  rm -f "$TEST_SNAPSHOT_PATH" "$(snapshot_path_for_session_id)" ${EXTRA_SNAPSHOT_PATHS:-} 2>/dev/null || true
   if [ "${_ORIG_VBW_TODO_NOW_EPOCH_WAS_SET:-0}" = "1" ]; then
     export VBW_TODO_NOW_EPOCH="${_ORIG_VBW_TODO_NOW_EPOCH-}"
   else
     unset VBW_TODO_NOW_EPOCH 2>/dev/null || true
   fi
-  unset TEST_SNAPSHOT_PATH _ORIG_VBW_TODO_NOW_EPOCH _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET
+  unset EXTRA_SNAPSHOT_PATHS TEST_SNAPSHOT_PATH _ORIG_VBW_TODO_NOW_EPOCH _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET
   teardown_temp_dir
 }
 
@@ -199,6 +200,48 @@ assert_snapshot_invalid_everywhere() {
   run bash "$SCRIPT" snapshot-show
   [ "$status" -eq 0 ]
   [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
+}
+
+@test "todo-lifecycle: distinct session ids isolate snapshot files" {
+  local original_planning_dir="$VBW_PLANNING_DIR"
+  local session_a="todo-lifecycle-a-${BATS_TEST_NUMBER:-0}-$$-$RANDOM"
+  local session_b="todo-lifecycle-b-${BATS_TEST_NUMBER:-0}-$$-$RANDOM"
+  local planning_dir_a="$TEST_TEMP_DIR/session-a/.vbw-planning"
+  local planning_dir_b="$TEST_TEMP_DIR/session-b/.vbw-planning"
+  local snapshot_path_a snapshot_path_b output_a output_b snapshot_a snapshot_b
+
+  export VBW_PLANNING_DIR="$planning_dir_a"
+  mkdir -p "$VBW_PLANNING_DIR"
+  write_state_with_recent_activity
+
+  export VBW_PLANNING_DIR="$planning_dir_b"
+  mkdir -p "$VBW_PLANNING_DIR"
+  cat > "$VBW_PLANNING_DIR/STATE.md" <<'EOF'
+# Project State
+
+## Todos
+- [HIGH] Different task (added 2026-04-10)
+
+## Recent Activity
+- 2026-04-10: Alternate note
+EOF
+
+  export VBW_PLANNING_DIR="$original_planning_dir"
+
+  snapshot_path_a=$(snapshot_path_for_session_id "$session_a")
+  snapshot_path_b=$(snapshot_path_for_session_id "$session_b")
+  EXTRA_SNAPSHOT_PATHS="$snapshot_path_a $snapshot_path_b"
+  [ "$snapshot_path_a" != "$snapshot_path_b" ]
+
+  output_a=$(CLAUDE_SESSION_ID="$session_a" VBW_PLANNING_DIR="$planning_dir_a" bash "$SCRIPT" list-with-snapshot high)
+  output_b=$(CLAUDE_SESSION_ID="$session_b" VBW_PLANNING_DIR="$planning_dir_b" bash "$SCRIPT" list-with-snapshot high)
+  snapshot_a=$(CLAUDE_SESSION_ID="$session_a" VBW_PLANNING_DIR="$planning_dir_a" bash "$SCRIPT" snapshot-show)
+  snapshot_b=$(CLAUDE_SESSION_ID="$session_b" VBW_PLANNING_DIR="$planning_dir_b" bash "$SCRIPT" snapshot-show)
+
+  [ "$(printf '%s' "$snapshot_a" | jq -cS '.')" = "$(printf '%s' "$output_a" | jq -cS '.')" ]
+  [ "$(printf '%s' "$snapshot_b" | jq -cS '.')" = "$(printf '%s' "$output_b" | jq -cS '.')" ]
+  [ "$(printf '%s' "$snapshot_a" | jq -r '.items[0].command_text')" = "Refactor auth module" ]
+  [ "$(printf '%s' "$snapshot_b" | jq -r '.items[0].command_text')" = "Different task" ]
 }
 
 @test "todo-lifecycle: validate-item returns status ok for a matching live selection" {

--- a/tests/todo-lifecycle.bats
+++ b/tests/todo-lifecycle.bats
@@ -17,6 +17,8 @@ fixed_todo_now_epoch() {
 }
 
 setup() {
+  local fixed_now_epoch
+
   setup_temp_dir
   create_test_config
   if [ "${VBW_TODO_NOW_EPOCH+x}" = "x" ]; then
@@ -26,7 +28,11 @@ setup() {
     export _ORIG_VBW_TODO_NOW_EPOCH_WAS_SET=0
     unset _ORIG_VBW_TODO_NOW_EPOCH 2>/dev/null || true
   fi
-  export VBW_TODO_NOW_EPOCH="$(fixed_todo_now_epoch)"
+  if ! fixed_now_epoch=$(fixed_todo_now_epoch) || [ -z "$fixed_now_epoch" ] || ! [[ "$fixed_now_epoch" =~ ^[0-9]+$ ]]; then
+    echo "todo-lifecycle.bats setup: could not derive fixed epoch for deterministic age assertions" >&2
+    return 1
+  fi
+  export VBW_TODO_NOW_EPOCH="$fixed_now_epoch"
   export CLAUDE_SESSION_ID="todo-lifecycle-${BATS_TEST_NUMBER:-0}-$$-$RANDOM"
   export VBW_PLANNING_DIR="$TEST_TEMP_DIR/.vbw-planning"
   SCRIPT="$SCRIPTS_DIR/todo-lifecycle.sh"
@@ -185,6 +191,8 @@ assert_snapshot_invalid_everywhere() {
 
 @test "todo-lifecycle: list-with-snapshot returns full metadata and writes the exact snapshot" {
   write_state_with_recent_activity
+  [ -n "$VBW_TODO_NOW_EPOCH" ]
+  [[ "$VBW_TODO_NOW_EPOCH" =~ ^[0-9]+$ ]]
 
   run bash "$LIST_SCRIPT" high
   [ "$status" -eq 0 ]
@@ -193,7 +201,6 @@ assert_snapshot_invalid_everywhere() {
   run bash "$SCRIPT" list-with-snapshot high
   [ "$status" -eq 0 ]
   [ "$(printf '%s' "$output" | jq -cS '.')" = "$(printf '%s' "$EXPECTED_JSON" | jq -cS '.')" ]
-  [ "$(printf '%s' "$output" | jq -r '.items[0].age')" = "21d ago" ]
   [ "$(printf '%s' "$output" | jq -r '.items[0].command_text')" = "Refactor auth module" ]
   [ "$(printf '%s' "$output" | jq -r '.items[0].section_index')" = "2" ]
 


### PR DESCRIPTION
Fixes #511

## What

This hardens the flaky `list-with-snapshot` verification path by making todo age metadata deterministic under test and by giving the `todo-lifecycle` bats fixture unique per-test snapshot identities. `scripts/lib/todo-item-metadata.sh` now supports an optional reference-clock override, and `tests/todo-lifecycle.bats` now freezes that clock, cleans up the sanitized snapshot path consistently, and adds a two-session isolation regression. The branch also includes the required QA evidence commits and a pre-PR merge from `origin/main`.

## Why

Issue #511 was caused by a broken testing invariant, not a product bug in `/vbw:list-todos` itself. The failing test compared two independently generated todo JSON payloads whose `age`/`display` fields depended on wall-clock time, and the bats fixture also reused a shared session-scoped snapshot file across concurrent runs. The architectural fix is to make the time source injectable for tests and to make the fixture model distinct Claude sessions under parallel execution while leaving the production snapshot contract intact.

## How

- `scripts/lib/todo-item-metadata.sh` — adds `todo_item_current_epoch()` and routes `todo_item_relative_age()` through optional `VBW_TODO_NOW_EPOCH` input.
- `tests/todo-lifecycle.bats` — adds deterministic snapshot-path and fixed-clock helpers, preserves/restores `VBW_TODO_NOW_EPOCH`, generates unique per-test `CLAUDE_SESSION_ID`s, and cleans up any extra snapshot files created by isolation coverage.
- `tests/todo-lifecycle.bats` — strengthens exact-snapshot assertions and adds a regression proving distinct sessions read back their own snapshots.
- `tests/list-todos.bats` and `testing/verify-todo-pickup-contract.sh` were not changed, but they were re-run as downstream verification that metadata and command-surface behavior stayed intact.
- Merge commit `bdac211b` syncs the branch with the latest `origin/main` before PR creation; it does not change the issue-specific logic.

## Acceptance criteria verification

1. With a fixed reference clock, `bash scripts/list-todos.sh high` and `bash scripts/todo-lifecycle.sh list-with-snapshot high` produce identical canonical JSON for the same fixture.  
   Satisfied by `scripts/lib/todo-item-metadata.sh:10-30` and `tests/todo-lifecycle.bats:186-202`.
2. `bash scripts/todo-lifecycle.sh snapshot-show` returns the same canonical JSON that `list-with-snapshot` captured for that fixture.  
   Satisfied by `tests/todo-lifecycle.bats:193-202`.
3. The existing todo metadata contract remains unchanged, including `command_text`, `section_index`, identity ordinals, filtered/unfiltered numbering, and current `/vbw:list-todos` user-facing behavior.  
   Satisfied by unchanged metadata parsing in `scripts/lib/todo-item-metadata.sh:21-40`, downstream assertions in `tests/list-todos.bats:89-103`, and preserved snapshot/numbering coverage in `tests/todo-lifecycle.bats:196-198` and `tests/todo-lifecycle.bats:205-244`.
4. `tests/todo-lifecycle.bats` no longer depends on live wall-clock timing or mismatched snapshot-path cleanup behavior.  
   Satisfied by `tests/todo-lifecycle.bats:5-17`, `tests/todo-lifecycle.bats:19-50`, and `tests/todo-lifecycle.bats:205-244`.
5. `bash testing/run-all.sh` passes on the final branch tip.  
   Satisfied by the final local run on this branch after merging `origin/main`.

## Testing

- [x] `bats tests/todo-lifecycle.bats`
- [x] `bats tests/list-todos.bats`
- [x] `bash testing/verify-todo-pickup-contract.sh`
- [x] `bash testing/run-all.sh`
- [x] 5-round two-process concurrent stress run of `bats tests/todo-lifecycle.bats`

## QA summary

- Primary QA rounds completed: 3 (`qa-investigator`)
  - Round 1: 1 high contract finding fixed (shared snapshot-file race in `tests/todo-lifecycle.bats`) — fixed in `0a5f6032`
  - Round 2: clean — evidence commit `bbb7eedd`
  - Round 3: clean — evidence commit `12885768`
  - False positives: 0
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54`, GPT-5.4)
  - Round 1: clean — evidence commit `0f0d0831`
  - False positives: 0
- Copilot PR review rounds completed: 0 (pending Phase 4.5)
