### PR TITLE
fix(skills): clarify high-cardinality selection behavior in /vbw:skills

### DIFF
--- a/commands/skills.md
+++ b/commands/skills.md
@@ -61,6 +61,7 @@ Run `npx skills find "<query>"`. Display results with `(registry)` tag. If npx u
 Combine curated + registry, deduplicate, rank (curated first).
 
 - If the combined list is empty: STOP here. Do NOT AskUserQuestion. The Step 3 / Step 4 output already explains the no-results state (for example, all recommended skills already installed, no stack detected, or no registry results).
+- For any bounded AskUserQuestion branch below that uses visible options, the built-in `Other` path is still part of that question: accept direct option intent (`install` / `skip`, `yes` / `no`), accept unambiguous visible option-by-number replies (for example `#1` / `#2`), accept hybrid replies anchored to one of those visible option numbers (for example `#2 for now`), and re-ask only when the follow-up is ambiguous or invalid for that same question.
 - If the combined list has exactly 1 candidate: keep it structured.
   - AskUserQuestion with a single bounded question.
   - Keep the header short.
@@ -68,7 +69,6 @@ Combine curated + registry, deduplicate, rank (curated first).
   - Options:
     - `Install {skill-name}` (Recommended)
     - `Skip for now`
-  - If the user takes the built-in `Other` path, treat it as plain-text follow-up for this one decision only: accept `install` / `yes` to select it, accept `skip` / `no` to decline it, otherwise re-ask the same question.
   - Declined → display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.
 
 - If the combined list has 2–4 candidates: keep it structured because this stays within the AskUserQuestion sweet spot.
@@ -77,7 +77,6 @@ Combine curated + registry, deduplicate, rank (curated first).
   - Each question should show `{skill-name} — {brief description}` with two options:
     - `Install`
     - `Skip`
-  - If the user takes the built-in `Other` path for one of these bounded questions, treat it as plain-text follow-up for that question only: accept `install` / `yes` to select it, accept `skip` / `no` to leave it unselected, otherwise re-ask that same question.
   - Collect every selected skill in ranked order.
   - If none were selected, display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.
 

--- a/commands/skills.md
+++ b/commands/skills.md
@@ -61,7 +61,28 @@ Run `npx skills find "<query>"`. Display results with `(registry)` tag. If npx u
 Combine curated + registry, deduplicate, rank (curated first).
 
 - If the combined list is empty: STOP here. Do NOT AskUserQuestion. The Step 3 / Step 4 output already explains the no-results state (for example, all recommended skills already installed, no stack detected, or no registry results).
-- If the combined list is non-empty: present it as a numbered list in the AskUserQuestion text (do NOT use `options` array — a single freeform question avoids the 4-option limit):
+- If the combined list has exactly 1 candidate: keep it structured.
+  - AskUserQuestion with a single bounded question.
+  - Keep the header short.
+  - Question text should show `{skill-name} — {brief description}`.
+  - Options:
+    - `Install {skill-name}` (Recommended)
+    - `Skip for now`
+  - If the user takes the built-in `Other` path, treat it as plain-text follow-up for this one decision only: accept `install` / `yes` to select it, accept `skip` / `no` to decline it, otherwise re-ask the same question.
+  - Declined → display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.
+
+- If the combined list has 2–4 candidates: keep it structured because this stays within the AskUserQuestion sweet spot.
+  - Use AskUserQuestion with 1 question per skill (2–4 questions total), in ranked order.
+  - Keep each header short. Use the skill name as the header.
+  - Each question should show `{skill-name} — {brief description}` with two options:
+    - `Install`
+    - `Skip`
+  - If the user takes the built-in `Other` path for one of these bounded questions, treat it as plain-text follow-up for that question only: accept `install` / `yes` to select it, accept `skip` / `no` to leave it unselected, otherwise re-ask that same question.
+  - Collect every selected skill in ranked order.
+  - If none were selected, display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.
+
+- If the combined list has more than 4 candidates: use intentional high-cardinality freeform input.
+  - Present it as a numbered list in the AskUserQuestion text (do NOT use `options` array — this list is larger than the 2–4 structured-choice sweet spot, so numeric/freeform input is intentional here rather than a faux bounded chooser).
 
 Question text:
 ```
@@ -70,6 +91,7 @@ Available skills for installation:
 2. {skill-name} — {brief description}
 ...N. {skill-name} — {brief description}
 
+This list is larger than the 2–4 structured-choice sweet spot, so use numeric/freeform selection here.
 Type numbers to install (comma-separated), or 'skip' to continue:
 ```
 

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -319,9 +319,68 @@ else
 fi
 
 echo ""
-echo "=== skills.md Step 5b Verification ==="
+echo "=== skills.md Step 5 Verification ==="
 
 SKILLS_FILE="$COMMANDS_DIR/skills.md"
+if [ ! -f "$SKILLS_FILE" ]; then
+  fail "skills: command file not found"
+else
+  skills_step_5="$({
+    awk '
+      /^### Step 5: Offer installation$/ { in_block=1; next }
+      in_block && /^### / { exit }
+      in_block { print }
+    ' "$SKILLS_FILE"
+  } || true)"
+
+  if [ -z "$skills_step_5" ]; then
+    fail "skills: missing Step 5 block"
+  else
+    if grep -Fq 'Combine curated + registry, deduplicate, rank (curated first).' <<< "$skills_step_5"; then
+      pass "skills: Step 5 preserves curated-first ranking"
+    else
+      fail "skills: Step 5 missing curated-first ranking guidance"
+    fi
+
+    if grep -Fq 'If the combined list is empty: STOP here. Do NOT AskUserQuestion.' <<< "$skills_step_5"; then
+      pass "skills: Step 5 stops immediately when no candidates exist"
+    else
+      fail "skills: Step 5 missing empty-list stop without AskUserQuestion"
+    fi
+
+    if grep -Fq 'If the combined list has exactly 1 candidate: keep it structured.' <<< "$skills_step_5" \
+      && grep -Fq 'AskUserQuestion with a single bounded question.' <<< "$skills_step_5"; then
+      pass "skills: Step 5 keeps single-candidate installs structured"
+    else
+      fail "skills: Step 5 missing structured single-candidate branch"
+    fi
+
+    if grep -Eq 'If the combined list has 2[-–]4 candidates: keep it structured' <<< "$skills_step_5" \
+      && grep -Eq 'Use AskUserQuestion with 1 question per skill \(2[-–]4 questions total\)' <<< "$skills_step_5"; then
+      pass "skills: Step 5 keeps bounded multi-candidate installs structured"
+    else
+      fail "skills: Step 5 missing structured 2-4 candidate branch"
+    fi
+
+    if grep -Fq 'If none were selected, display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.' <<< "$skills_step_5"; then
+      pass "skills: Step 5 skips scope selection when bounded structured branch declines everything"
+    else
+      fail "skills: Step 5 missing no-selection stop before Step 5b"
+    fi
+
+    if grep -Fq 'If the combined list has more than 4 candidates: use intentional high-cardinality freeform input.' <<< "$skills_step_5" \
+      && grep -Fq 'do NOT use `options` array' <<< "$skills_step_5" \
+      && grep -Eq 'larger than the 2[-–]4 structured-choice sweet spot' <<< "$skills_step_5"; then
+      pass "skills: Step 5 keeps 5+ candidates on an intentional freeform path"
+    else
+      fail "skills: Step 5 missing explicit intentional freeform 5+ candidate branch"
+    fi
+  fi
+fi
+
+echo ""
+echo "=== skills.md Step 5b Verification ==="
+
 if [ ! -f "$SKILLS_FILE" ]; then
   fail "skills: command file not found"
 else

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -362,6 +362,15 @@ else
       fail "skills: Step 5 missing structured 2-4 candidate branch"
     fi
 
+    if grep -Fq 'For any bounded AskUserQuestion branch below that uses visible options, the built-in `Other` path is still part of that question:' <<< "$skills_step_5" \
+      && grep -Fq 'accept unambiguous visible option-by-number replies (for example `#1` / `#2`)' <<< "$skills_step_5" \
+      && grep -Fq 'accept hybrid replies anchored to one of those visible option numbers (for example `#2 for now`)' <<< "$skills_step_5" \
+      && grep -Fq 're-ask only when the follow-up is ambiguous or invalid for that same question.' <<< "$skills_step_5"; then
+      pass "skills: Step 5 bounded Other path accepts numbered and hybrid replies"
+    else
+      fail "skills: Step 5 missing bounded Other-path numbered/hybrid reply guidance"
+    fi
+
     if grep -Fq 'If none were selected, display `○ No skills selected for installation.` and STOP here. Do not ask Step 5b and do not enter Step 6.' <<< "$skills_step_5"; then
       pass "skills: Step 5 skips scope selection when bounded structured branch declines everything"
     else


### PR DESCRIPTION
Fixes #484

## What
This PR tightens the `/vbw:skills` Step 5 prompt contract in `commands/skills.md` so bounded candidate sets stay structured, `>4` candidates remain explicitly numeric/freeform, and bounded prompts now honor numbered and hybrid replies from AskUserQuestion's built-in `Other` path. `testing/verify-commands-contract.sh` now guards the Step 5 branching boundary and the bounded `Other`-path behavior directly.

## Why
The bug was prompt-contract drift in Step 5, not discovery or install logic. The command had started to clarify the bounded vs high-cardinality boundary, but the bounded branches narrowed `Other`-path handling to plain yes/no-style text. That violated the shared AskUserQuestion contract and made the interaction shape feel improvised. The durable fix is to state one shared bounded `Other`-path rule while keeping the high-cardinality freeform path explicitly intentional.

## How
- `commands/skills.md`: makes the Step 5 empty / `1` / `2–4` / `>4` candidate split explicit and adds a shared bounded `Other`-path rule that accepts direct intent, visible option numbers, and hybrid replies anchored to those visible options. Ranking, deduplication, scope selection, and install behavior stay unchanged.
- `testing/verify-commands-contract.sh`: adds a narrow Step 5 contract check for numbered and hybrid replies in bounded prompts alongside the existing structured and intentional-freeform branch guards. This verifier update was added during QA round 3 remediation to lock in the shared AskUserQuestion behavior the first implementation missed.

## Acceptance criteria verification
1. `commands/skills.md` clearly follows the shared interaction contract for structured vs intentional-freeform selection.  
   Satisfied by `commands/skills.md:63-105`, validated by `testing/verify-commands-contract.sh:339-385`.
2. Small bounded choices remain structured AskUserQuestion prompts.  
   Satisfied by `commands/skills.md:65-81` and `commands/skills.md:109-113`, validated by `testing/verify-commands-contract.sh:351-360`.
3. The install-selection step behaves intentionally.  
   Satisfied by structured branches at `commands/skills.md:65-81` and the intentional freeform branch at `commands/skills.md:83-105`, validated by `testing/verify-commands-contract.sh:351-385` and `testing/verify-askuserquestion-contract.sh`.
4. Prompt wording no longer frames a long numeric parser step as if it were a normal chooser.  
   Satisfied by `commands/skills.md:64` and `commands/skills.md:83-95`.
5. Existing curated + registry ranking / dedup / install behavior remains unchanged.  
   Preserved in `commands/skills.md:61` and `commands/skills.md:117`; no discovery or install logic files changed.
6. Files touched are limited to `commands/skills.md` and directly affected tests/contracts unless a small shared-reference touch is strictly required.  
   Satisfied by the branch diff touching only `commands/skills.md` and `testing/verify-commands-contract.sh`.
7. `bash testing/run-all.sh` passes.  
   Satisfied by the latest local pre-PR run: `46/46` contract checks passed and `3081` BATS tests passed.

## Testing
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/verify-askuserquestion-contract.sh`
- [x] `bash testing/run-all.sh`

Coverage notes:
- `testing/verify-commands-contract.sh` covers the empty / `1` / `2–4` / `>4` Step 5 branches plus the bounded `Other`-path numbered/hybrid reply rule.
- `testing/verify-askuserquestion-contract.sh` keeps the numbered-list guard language in place for the `5+` branch.
- `testing/run-all.sh` passed before PR creation and again after merging the latest `origin/main`.

## QA summary
- Primary QA: 4 rounds with `qa-investigator`; 1 legitimate low-severity contract finding fixed in round 3 (`9d9507c6`), round 4 clean, 0 false positives.
- Cross-model QA: 1 round with GPT-5.4 (`qa-investigator-gpt-54`); clean, 0 findings.
- Copilot PR review: pending until the PR is marked ready for review.
- Main sync: merged non-overlapping `origin/main` updates before cross-model QA; the suite re-ran clean afterward.
