### PR TITLE
fix(debug): preserve completed explicit session state

### DIFF
--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -689,7 +689,6 @@ case "$CMD" in
       echo "Error: refusing to resume symlink session file: $SESSION_PATH" >&2
       exit 1
     fi
-    session_file_status=$(read_field "$SESSION_PATH" "status")
     SESSION_PATH=$(reconcile_session_location "$SESSION_PATH") || exit 1
     session_file_status=$(read_field "$SESSION_PATH" "status")
     # Explicit targeting of a completed session is metadata-only: preserve the

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -8,7 +8,7 @@
 #                                                               → creates session from selected todo JSON + detail helper output
 #   debug-session-state.sh get             <planning-dir>                → prints active session metadata
 #   debug-session-state.sh get-or-latest   <planning-dir>                → active session or latest unresolved
-#   debug-session-state.sh resume          <planning-dir> <session-id>   → sets active pointer to session
+#   debug-session-state.sh resume          <planning-dir> <session-id>   → resumes unresolved session or returns completed-session metadata without reopening
 #   debug-session-state.sh set-status      <planning-dir> <status>       → updates status field
 #   debug-session-state.sh increment-qa    <planning-dir>                → bumps qa_round, sets qa_last_result=pending
 #   debug-session-state.sh increment-uat   <planning-dir>                → bumps uat_round, sets uat_last_result=pending
@@ -690,18 +690,21 @@ case "$CMD" in
       exit 1
     fi
     session_file_status=$(read_field "$SESSION_PATH" "status")
-    if [ "$session_file_status" != "complete" ]; then
-      SESSION_PATH=$(reconcile_session_location "$SESSION_PATH") || exit 1
-    fi
-    # Explicit resume currently re-activates complete sessions, but preserves
-    # the stored status for unresolved sessions that were stranded in completed/.
+    SESSION_PATH=$(reconcile_session_location "$SESSION_PATH") || exit 1
+    session_file_status=$(read_field "$SESSION_PATH" "status")
+    # Explicit targeting of a completed session is metadata-only: preserve the
+    # terminal lifecycle state so the command layer can stop cleanly instead of
+    # silently reopening the investigation.
     if [ "$session_file_status" = "complete" ]; then
-      if [[ "$SESSION_PATH" == "$COMPLETED_DIR/"* ]]; then
-        SESSION_PATH=$(safe_move_session "$SESSION_PATH" "$ACTIVE_DIR") || exit 1
+      if [ -f "$ACTIVE_FILE" ]; then
+        pointer=$(cat "$ACTIVE_FILE" 2>/dev/null | tr -d '[:space:]')
+        if [ "$pointer" = "$SESSION_NAME" ]; then
+          rm -f "$ACTIVE_FILE"
+        fi
       fi
-      update_field "$SESSION_PATH" "status" "investigating"
+    else
+      echo "$SESSION_NAME" > "$ACTIVE_FILE"
     fi
-    echo "$SESSION_NAME" > "$ACTIVE_FILE"
     echo "active_session=true"
     print_session_metadata "$SESSION_PATH"
     ;;

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -117,6 +117,31 @@ assert_no_repeated_blank_lines() {
   ! grep -q '### Round 1 — pass' "$SESSION_FILE"
 }
 
+@test "explicit resume does not reopen completed already-fixed session" {
+  SESSION_FILE=$(start_session)
+  [ -f "$SESSION_FILE" ]
+
+  echo '{"mode":"investigation","issue":"Guard already present","hypotheses":[{"description":"Fix landed earlier","status":"confirmed","evidence_for":"Current branch already includes the guard","evidence_against":"None","conclusion":"Bug was already fixed before this session"}],"root_cause":"Missing guard was fixed earlier in scripts/example.sh","plan":"No new changes required","implementation":"No new changes were required because the current branch already contained the fix.","changed_files":["scripts/example.sh"],"commit":"Already fixed before this investigation — no new fix commit was required. If planning_tracking=commit, this completion path may create a planning-artifact commit."}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"
+
+  local session_name
+  session_name=$(basename "$SESSION_FILE")
+
+  bash "$SCRIPTS_DIR/debug-session-state.sh" set-status "$PLANNING_DIR" complete > /dev/null
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$PLANNING_DIR" "$session_name"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=complete$'
+  [ -f "$PLANNING_DIR/debugging/completed/$session_name" ]
+  [ ! -f "$PLANNING_DIR/debugging/active/$session_name" ]
+  [ ! -f "$PLANNING_DIR/debugging/.active-session" ]
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get "$PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=none"* ]]
+}
+
 # ── Failure/remediation lifecycle ─────────────────────────
 
 @test "remediation lifecycle: QA fail → debug resume → QA pass" {

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -509,28 +509,75 @@ teardown() {
   [[ "$output" == *"session_count=2"* ]]
 }
 
-@test "resume moves completed session back to active directory" {
+@test "resume returns completed session metadata without reactivating it" {
   eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "resume-done")"
   local fname
   fname=$(basename "$session_file")
 
   bash "$SCRIPTS_DIR/debug-session-state.sh" set-status "$VBW_PLANNING_DIR" complete > /dev/null
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
 
   run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$VBW_PLANNING_DIR" "$fname"
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=true"* ]]
-  # Resume should move file back to active/ and reset status
-  printf '%s\n' "$output" | grep -Eq '^session_status=investigating$'
+  printf '%s\n' "$output" | grep -Eq '^session_status=complete$'
   ! printf '%s\n' "$output" | grep -Eq '^status='
-  [ -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
-  [ ! -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
-  # Pointer should reference the active session
-  [ -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
-  # Subsequent get-or-latest should find it
-  run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
+  [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
+  [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=none"* ]]
+}
+
+@test "resume migrates legacy completed session without reactivating it" {
+  mkdir -p "$VBW_PLANNING_DIR/debugging"
+  local session_name="20240101-120000-legacy-resume-done.md"
+  cat > "$VBW_PLANNING_DIR/debugging/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-legacy-resume-done
+title: legacy-resume-done
+status: complete
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:00:00
+qa_round: 1
+qa_last_result: pass
+uat_round: 1
+uat_last_result: pass
+---
+# Legacy completed session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$VBW_PLANNING_DIR" "$session_name"
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=complete$'
+  [ ! -f "$VBW_PLANNING_DIR/debugging/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/active/$session_name" ]
+  [ -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
+}
+
+@test "resume canonicalizes completed session stranded in active without reactivating it" {
+  eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "resume-stranded-done")"
+  local fname
+  fname=$(basename "$session_file")
+
+  awk 'BEGIN{in_fm=0} /^---$/{in_fm=!in_fm} in_fm && /^status:/{print "status: complete";next} {print}' \
+    "$session_file" > "${session_file}.tmp" && mv "${session_file}.tmp" "$session_file"
+
+  [ -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
+  [ -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" resume "$VBW_PLANNING_DIR" "$fname"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=true"* ]]
+  printf '%s\n' "$output" | grep -Eq '^session_status=complete$'
+  [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
+  [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
 }
 
 @test "get-or-latest recovers pointer to unresolved session stranded in completed directory" {


### PR DESCRIPTION
Fixes #508

## What

This PR makes completed standalone debug sessions durable when they are explicitly targeted with `/vbw:debug --session <id>`. The helper no longer silently reopens a `complete` session back into active investigation; instead it returns completed-session metadata so the command layer can stop cleanly.

Files changed:
- `scripts/debug-session-state.sh` — changes `resume` so completed sessions are canonicalized and reported as complete instead of being reactivated.
- `tests/debug-session-state.bats` — adds helper-level durability coverage for normal, legacy, and mislocated completed sessions.
- `tests/debug-session-lifecycle.bats` — adds lifecycle coverage for explicit resume after an `already_fixed` investigation completes.

## Why

The root cause was a contract mismatch between the command and helper layers. `commands/debug.md` already treated `session_status=complete` as terminal, but `scripts/debug-session-state.sh resume` rewrote completed sessions back to `investigating` and moved them into `debugging/active/` before the command could inspect that state. The correct architectural fix is to make the helper preserve terminal lifecycle state and let the command’s existing complete-session stop path remain authoritative.

## How

- `scripts/debug-session-state.sh` — always reconciles the target session to its canonical location first, then treats `status=complete` as metadata-only: preserve `session_status=complete`, clear a stale matching `.active-session` pointer if present, and only repoint `.active-session` for unresolved sessions.
- `tests/debug-session-state.bats` — replaces the prior reopen expectation with completed-session durability assertions and adds legacy/mislocated completed-session cases.
- `tests/debug-session-lifecycle.bats` — verifies an `already_fixed` session that reaches `complete` still stays complete when explicitly targeted again.

## Acceptance criteria verification

1. A session marked `complete` is not silently reactivated by `/vbw:debug --session <id>`.
   - Satisfied by `scripts/debug-session-state.sh:692-709`, which preserves `session_status=complete` and avoids repointing `.active-session` for completed sessions.
   - Locked by `tests/debug-session-state.bats:512-580` and `tests/debug-session-lifecycle.bats:120-142`.
2. Command-layer UX and helper behavior agree on whether explicit `--session` is allowed to reopen completed sessions.
   - Satisfied by the preserved helper behavior in `scripts/debug-session-state.sh:692-709` and the existing terminal stop path in `commands/debug.md:108-120`.
   - Guarded by `testing/verify-debug-session-contract.sh` checks covering the `session_status=complete` stop path.
3. Targeted lifecycle coverage exists for explicit resume of completed sessions.
   - Satisfied by `tests/debug-session-state.bats:512-580` (helper-level coverage) and `tests/debug-session-lifecycle.bats:120-142` (already-fixed lifecycle coverage).

## Testing

- [x] `bats tests/debug-session-state.bats tests/debug-session-lifecycle.bats`
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bash testing/run-all.sh`

Coverage notes:
- `tests/debug-session-state.bats` covers explicit completed-session resume, legacy completed-session migration, and completed sessions stranded in `debugging/active/`.
- `tests/debug-session-lifecycle.bats` covers the `already_fixed -> complete -> explicit resume` lifecycle.
- `testing/verify-debug-session-contract.sh` continues to enforce the command-layer `session_status=complete` stop contract.

## QA summary

- Primary QA rounds completed: 3 (`qa-investigator`) — 0 legitimate findings, 0 false positives.
- Cross-model QA rounds completed: 1 (`qa-investigator-gpt-54` / GPT-5.4) — 0 legitimate findings, 0 false positives.
- Copilot PR review rounds completed so far: 0 (pending Phase 4.5 after draft PR creation).
