### PR TITLE
Replace /vbw:config pseudo-menu with bounded structured prompts

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -159,7 +159,7 @@ If `SETTING=auto_push`, AskUserQuestion with 1 question:
 
 Store the selected value in variable `VALUE`.
 
-After a core setting value is chosen, apply it with the same validation, write behavior, and side effects as the `/vbw:config <setting> <value>` path below, then continue to Step 4 for no-args tail behavior.
+After a core setting value is chosen, continue to Step 3 and apply it there with the same validation, write behavior, and side effects as the `/vbw:config <setting> <value>` path below. Step 4 remains the no-args tail behavior after that shared apply step.
 
 **Step 2.7:** If `CONFIG_SECTION = "Model profile"`, AskUserQuestion with 1 question:
 - header: `Models`
@@ -288,7 +288,7 @@ else
 fi
 ```
 
-**Step 3:** Apply changes to config.json. Display ✓ per changed setting with ➜. No changes: "✓ No changes made."
+**Step 3:** Apply changes to config.json. This is the shared apply step for no-args core-setting changes and preset-model-profile changes. Display ✓ per changed setting with ➜. No changes: "✓ No changes made."
 
 **Step 4: Profile drift detection** — if effort/autonomy/verification_tier changed:
 - Compare against active profile's expected values

--- a/commands/config.md
+++ b/commands/config.md
@@ -171,7 +171,7 @@ After a core setting value is chosen, continue to Step 3 and apply it there with
 Store selection in variable `PROFILE_METHOD`.
 
 **Branching:**
-- If `PROFILE_METHOD = "Use preset profile"`: AskUserQuestion with 1 question and 3 options (`quality`, `balanced`, `budget`). Apply the selected profile using the `Model profile switching` logic below.
+- If `PROFILE_METHOD = "Use preset profile"`: AskUserQuestion with 1 question and 3 options (`quality`, `balanced`, `budget`). Store the selected preset in `PROFILE`, then continue to Step 3 and apply it there using the `Model profile switching` logic below.
 - If `PROFILE_METHOD = "Configure each agent individually"`: Proceed to individual agent configuration flow (Round 1 below).
 
 **Individual Configuration - Round 1 (4 agents):**

--- a/commands/config.md
+++ b/commands/config.md
@@ -82,35 +82,96 @@ echo "  Lead: $LEAD_DISPLAY | Dev: $DEV_DISPLAY | QA: $QA_DISPLAY | Scout: $SCOU
 
 Note: Core infrastructure flags (v2_hard_contracts, v2_hard_gates, v2_typed_protocol, v2_role_isolation, v3_event_log, v3_delta_context, v3_context_cache, v3_plan_research_persist, v3_schema_validation, v3_contract_lite, v3_lock_lite) have graduated to always-on behavior. The remaining flags are configurable under unprefixed names (see Settings Reference below). Brownfield configs with old `v2_`/`v3_` prefixed keys are auto-migrated by `migrate-config.sh`.
 
-**Step 2:** AskUserQuestion — present settings as a numbered list in the question text (do NOT use `options` array — a single freeform question avoids the 4-option limit):
+**Step 2:** AskUserQuestion with 1 question:
+- header: `Config`
+- question: `What would you like to adjust?`
+- options:
+  - `Core settings` — Effort, autonomy, planning tracking, auto push
+  - `Model profile` — Preset profile or per-agent overrides
+  - `Exit` — Leave config unchanged
 
-Question text:
-```
-Which setting would you like to change?
-1. Effort — current: {effort value}  (thorough | balanced | fast | turbo)
-2. Autonomy — current: {autonomy value}  (cautious | standard | confident | pure-vibe)
-3. Planning tracking — current: {tracking value}  (manual | ignore | commit)
-4. Auto push — current: {auto_push value}  (never | after_phase | always)
-5. Model Profile
-Type a number (1-5):
-```
+Store selection in variable `CONFIG_SECTION`.
 
-Parse the user's freeform response using these rules:
-- Accept only a single digit `1`, `2`, `3`, `4`, or `5`, with optional leading/trailing whitespace.
-- Treat anything else as invalid (punctuation like `2.`, words like `two`, mixed text like `option 2`, multiple numbers, empty input, or out-of-range values like `0` or `6`).
-- If invalid, show `Invalid selection. Please type a single number from 1 to 5.` and AskUserQuestion again with the same question text.
-- Repeat until a valid selection is obtained.
+For every bounded AskUserQuestion branch below that uses visible options, the built-in `Other` path is still part of that question:
+- accept direct option intent that clearly matches a visible choice
+- accept unambiguous visible option-by-number replies (for example `#1`, `option 2`, or `2` when it clearly maps to one visible option)
+- accept hybrid replies anchored to one visible option number (for example `#2 please`)
+- re-ask only when the reply is ambiguous or invalid for that same question
+- do NOT add an extra visible `Other` option — keep these prompts within the 2–4 option sweet spot
 
-Map: 1 = Effort, 2 = Autonomy, 3 = Planning tracking, 4 = Auto push, 5 = Model Profile.
+If `CONFIG_SECTION = "Exit"`:
+- Display `✓ No changes made.`
+- Run `bash "{plugin-root}/scripts/suggest-next.sh" config` and display.
+- STOP.
 
-**Step 2.5:** If "Model Profile" was selected (5), AskUserQuestion with 2 options:
-- Use preset profile (quality/balanced/budget)
-- Configure each agent individually (6 questions)
+**Step 2.5:** If `CONFIG_SECTION = "Core settings"`, AskUserQuestion with 1 question:
+- header: `Core`
+- question: `Which core setting do you want to change?`
+- options:
+  - `Effort` — current: {effort value}  (thorough | balanced | fast | turbo)
+  - `Autonomy` — current: {autonomy value}  (cautious | standard | confident | pure-vibe)
+  - `Planning tracking` — current: {tracking value}  (manual | ignore | commit)
+  - `Auto push` — current: {auto_push value}  (never | after_phase | always)
+
+Store selection in variable `SETTING_GROUP`.
+
+Map:
+- `Effort` → `SETTING=effort`
+- `Autonomy` → `SETTING=autonomy`
+- `Planning tracking` → `SETTING=planning_tracking`
+- `Auto push` → `SETTING=auto_push`
+
+**Step 2.6:** Ask the bounded value question for the selected core setting.
+
+If `SETTING=effort`, AskUserQuestion with 1 question:
+- header: `Effort`
+- question: `Choose effort level.`
+- options:
+  - `thorough` — Maximum planning and verification depth
+  - `balanced` — Default depth for most work
+  - `fast` — Lighter planning, quicker verification
+  - `turbo` — Minimal ceremony, fastest path
+
+If `SETTING=autonomy`, AskUserQuestion with 1 question:
+- header: `Autonomy`
+- question: `Choose autonomy level.`
+- options:
+  - `cautious` — Confirm more often
+  - `standard` — Default phase-by-phase flow
+  - `confident` — Fewer confirmations
+  - `pure-vibe` — Full auto loop through phases
+
+If `SETTING=planning_tracking`, AskUserQuestion with 1 question:
+- header: `Tracking`
+- question: `How should planning artifacts be tracked?`
+- options:
+  - `manual` — Leave planning files for manual git handling
+  - `ignore` — Keep `.vbw-planning/` out of git
+  - `commit` — Auto-commit planning artifacts
+
+If `SETTING=auto_push`, AskUserQuestion with 1 question:
+- header: `Auto push`
+- question: `When should VBW push automatically?`
+- options:
+  - `never` — Never push automatically
+  - `after_phase` — Push once after each phase
+  - `always` — Push after every commit
+
+Store the selected value in variable `VALUE`.
+
+After a core setting value is chosen, apply it with the same validation, write behavior, and side effects as the `/vbw:config <setting> <value>` path below, then continue to Step 4 for no-args tail behavior.
+
+**Step 2.7:** If `CONFIG_SECTION = "Model profile"`, AskUserQuestion with 1 question:
+- header: `Models`
+- question: `How do you want to configure model behavior?`
+- options:
+  - `Use preset profile` — quality, balanced, or budget
+  - `Configure each agent individually` — 6 per-agent model questions
 
 Store selection in variable `PROFILE_METHOD`.
 
 **Branching:**
-- If `PROFILE_METHOD = "Use preset profile"`: AskUserQuestion with 3 options (quality | balanced | budget). Apply selected profile using model profile switching logic (lines 88-130).
+- If `PROFILE_METHOD = "Use preset profile"`: AskUserQuestion with 1 question and 3 options (`quality`, `balanced`, `budget`). Apply the selected profile using the `Model profile switching` logic below.
 - If `PROFILE_METHOD = "Configure each agent individually"`: Proceed to individual agent configuration flow (Round 1 below).
 
 **Individual Configuration - Round 1 (4 agents):**


### PR DESCRIPTION
Fixes #485

## What
This PR replaces `/vbw:config`'s top-level pseudo-menu with a bounded structured AskUserQuestion flow. `commands/config.md` now uses a 3-option first screen (`Core settings`, `Model profile`, `Exit`) and a 4-option second screen for core settings, while leaving the existing preset-model and per-agent model flows intact.

## Why
Issue #485 calls out that the previous flow looked like a bounded chooser but was actually a freeform numeric parser (`Type a number (1-5)` with re-prompt rules). That violated the AskUserQuestion interaction guidance for small fixed choice sets. The new design fixes the root cause by expressing the choice hierarchy as actual bounded prompts instead of teaching the model to emulate a parser.

## How
- `commands/config.md` — replaced the top-level 5-item typed-number prompt with a 3-option bounded section chooser; added a 4-option core-settings sub-chooser; added bounded value choosers for `effort`, `autonomy`, `planning_tracking`, and `auto_push`; clarified the shared apply-step handoff for both core-setting and preset-model-profile paths; preserved the existing model-profile method split, direct-path write semantics, `Exit` no-op path, `planning_tracking` side effect, and downstream `suggest-next` behavior.
- No other files changed.

## Acceptance criteria verification
1. Top-level settings selection no longer relies on a freeform numeric parser.
   - Satisfied by `commands/config.md:85-105`; the old `Type a number (1-5)` flow is removed.
2. The replacement flow uses bounded structured AskUserQuestion prompts sized to the documented interaction sweet spot.
   - Satisfied by `commands/config.md:85-175`; visible option counts are kept within the 2–4 option range across the new selection path.
3. The rest of the config workflow continues to use structured choices where appropriate (profiles, model choices, yes/no prompts).
   - Satisfied by `commands/config.md:164-175` and `commands/config.md:213-233`; model profile, preset-profile, and per-agent model flows remain structured.
4. Truly unbounded input remains freeform only when it is actually needed.
   - Satisfied by removing the faux bounded freeform parser from the touched flow; the changed no-args path is now fully bounded in `commands/config.md:85-175`.
5. Config semantics and writes are unchanged apart from prompt UX.
   - Satisfied by `commands/config.md:162`, `commands/config.md:173-175`, `commands/config.md:291-329`, and `commands/config.md:342-419`; both no-args branches route into the existing apply logic, `planning_tracking` still runs `planning-git.sh`, and model profile / override logic remains intact.
6. Files touched are limited to `commands/config.md` and directly affected tests/contracts unless a small shared-reference touch is strictly required.
   - Satisfied: only `commands/config.md` changed.
7. `bash testing/run-all.sh` passes.
   - Satisfied locally and in CI; see Testing and QA summary below.

## Testing
- [x] `bash testing/verify-askuserquestion-contract.sh`
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/verify-config-defaults-sync.sh`
- [x] `bash testing/verify-issue-157-migration-contract.sh`
- [x] `bats tests/planning-git-callsites.bats`
- [x] `bash testing/run-all.sh`
- [x] `bash testing/run-all.sh` after pre-PR main sync
- [x] `bash testing/run-all.sh` before marking ready for review
- [x] `bash testing/run-all.sh` after Copilot review round 1 fix
- [x] `bash testing/run-all.sh` after Copilot review round 2 fix
- [x] GitHub Actions required checks green on current head

### Coverage notes
- `testing/verify-askuserquestion-contract.sh` guards the bounded-choice contract and numbered-list workaround rules.
- `testing/verify-config-defaults-sync.sh` ensures the config command’s settings reference table stayed in sync after the prompt rewrite.
- `bats tests/planning-git-callsites.bats` covers the preserved `planning_tracking` helper callsite invariant.

## QA summary
- Primary QA: 1 round with `qa-investigator` — clean, 0 findings, recorded in commit `9bbd507`.
- Cross-model QA: skipped because this session is GPT-class, so `qa-investigator-gpt-54` would not provide a different model-family review.
- Copilot PR review: 3 rounds total.
  - Round 1 found 1 wording-flow ambiguity, fixed in `56774a0`.
  - Round 2 found 1 sibling wording-flow ambiguity, fixed in `825a598`.
  - Round 3 returned clean with zero unresolved Copilot threads.
- CI/CD: all 18 required checks passed on `825a598`.
