### PR TITLE
fix(debug-session): normalize completed no-verification results

### DIFF
--- a/scripts/compile-debug-session-context.sh
+++ b/scripts/compile-debug-session-context.sh
@@ -51,6 +51,18 @@ read_field() {
   ' "$SESSION_FILE"
 }
 
+display_result_label() {
+  local raw_value="${1:-}"
+  case "$raw_value" in
+    skipped_no_fix_required)
+      echo 'skipped — no fix required'
+      ;;
+    *)
+      echo "$raw_value"
+      ;;
+  esac
+}
+
 # Known top-level session section headings — must stay aligned with write-debug-session.sh.
 # Only these headings are treated as section boundaries; user-pasted ## headings inside
 # section content are preserved verbatim.
@@ -75,6 +87,8 @@ QA_ROUND=$(read_field "qa_round")
 QA_LAST=$(read_field "qa_last_result")
 UAT_ROUND=$(read_field "uat_round")
 UAT_LAST=$(read_field "uat_last_result")
+QA_LAST_DISPLAY=$(display_result_label "$QA_LAST")
+UAT_LAST_DISPLAY=$(display_result_label "$UAT_LAST")
 
 # Extract sections
 ISSUE_CONTENT=$(extract_section "Issue")
@@ -93,7 +107,7 @@ case "$CONTEXT_MODE" in
 **Session:** ${SESSION_ID}
 **Title:** ${TITLE}
 **Status:** ${STATUS}
-**QA Round:** ${QA_ROUND} (last result: ${QA_LAST})
+**QA Round:** ${QA_ROUND} (last result: ${QA_LAST_DISPLAY})
 
 ## Issue Summary
 
@@ -132,7 +146,7 @@ ENDCONTEXT
 **Session:** ${SESSION_ID}
 **Title:** ${TITLE}
 **Status:** ${STATUS}
-**UAT Round:** ${UAT_ROUND} (last result: ${UAT_LAST})
+**UAT Round:** ${UAT_ROUND} (last result: ${UAT_LAST_DISPLAY})
 
 ## Issue Summary
 
@@ -148,7 +162,7 @@ ${IMPL_CONTENT:-No implementation recorded.}
 
 ## Latest QA Result
 
-QA round ${QA_ROUND}: ${QA_LAST}
+QA round ${QA_ROUND}: ${QA_LAST_DISPLAY}
 ENDCONTEXT
 
     # Include QA details for UAT reference

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -18,9 +18,9 @@
 # State fields in frontmatter:
 #   status:          investigating | fix_applied | qa_pending | qa_failed | uat_pending | uat_failed | complete
 #   qa_round:        integer (0 = no QA yet)
-#   qa_last_result:  pending | pass | fail
+#   qa_last_result:  pending | skipped_no_fix_required | pass | fail
 #   uat_round:       integer (0 = no UAT yet)
-#   uat_last_result: pending | pass | issues_found
+#   uat_last_result: pending | skipped_no_fix_required | pass | issues_found
 #
 # Active pointer: <planning-dir>/debugging/.active-session (contains session filename)
 # Session files:  <planning-dir>/debugging/active/{YYYYMMDD-HHMMSS}-{slug}.md   (in-progress)
@@ -41,6 +41,7 @@ DEBUG_DIR="$PLANNING_DIR/debugging"
 ACTIVE_DIR="$DEBUG_DIR/active"
 COMPLETED_DIR="$DEBUG_DIR/completed"
 ACTIVE_FILE="$DEBUG_DIR/.active-session"
+SKIPPED_NO_FIX_REQUIRED="skipped_no_fix_required"
 
 # Valid status values
 VALID_STATUSES="investigating fix_applied qa_pending qa_failed uat_pending uat_failed complete"
@@ -164,6 +165,54 @@ safe_move_session() {
   echo "$dest"
 }
 
+# Normalize terminal metadata for completed standalone debug sessions that never ran QA/UAT.
+# This is intentionally idempotent: it only rewrites sessions that are complete,
+# still have zero QA/UAT rounds, and still carry the template-default pending results.
+normalize_completed_no_verification_results() {
+  local file="$1"
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+
+  local file_status qa_round uat_round qa_last_result uat_last_result now
+  file_status=$(read_field "$file" "status")
+  qa_round=$(read_field "$file" "qa_round")
+  uat_round=$(read_field "$file" "uat_round")
+  qa_last_result=$(read_field "$file" "qa_last_result")
+  uat_last_result=$(read_field "$file" "uat_last_result")
+
+  if [ "$file_status" != "complete" ] \
+    || [ "${qa_round:-0}" != "0" ] \
+    || [ "${uat_round:-0}" != "0" ] \
+    || [ "$qa_last_result" != "pending" ] \
+    || [ "$uat_last_result" != "pending" ]; then
+    return 0
+  fi
+
+  now=$(date '+%Y-%m-%d %H:%M:%S')
+  awk -v skipped="$SKIPPED_NO_FIX_REQUIRED" -v now="$now" '
+    BEGIN { in_fm = 0; delim = 0 }
+    $0 == "---" {
+      delim++
+      if (delim == 1) in_fm = 1
+      else if (delim == 2) in_fm = 0
+      print
+      next
+    }
+    in_fm && /^qa_last_result:/ {
+      print "qa_last_result: " skipped
+      next
+    }
+    in_fm && /^uat_last_result:/ {
+      print "uat_last_result: " skipped
+      next
+    }
+    in_fm && /^updated:/ {
+      print "updated: " now
+      next
+    }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
 # Reconcile a session's physical location with its frontmatter status.
 # - complete sessions belong in completed/
 # - all other statuses belong in active/
@@ -171,6 +220,7 @@ safe_move_session() {
 reconcile_session_location() {
   local file="$1"
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  normalize_completed_no_verification_results "$file" || return 1
 
   local file_status target_dir current_dir fname moved pointer collision_file
   file_status=$(read_field "$file" "status")
@@ -225,6 +275,7 @@ migrate_legacy_session() {
     echo "$file"
     return
   fi
+  normalize_completed_no_verification_results "$file" || return 1
   local fname
   fname=$(basename "$file")
   local file_status
@@ -355,9 +406,7 @@ find_latest_unresolved() {
   if [ -d "$COMPLETED_DIR" ]; then
     for f in "$COMPLETED_DIR"/*.md; do
       [ -f "$f" ] && [ ! -L "$f" ] || continue
-      if [ "$(read_field "$f" "status")" != "complete" ]; then
-        reconcile_session_location "$f" > /dev/null 2>&1 || true
-      fi
+      reconcile_session_location "$f" > /dev/null 2>&1 || true
     done
   fi
   # Collect candidates from active/ and any unmigrated legacy files
@@ -723,6 +772,7 @@ case "$CMD" in
     update_field "$SESSION_PATH" "status" "$STATUS"
     # Auto-move to completed/ when status transitions to complete
     if [ "$STATUS" = "complete" ]; then
+      normalize_completed_no_verification_results "$SESSION_PATH" || exit 1
       fname=$(basename "$SESSION_PATH")
       current_dir=$(dirname "$SESSION_PATH")
       if [ "$current_dir" != "$COMPLETED_DIR" ]; then

--- a/scripts/debug-session-state.sh
+++ b/scripts/debug-session-state.sh
@@ -79,6 +79,82 @@ read_field() {
   ' "$file"
 }
 
+DEBUG_SESSION_INSPECT_STATUS=""
+DEBUG_SESSION_INSPECT_QA_ROUND=""
+DEBUG_SESSION_INSPECT_UAT_ROUND=""
+DEBUG_SESSION_INSPECT_QA_LAST_RESULT=""
+DEBUG_SESSION_INSPECT_UAT_LAST_RESULT=""
+
+inspect_normalization_fields() {
+  local file="$1"
+  local old_ifs="$IFS"
+
+  IFS=$'\t' read -r \
+    DEBUG_SESSION_INSPECT_STATUS \
+    DEBUG_SESSION_INSPECT_QA_ROUND \
+    DEBUG_SESSION_INSPECT_UAT_ROUND \
+    DEBUG_SESSION_INSPECT_QA_LAST_RESULT \
+    DEBUG_SESSION_INSPECT_UAT_LAST_RESULT <<EOF
+$(awk '
+  BEGIN {
+    in_fm = 0
+    delim = 0
+    status = ""
+    qa_round = ""
+    uat_round = ""
+    qa_last_result = ""
+    uat_last_result = ""
+  }
+  $0 == "---" {
+    delim++
+    if (delim == 1) {
+      in_fm = 1
+      next
+    }
+    if (delim == 2) {
+      exit
+    }
+  }
+  !in_fm { next }
+  /^status:[[:space:]]*/ {
+    value = $0
+    sub(/^status:[[:space:]]*/, "", value)
+    status = value
+    next
+  }
+  /^qa_round:[[:space:]]*/ {
+    value = $0
+    sub(/^qa_round:[[:space:]]*/, "", value)
+    qa_round = value
+    next
+  }
+  /^uat_round:[[:space:]]*/ {
+    value = $0
+    sub(/^uat_round:[[:space:]]*/, "", value)
+    uat_round = value
+    next
+  }
+  /^qa_last_result:[[:space:]]*/ {
+    value = $0
+    sub(/^qa_last_result:[[:space:]]*/, "", value)
+    qa_last_result = value
+    next
+  }
+  /^uat_last_result:[[:space:]]*/ {
+    value = $0
+    sub(/^uat_last_result:[[:space:]]*/, "", value)
+    uat_last_result = value
+    next
+  }
+  END {
+    printf "%s\t%s\t%s\t%s\t%s\n", status, qa_round, uat_round, qa_last_result, uat_last_result
+  }
+' "$file")
+EOF
+
+  IFS="$old_ifs"
+}
+
 # Update a frontmatter field in a session file, scoped to the YAML frontmatter block only.
 # Uses awk to restrict replacement to lines between the opening and closing --- delimiters.
 update_field() {
@@ -170,14 +246,18 @@ safe_move_session() {
 # still have zero QA/UAT rounds, and still carry the template-default pending results.
 normalize_completed_no_verification_results() {
   local file="$1"
+  local fields_state="${2:-}"
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
 
   local file_status qa_round uat_round qa_last_result uat_last_result now
-  file_status=$(read_field "$file" "status")
-  qa_round=$(read_field "$file" "qa_round")
-  uat_round=$(read_field "$file" "uat_round")
-  qa_last_result=$(read_field "$file" "qa_last_result")
-  uat_last_result=$(read_field "$file" "uat_last_result")
+  if [ "$fields_state" != "preloaded" ]; then
+    inspect_normalization_fields "$file" || return 1
+  fi
+  file_status="$DEBUG_SESSION_INSPECT_STATUS"
+  qa_round="$DEBUG_SESSION_INSPECT_QA_ROUND"
+  uat_round="$DEBUG_SESSION_INSPECT_UAT_ROUND"
+  qa_last_result="$DEBUG_SESSION_INSPECT_QA_LAST_RESULT"
+  uat_last_result="$DEBUG_SESSION_INSPECT_UAT_LAST_RESULT"
 
   if [ "$file_status" != "complete" ] \
     || [ "${qa_round:-0}" != "0" ] \
@@ -211,6 +291,9 @@ normalize_completed_no_verification_results() {
     }
     { print }
   ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+  DEBUG_SESSION_INSPECT_QA_LAST_RESULT="$SKIPPED_NO_FIX_REQUIRED"
+  DEBUG_SESSION_INSPECT_UAT_LAST_RESULT="$SKIPPED_NO_FIX_REQUIRED"
 }
 
 # Reconcile a session's physical location with its frontmatter status.
@@ -220,10 +303,11 @@ normalize_completed_no_verification_results() {
 reconcile_session_location() {
   local file="$1"
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
-  normalize_completed_no_verification_results "$file" || return 1
+  inspect_normalization_fields "$file" || return 1
+  normalize_completed_no_verification_results "$file" preloaded || return 1
 
   local file_status target_dir current_dir fname moved pointer collision_file
-  file_status=$(read_field "$file" "status")
+  file_status="$DEBUG_SESSION_INSPECT_STATUS"
   if [ "$file_status" = "complete" ]; then
     target_dir="$COMPLETED_DIR"
   else
@@ -275,11 +359,12 @@ migrate_legacy_session() {
     echo "$file"
     return
   fi
-  normalize_completed_no_verification_results "$file" || return 1
+  inspect_normalization_fields "$file" || return 1
+  normalize_completed_no_verification_results "$file" preloaded || return 1
   local fname
   fname=$(basename "$file")
   local file_status
-  file_status=$(read_field "$file" "status")
+  file_status="$DEBUG_SESSION_INSPECT_STATUS"
   local target_dir
   if [ "$file_status" = "complete" ]; then
     target_dir="$COMPLETED_DIR"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -90,6 +90,42 @@ else
   fail "debug-session-state.sh set-status output contract drifted from status=..."
 fi
 
+if grep -Eq 'qa_last_result:[[:space:]]+pending \| skipped_no_fix_required \| pass \| fail' "$STATE_SCRIPT" 2>/dev/null; then
+  pass "debug-session-state.sh documents skipped_no_fix_required in qa_last_result vocabulary"
+else
+  fail "debug-session-state.sh missing skipped_no_fix_required in qa_last_result vocabulary"
+fi
+
+if grep -Eq 'uat_last_result:[[:space:]]+pending \| skipped_no_fix_required \| pass \| issues_found' "$STATE_SCRIPT" 2>/dev/null; then
+  pass "debug-session-state.sh documents skipped_no_fix_required in uat_last_result vocabulary"
+else
+  fail "debug-session-state.sh missing skipped_no_fix_required in uat_last_result vocabulary"
+fi
+
+if grep -q 'normalize_completed_no_verification_results()' "$STATE_SCRIPT" 2>/dev/null; then
+  pass "debug-session-state.sh has completed no-verification normalization helper"
+else
+  fail "debug-session-state.sh missing completed no-verification normalization helper"
+fi
+
+if awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$SESSION_PATH"'; then
+  pass "debug-session-state.sh set-status normalizes completed no-verification sessions before move"
+else
+  fail "debug-session-state.sh set-status missing completed no-verification normalization"
+fi
+
+if awk '/reconcile_session_location\(\)/,/^}/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$file"'; then
+  pass "debug-session-state.sh reconcile path normalizes completed no-verification sessions"
+else
+  fail "debug-session-state.sh reconcile path missing completed no-verification normalization"
+fi
+
+if awk '/migrate_legacy_session\(\)/,/^}/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$file"'; then
+  pass "debug-session-state.sh legacy migration normalizes completed no-verification sessions"
+else
+  fail "debug-session-state.sh legacy migration missing completed no-verification normalization"
+fi
+
 # — Writer script checks —
 
 WRITER="$ROOT/scripts/write-debug-session.sh"
@@ -107,6 +143,13 @@ for mode in source-todo investigation qa uat status; do
     fail "writer script missing mode: $mode"
   fi
 done
+
+INVESTIGATION_BLOCK="$(awk '/investigation\)/,/;;/' "$WRITER" 2>/dev/null || true)"
+if ! grep -Eq 'qa_last_result|uat_last_result' <<< "$INVESTIGATION_BLOCK"; then
+  pass "write-debug-session.sh investigation mode does not mutate QA/UAT result fields"
+else
+  fail "write-debug-session.sh investigation mode should not mutate QA/UAT result fields"
+fi
 
 # — Context compiler checks —
 
@@ -131,6 +174,20 @@ for mode in qa uat; do
     fail "context compiler missing mode: $mode"
   fi
 done
+
+if grep -Fq 'skipped — no fix required' "$COMPILER" 2>/dev/null; then
+  pass "context compiler has friendly label for skipped no-fix-required results"
+else
+  fail "context compiler missing friendly label for skipped no-fix-required results"
+fi
+
+if grep -Fq '**QA Round:** ${QA_ROUND} (last result: ${QA_LAST_DISPLAY})' "$COMPILER" 2>/dev/null \
+  && grep -Fq '**UAT Round:** ${UAT_ROUND} (last result: ${UAT_LAST_DISPLAY})' "$COMPILER" 2>/dev/null \
+  && grep -Fq 'QA round ${QA_ROUND}: ${QA_LAST_DISPLAY}' "$COMPILER" 2>/dev/null; then
+  pass "context compiler renders display-mapped QA/UAT result labels in all three summary sites"
+else
+  fail "context compiler still interpolates raw QA/UAT result labels in one or more summary sites"
+fi
 
 # — Command integration checks —
 

--- a/tests/debug-session-lifecycle.bats
+++ b/tests/debug-session-lifecycle.bats
@@ -111,10 +111,21 @@ assert_no_repeated_blank_lines() {
   [ -f "$SESSION_FILE" ]
   [[ "$SESSION_FILE" == *"/debugging/completed/"* ]]
   grep -q '^status: complete$' "$SESSION_FILE"
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$SESSION_FILE"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$SESSION_FILE"
   grep -q 'Already fixed before this investigation — no new fix commit was required\. If planning_tracking=commit, this completion path may create a planning-artifact commit\.' "$SESSION_FILE"
   grep -q 'No new changes were required because the current branch already contained the fix\.' "$SESSION_FILE"
   ! grep -q '### Round 1 — PASS' "$SESSION_FILE"
   ! grep -q '### Round 1 — pass' "$SESSION_FILE"
+
+  run bash "$SCRIPTS_DIR/compile-debug-session-context.sh" "$SESSION_FILE" qa
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**QA Round:** 0 (last result: skipped — no fix required)"* ]]
+
+  run bash "$SCRIPTS_DIR/compile-debug-session-context.sh" "$SESSION_FILE" uat
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**UAT Round:** 0 (last result: skipped — no fix required)"* ]]
+  [[ "$output" == *"QA round 0: skipped — no fix required"* ]]
 }
 
 @test "explicit resume does not reopen completed already-fixed session" {

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -383,6 +383,27 @@ teardown() {
   [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
   grep -q '^status: complete$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+}
+
+@test "set-status complete preserves existing verified results" {
+  eval "$(bash "$SCRIPTS_DIR/debug-session-state.sh" start "$VBW_PLANNING_DIR" "complete-preserve")"
+  local fname
+  fname=$(basename "$session_file")
+
+  echo '{"mode":"qa","round":1,"result":"PASS","checks":[{"id":"c1","description":"QA check","status":"PASS","evidence":"ok"}]}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$session_file" > /dev/null
+  echo '{"mode":"uat","round":1,"result":"pass","checkpoints":[{"description":"UAT check","result":"pass","user_response":"verified"}]}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$session_file" > /dev/null
+
+  bash "$SCRIPTS_DIR/debug-session-state.sh" set-status "$VBW_PLANNING_DIR" complete > /dev/null
+
+  [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  grep -q '^qa_round: 1$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^qa_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_round: 1$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
 }
 
 @test "set-status complete clears active pointer" {
@@ -469,6 +490,8 @@ teardown() {
   # Legacy file should be migrated to completed/
   [ ! -f "$legacy_file" ]
   [ -f "$VBW_PLANNING_DIR/debugging/completed/${session_id}.md" ]
+  grep -q '^qa_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/${session_id}.md"
+  grep -q '^uat_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/${session_id}.md"
 }
 
 @test "list emits warning to stderr when legacy migration fails" {
@@ -778,6 +801,33 @@ EOF
   [[ "$output" == *"active_session=none"* ]]
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$session_name" ]
   [ ! -f "$VBW_PLANNING_DIR/debugging/$session_name" ]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+}
+
+@test "get-or-latest normalizes canonical completed session with skipped verification results" {
+  local session_name="20240101-120000-canonical-done.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-canonical-done
+title: canonical-done
+status: complete
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:00:00
+qa_round: 0
+qa_last_result: pending
+uat_round: 0
+uat_last_result: pending
+---
+# Canonical completed session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=none"* ]]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
 }
 
 @test "get returns none for stale pointer to completed session" {

--- a/tests/debug-session-state.bats
+++ b/tests/debug-session-state.bats
@@ -600,6 +600,8 @@ EOF
   printf '%s\n' "$output" | grep -Eq '^session_status=complete$'
   [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
   [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
 }
 
@@ -729,6 +731,8 @@ EOF
   # File should be physically moved
   [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
 }
 
 @test "get returns none after self-heal of completed session in active" {
@@ -747,6 +751,8 @@ EOF
   # File moved to completed/, pointer cleared
   [ -f "$VBW_PLANNING_DIR/debugging/completed/$fname" ]
   [ ! -f "$VBW_PLANNING_DIR/debugging/active/$fname" ]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname"
   [ ! -f "$VBW_PLANNING_DIR/debugging/.active-session" ]
 }
 
@@ -773,6 +779,8 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"active_session=fallback"* ]]
   [[ "$output" == *"fallback-b"* ]]
+  grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname_a"
+  grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$fname_a"
 }
 
 @test "get returns none after legacy migration of completed session" {
@@ -805,7 +813,7 @@ EOF
   grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
 }
 
-@test "get-or-latest normalizes canonical completed session with skipped verification results" {
+@test "get-or-latest normalizes canonical completed session with pending no-verification results" {
   local session_name="20240101-120000-canonical-done.md"
   mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
   cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
@@ -828,6 +836,33 @@ EOF
   [[ "$output" == *"active_session=none"* ]]
   grep -q '^qa_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
   grep -q '^uat_last_result: skipped_no_fix_required$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+}
+
+@test "get-or-latest preserves verified results for canonical completed session" {
+  local session_name="20240101-120000-canonical-verified.md"
+  mkdir -p "$VBW_PLANNING_DIR/debugging/completed"
+  cat > "$VBW_PLANNING_DIR/debugging/completed/$session_name" << 'EOF'
+---
+session_id: 20240101-120000-canonical-verified
+title: canonical-verified
+status: complete
+created: 2024-01-01 12:00:00
+updated: 2024-01-01 12:00:00
+qa_round: 1
+qa_last_result: pass
+uat_round: 1
+uat_last_result: pass
+---
+# Canonical completed verified session
+EOF
+
+  run bash "$SCRIPTS_DIR/debug-session-state.sh" get-or-latest "$VBW_PLANNING_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"active_session=none"* ]]
+  grep -q '^qa_round: 1$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+  grep -q '^qa_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+  grep -q '^uat_round: 1$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
+  grep -q '^uat_last_result: pass$' "$VBW_PLANNING_DIR/debugging/completed/$session_name"
 }
 
 @test "get returns none for stale pointer to completed session" {

--- a/tests/write-debug-session.bats
+++ b/tests/write-debug-session.bats
@@ -59,6 +59,21 @@ teardown() {
   grep -q "Fix crash in src/lib/parser.sh & helpers" "$SESSION_FILE"
 }
 
+@test "investigation mode does not mutate QA or UAT result fields" {
+  echo '{"mode":"qa","round":2,"result":"PASS","checks":[{"id":"C1","description":"Existing QA","status":"PASS","evidence":"ok"}]}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE" > /dev/null
+  echo '{"mode":"uat","round":1,"result":"issues_found","checkpoints":[{"description":"Existing UAT","result":"issue","user_response":"still broken"}],"issues":[{"description":"Known issue","severity":"major"}]}' \
+    | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE" > /dev/null
+
+  run bash -c 'echo '"'"'{"mode":"investigation","issue":"Fresh investigation","hypotheses":[],"root_cause":"New root cause","plan":"New plan","changed_files":["src/new.sh"],"commit":"def456"}'"'"' | bash "$SCRIPTS_DIR/write-debug-session.sh" "$SESSION_FILE"'
+  [ "$status" -eq 0 ]
+
+  grep -q '^qa_round: 2$' "$SESSION_FILE"
+  grep -q '^qa_last_result: pass$' "$SESSION_FILE"
+  grep -q '^uat_round: 1$' "$SESSION_FILE"
+  grep -q '^uat_last_result: issues_found$' "$SESSION_FILE"
+}
+
 # ── qa mode (array format) ───────────────────────────────
 
 @test "qa mode handles checks as array of objects" {


### PR DESCRIPTION
Fixes #521

## What
This change normalizes standalone `/vbw:debug` sessions that complete without inline QA/UAT so they no longer retain template-default `pending` verification results. `scripts/debug-session-state.sh` now rewrites those terminal no-verification sessions to `skipped_no_fix_required` when they are completed, reconciled, or migrated; `scripts/compile-debug-session-context.sh` renders that terminal state as `skipped — no fix required`; and the BATS/contract coverage was extended around completion, reconciliation, migration, and investigation-mode non-mutation behavior.

## Why
The issue was not a flaky write. The debug-session lifecycle had no terminal metadata state for “completed without verification”, so complete sessions could retain `qa_last_result: pending` and `uat_last_result: pending`. The fix restores the invariant that a completed standalone debug session must never present non-terminal verification metadata, while avoiding a broader outcome-schema change in this PR.

## How
- `scripts/debug-session-state.sh`: adds idempotent normalization for completed zero-round sessions and invokes it from completion, reconciliation, and legacy migration paths.
- `scripts/compile-debug-session-context.sh`: maps the normalized terminal value to `skipped — no fix required` in QA/UAT summaries.
- `testing/verify-debug-session-contract.sh`: validates the documented frontmatter vocabulary includes the new terminal value.
- `tests/debug-session-lifecycle.bats`: covers already-fixed/no-verification completion and friendly compiled context output.
- `tests/debug-session-state.bats`: covers completion-time normalization, canonical completed-session normalization on read, legacy migration normalization, and preservation of verified flows.
- `tests/write-debug-session.bats`: locks in that investigation-mode writes do not mutate QA/UAT result fields.

## Acceptance criteria verification
1. `scripts/debug-session-state.sh set-status ... complete` normalizes `qa_last_result` and `uat_last_result` from `pending` to `skipped_no_fix_required` when `qa_round=0` and `uat_round=0`.
   - Satisfied by `normalize_completed_no_verification_results()` and the `set-status complete` path in `scripts/debug-session-state.sh:171-207` and `scripts/debug-session-state.sh:775`; covered by `tests/debug-session-state.bats:372`.
2. Canonical completed sessions with zero rounds and pending results are normalized when touched through reconciliation, `get`, `get-or-latest`, `resume`, or `list` paths.
   - Satisfied by `reconcile_session_location()` in `scripts/debug-session-state.sh:220-266`, which is reached by the read/list paths; covered by `tests/debug-session-state.bats:808` and adjacent canonical completed-session cases.
3. Legacy flat-path completed sessions with zero rounds and pending results are normalized during migration into `debugging/completed/`.
   - Satisfied by `migrate_legacy_session()` in `scripts/debug-session-state.sh:269-303`; covered by the legacy-migration cases in `tests/debug-session-state.bats`.
4. Sessions that already contain verified terminal results (`pass`, `fail`, `issues_found`) remain unchanged.
   - Satisfied by the normalizer guards in `scripts/debug-session-state.sh:171-189`, which only rewrite `complete + qa_round=0 + uat_round=0 + both pending`; preserved-flow coverage remains in `tests/debug-session-state.bats`.
5. `scripts/compile-debug-session-context.sh` renders `skipped_no_fix_required` as `skipped — no fix required` in the QA Round line, UAT Round line, and UAT Latest QA Result line.
   - Satisfied by `display_result_label()` and its call sites in `scripts/compile-debug-session-context.sh:54-58`, `:90-91`, `:110`, `:149`, and `:163`; covered by `tests/debug-session-lifecycle.bats:101`.
6. `scripts/write-debug-session.sh` investigation-mode writes do not mutate QA/UAT result fields directly.
   - Satisfied by the explicit regression coverage in `tests/write-debug-session.bats:62`.
7. Targeted bats coverage verifies completion-time normalization, canonical-session normalization on later reads, legacy migration normalization, friendly context rendering, and preservation of normal verified flows.
   - Satisfied by `tests/debug-session-lifecycle.bats:101`, `tests/debug-session-state.bats:372`, `tests/debug-session-state.bats:808`, and `tests/write-debug-session.bats:62`.
8. `bash testing/verify-debug-session-contract.sh` passes.
   - Passed locally on this branch.
9. `bash testing/run-all.sh` passes.
   - Passed locally on this branch.

## Testing
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bats tests/debug-session-state.bats`
- [x] `bats tests/debug-session-lifecycle.bats`
- [x] `bats tests/write-debug-session.bats`
- [x] `bash testing/run-all.sh`

## QA summary
- Primary QA rounds completed: 1 (`qa-investigator`), clean round, 0 legitimate findings, 0 false positives; recorded by empty commit `63f73987`.
- Cross-model QA rounds completed: skipped by the model gate because this session is GPT-5.4, so `qa-investigator-gpt-54` would be same-family validation.
- Copilot PR review rounds completed: 0 so far; Phase 4.5 starts after draft PR creation.
