### PR TITLE
fix(testing): harden archive contract block matching

### DIFF
--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -76,6 +76,64 @@ trim() {
   printf '%s' "$value"
 }
 
+normalize_block_whitespace() {
+  tr '\r\n\t' '   ' | awk '
+    {
+      gsub(/[[:space:]]+/, " ")
+      sub(/^ /, "")
+      sub(/ $/, "")
+      print
+    }
+  '
+}
+
+extract_heading_block() {
+  local file="$1"
+  local heading="$2"
+  local end_regex="$3"
+
+  awk -v h="$heading" -v end_re="$end_regex" '
+    function trim_line(s) {
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+
+    {
+      line=$0
+      gsub(/\r/, "", line)
+      trimmed=trim_line(line)
+
+      if (trimmed == h) {
+        found=1
+        print line
+        next
+      }
+
+      if (found && trimmed ~ end_re) {
+        exit
+      }
+
+      if (found) {
+        print line
+      }
+    }
+  ' "$file"
+}
+
+block_contains_normalized() {
+  local block="$1"
+  local expected="$2"
+  local normalized_block=""
+  local normalized_expected=""
+
+  normalized_block=$(printf '%s' "$block" | normalize_block_whitespace)
+  normalized_expected=$(printf '%s' "$expected" | normalize_block_whitespace)
+  [ -n "$normalized_expected" ] || return 1
+
+  printf '%s\n' "$normalized_block" | grep -Fq -- "$normalized_expected"
+}
+
 has_allowed_tool() {
   local allowed="$1"
   local target="$2"
@@ -191,13 +249,7 @@ echo "=== AskUserQuestion Contract Verification ==="
 
 ASK_USER_QUESTION_REF="$ROOT/references/ask-user-question.md"
 VIBE_COMMAND_FILE="$COMMANDS_DIR/vibe.md"
-VIBE_CONFIRMATION_BLOCK="$({
-  awk '
-    /^### Confirmation Gate$/ { in_block=1; print; next }
-    in_block && /^## / { exit }
-    in_block { print }
-  ' "$VIBE_COMMAND_FILE"
-} || true)"
+VIBE_CONFIRMATION_BLOCK="$(extract_heading_block "$VIBE_COMMAND_FILE" "### Confirmation Gate" '^## ' || true)"
 
 if [ -f "$ASK_USER_QUESTION_REF" ]; then
   pass "ask-user-question: shared reference exists"
@@ -700,13 +752,42 @@ fi
 echo ""
 echo "=== Milestone Context Refresh Verification ==="
 mode_block() {
-  local heading="$1"
-  awk -v h="$heading" '
-    $0 == h { found=1; print; next }
-    found && /^### Mode: / { exit }
-    found { print }
-  ' "$VIBE_FILE"
+  extract_heading_block "$VIBE_FILE" "$1" '^### Mode: '
 }
+
+echo ""
+echo "=== Mode Block Helper Regression Verification ==="
+
+_mode_helper_tmp_dir="$(mktemp -d)"
+_mode_helper_fixture="$_mode_helper_tmp_dir/mode-block-fixture.md"
+printf '%s' $'### Mode: Archive   \r\n9b. Post-archive hook (non-blocking): after successful archive completion, run:\r\n  MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh\r\n    .vbw-planning)\r\n### Mode: Next\r\nignored\r\n' > "$_mode_helper_fixture"
+_mode_helper_block="$(extract_heading_block "$_mode_helper_fixture" "### Mode: Archive" '^### Mode: ' || true)"
+
+if [ -n "$_mode_helper_block" ]; then
+  pass "mode-block helper extracts mode blocks with trailing-space/CRLF headings"
+else
+  fail "mode-block helper failed to extract mode block with trailing-space/CRLF heading"
+fi
+
+if block_contains_normalized "$_mode_helper_block" 'MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh .vbw-planning)'; then
+  pass "mode-block helper matches wrapped milestone slug command after whitespace normalization"
+else
+  fail "mode-block helper missed wrapped milestone slug command after whitespace normalization"
+fi
+
+if printf '%s\n' "$_mode_helper_block" | grep -Fq 'ignored'; then
+  fail "mode-block helper did not stop at the next mode heading"
+else
+  pass "mode-block helper stops at the next mode heading"
+fi
+
+if block_contains_normalized "$_mode_helper_block" 'MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/not-the-helper.sh .vbw-planning)'; then
+  fail "mode-block helper normalization produced a false positive for the wrong helper path"
+else
+  pass "mode-block helper normalization rejects wrong helper paths"
+fi
+
+rm -rf "$_mode_helper_tmp_dir"
 
 for mode in "### Mode: Add Phase" "### Mode: Insert Phase" "### Mode: Remove Phase"; do
   block=$(mode_block "$mode")
@@ -751,7 +832,7 @@ else
   fail "vibe: Archive mode missing explicit post-archive hook step"
 fi
 
-if printf '%s\n' "$archive_block" | tr '\n' ' ' | grep -Eq 'MILESTONE_SLUG=\$\(bash /tmp/\.vbw-plugin-root-link-\$\{CLAUDE_SESSION_ID:-default\}/scripts/derive-milestone-slug\.sh \.vbw-planning\)'; then
+if block_contains_normalized "$archive_block" 'MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh .vbw-planning)'; then
   pass "vibe: Archive mode derives milestone slug via derive-milestone-slug.sh"
 else
   fail "vibe: Archive mode missing deterministic milestone slug derivation"
@@ -769,7 +850,7 @@ else
   pass "vibe: Archive mode keeps milestone slug separate from custom --tag"
 fi
 
-if printf '%s\n' "$archive_block" | grep -Fq 'bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/post-archive-hook.sh "{SLUG}" ".vbw-planning/milestones/{SLUG}" "{tag}" .vbw-planning/config.json'; then
+if block_contains_normalized "$archive_block" 'bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/post-archive-hook.sh "{SLUG}" ".vbw-planning/milestones/{SLUG}" "{tag}" .vbw-planning/config.json'; then
   pass "vibe: Archive mode wires post-archive hook with slug/archive/tag/config arguments"
 else
   fail "vibe: Archive mode missing post-archive hook argument contract"


### PR DESCRIPTION
Fixes #531

## What

This change hardens the archive-mode contract checks in `testing/verify-commands-contract.sh` so they verify the semantic presence of the deterministic milestone-slug helper call instead of depending on one fragile whitespace shape. The fix keeps `commands/vibe.md` and archive runtime behavior unchanged; it only strengthens the contract harness by making block extraction tolerant of trailing-space/CRLF headings, normalizing wrapped shell snippets before matching, and adding an in-script synthetic regression for the helper behavior.

## Why

Issue #531 was a flaky contract failure, not evidence that archive mode was actually missing the slug derivation call. The underlying problem was that the harness relied on exact heading extraction and newline-only flattening, so a valid archive block could be misread when line endings or line wrapping differed. Hardening the verifier is the correct architectural fix because the invariant is "Archive mode still contains the deterministic helper call," not "the command appears in exactly one whitespace layout."

## How

- `testing/verify-commands-contract.sh` — added reusable helper functions to extract heading-scoped blocks with CRLF/trailing-space tolerance, normalize whitespace for multi-line shell-snippet matching, and validate normalized substrings.
- `testing/verify-commands-contract.sh` — replaced the archive slug assertion with normalized semantic matching and applied the same normalized matcher to the post-archive hook argument contract.
- `testing/verify-commands-contract.sh` — added a synthetic helper regression section that proves the extractor handles CRLF/trailing-space mode headings, matches the wrapped `derive-milestone-slug.sh` call, stops at the next mode heading, and rejects an incorrect helper path.
- `commands/vibe.md` — audited only; no change was needed because the deterministic helper call was already present.
- `scripts/derive-milestone-slug.sh` / `tests/derive-milestone-slug.bats` — audited as source-of-truth runtime coverage; no behavior change was required.

## Acceptance criteria verification

1. `testing/verify-commands-contract.sh` extracts the `### Mode: Archive` block even when the heading has trailing whitespace or CRLF line endings.
   - Satisfied by the new `extract_heading_block` helper in `testing/verify-commands-contract.sh` and the synthetic regression check `mode-block helper extracts mode blocks with trailing-space/CRLF headings`.
2. The archive milestone-slug assertion in `testing/verify-commands-contract.sh` matches the deterministic `derive-milestone-slug.sh` call even when the shell snippet is line-wrapped or otherwise whitespace-normalized differently.
   - Satisfied by `normalize_block_whitespace`, `block_contains_normalized`, and the updated archive assertion `vibe: Archive mode derives milestone slug via derive-milestone-slug.sh`.
3. The contract coverage rejects an incorrect helper path while still matching the correct wrapped `derive-milestone-slug.sh` invocation.
   - Satisfied by the synthetic helper regression checks for the wrapped positive case and the wrong-helper negative case in `testing/verify-commands-contract.sh`.
4. `commands/vibe.md` still contains the deterministic `MILESTONE_SLUG=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/derive-milestone-slug.sh .vbw-planning)` call.
   - Verified by the unchanged `commands/vibe.md` archive block and by the updated contract assertion passing in local verification.
5. `bash testing/verify-commands-contract.sh` and `bash testing/run-all.sh` pass after the fix.
   - Verified locally in this branch.

## Testing

- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/run-all.sh`

Additional coverage notes:
- The contract script now includes a synthetic regression fixture for block extraction and normalized shell-snippet matching, so the whitespace/CRLF failure mode is covered directly where it matters.

## QA summary

- Primary QA rounds completed: 1 (`qa-investigator`) — round 1 clean, no legitimate findings.
- Cross-model QA rounds completed: skipped due GPT-class session model; no different-model cross-check was available under the workflow gate.
- Copilot PR review rounds completed: 0 at draft creation time; Phase 4.5 follows after the draft PR is opened and marked ready.

## Commits

- `3c5ecc73` — `fix(testing): harden archive contract block matching`
- `db013f59` — `fix(testing): address QA round 1`
