### PR TITLE
fix(testing): harden verifier pipelines under pipefail

### DIFF
--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -16,6 +16,7 @@ printf '%s\t%s\n' \
   claude-bootstrap             scripts/verify-claude-bootstrap.sh \
   bash-scripts-contract        testing/verify-bash-scripts-contract.sh \
   commands-contract            testing/verify-commands-contract.sh \
+  pipefail-safety             testing/verify-pipefail-safety.sh \
   no-inline-exec-spans         testing/verify-no-inline-exec-spans.sh \
   issue-157-migration          testing/verify-issue-157-migration-contract.sh \
   plugin-root-resolution       testing/verify-plugin-root-resolution.sh \

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -16,7 +16,7 @@ printf '%s\t%s\n' \
   claude-bootstrap             scripts/verify-claude-bootstrap.sh \
   bash-scripts-contract        testing/verify-bash-scripts-contract.sh \
   commands-contract            testing/verify-commands-contract.sh \
-  pipefail-safety             testing/verify-pipefail-safety.sh \
+  pipefail-safety              testing/verify-pipefail-safety.sh \
   no-inline-exec-spans         testing/verify-no-inline-exec-spans.sh \
   issue-157-migration          testing/verify-issue-157-migration-contract.sh \
   plugin-root-resolution       testing/verify-plugin-root-resolution.sh \

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -91,7 +91,7 @@ contains_literal() {
   local haystack="$1"
   local needle="$2"
 
-  [[ "$haystack" == *"$needle"* ]]
+  grep -Fq -- "$needle" <<< "$haystack"
 }
 
 frontmatter_first_scalar() {

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -87,6 +87,83 @@ normalize_block_whitespace() {
   '
 }
 
+contains_literal() {
+  local haystack="$1"
+  local needle="$2"
+
+  [[ "$haystack" == *"$needle"* ]]
+}
+
+frontmatter_first_scalar() {
+  local frontmatter="$1"
+  local field="$2"
+
+  awk -v field="$field" '
+    BEGIN {
+      pattern = "^" field ":[[:space:]]*"
+    }
+
+    $0 ~ pattern && first == "" {
+      line = $0
+      sub(pattern, "", line)
+      first = line
+    }
+
+    END {
+      if (first != "") print first
+    }
+  ' <<< "$frontmatter"
+}
+
+frontmatter_first_scalar_from_file() {
+  local file="$1"
+  local field="$2"
+  local frontmatter=""
+
+  frontmatter="$(extract_frontmatter "$file")"
+  frontmatter_first_scalar "$frontmatter" "$field"
+}
+
+frontmatter_continuation_lines() {
+  local frontmatter="$1"
+  local field="$2"
+
+  awk -v field="$field" '
+    BEGIN {
+      pattern = "^" field ":"
+    }
+
+    $0 ~ pattern {
+      collecting = 1
+      next
+    }
+
+    collecting && /^[[:space:]]/ {
+      print
+      next
+    }
+
+    collecting {
+      collecting = 0
+    }
+  ' <<< "$frontmatter"
+}
+
+first_matching_line_number() {
+  local text="$1"
+  local needle="$2"
+
+  awk -v needle="$needle" '
+    index($0, needle) && first == 0 {
+      first = NR
+    }
+
+    END {
+      if (first > 0) print first
+    }
+  ' <<< "$text"
+}
+
 extract_heading_block() {
   local file="$1"
   local heading="$2"
@@ -131,7 +208,7 @@ block_contains_normalized() {
   normalized_expected=$(printf '%s' "$expected" | normalize_block_whitespace)
   [ -n "$normalized_expected" ] || return 1
 
-  printf '%s\n' "$normalized_block" | grep -Fq -- "$normalized_expected"
+  contains_literal "$normalized_block" "$normalized_expected"
 }
 
 has_allowed_tool() {
@@ -205,7 +282,7 @@ for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
     continue
   fi
 
-  NAME_VALUE="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^name:[[:space:]]*//p' | head -1)"
+  NAME_VALUE="$(frontmatter_first_scalar "$FRONTMATTER" "name")"
   # Strip vbw: prefix if present — plugin auto-prefixes the namespace
   NAME_STEM="${NAME_VALUE#vbw:}"
 
@@ -229,13 +306,13 @@ for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
     continue
   fi
 
-  DESC_VALUE="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^description:[[:space:]]*//p' | head -1)"
+  DESC_VALUE="$(frontmatter_first_scalar "$FRONTMATTER" "description")"
   if [ -z "$DESC_VALUE" ]; then
     fail "$base: description is empty"
   elif [[ "$DESC_VALUE" == \|* || "$DESC_VALUE" == \>* ]]; then
     fail "$base: description must be single-line (block scalar found)"
   else
-    AFTER_DESC="$(printf '%s\n' "$FRONTMATTER" | awk '/^description:/{found=1; next} found && /^[[:space:]]/{print; next} found{exit}')"
+    AFTER_DESC="$(frontmatter_continuation_lines "$FRONTMATTER" "description")"
     if [ -n "$AFTER_DESC" ]; then
       fail "$base: description has continuation lines"
     else
@@ -775,7 +852,7 @@ else
   fail "mode-block helper missed wrapped milestone slug command after whitespace normalization"
 fi
 
-if printf '%s\n' "$_mode_helper_block" | grep -Fq 'ignored'; then
+if contains_literal "$_mode_helper_block" 'ignored'; then
   fail "mode-block helper did not stop at the next mode heading"
 else
   pass "mode-block helper stops at the next mode heading"
@@ -810,12 +887,12 @@ echo ""
 echo "=== Add Phase Numbering Verification ==="
 
 add_phase_block=$(mode_block "### Mode: Add Phase")
-if printf '%s\n' "$add_phase_block" | grep -Fq '6. Update ROADMAP.md:' \
-  && printf '%s\n' "$add_phase_block" | grep -Fq '7. If `.vbw-planning/CONTEXT.md` exists, rewrite it to reflect the updated milestone decomposition' \
-  && printf '%s\n' "$add_phase_block" | grep -Fq '8. Update STATE.md phase total:' \
-  && printf '%s\n' "$add_phase_block" | grep -Fq '9. **Phase mutation commit boundary (conditional):**' \
-  && printf '%s\n' "$add_phase_block" | grep -Fq '10. Present:' \
-  && ! printf '%s\n' "$add_phase_block" | grep -Fq '1. Update ROADMAP.md:'; then
+if contains_literal "$add_phase_block" '6. Update ROADMAP.md:' \
+  && contains_literal "$add_phase_block" '7. If `.vbw-planning/CONTEXT.md` exists, rewrite it to reflect the updated milestone decomposition' \
+  && contains_literal "$add_phase_block" '8. Update STATE.md phase total:' \
+  && contains_literal "$add_phase_block" '9. **Phase mutation commit boundary (conditional):**' \
+  && contains_literal "$add_phase_block" '10. Present:' \
+  && ! contains_literal "$add_phase_block" '1. Update ROADMAP.md:'; then
   pass "vibe: Add Phase keeps one ordered parent step list"
 else
   fail "vibe: Add Phase restarts ordered steps instead of continuing 6-10"
@@ -826,7 +903,7 @@ echo "=== Archive Hook Wiring Verification ==="
 
 archive_block=$(mode_block "### Mode: Archive")
 
-if printf '%s\n' "$archive_block" | grep -Fq '9b. Post-archive hook (non-blocking): after successful archive completion, run:'; then
+if contains_literal "$archive_block" '9b. Post-archive hook (non-blocking): after successful archive completion, run:'; then
   pass "vibe: Archive mode includes explicit post-archive hook step"
 else
   fail "vibe: Archive mode missing explicit post-archive hook step"
@@ -838,13 +915,13 @@ else
   fail "vibe: Archive mode missing deterministic milestone slug derivation"
 fi
 
-if printf '%s\n' "$archive_block" | grep -Fq 'Parse args: --tag=vN.N.N (custom tag), --no-tag (skip), --force (skip non-UAT audit).'; then
+if contains_literal "$archive_block" 'Parse args: --tag=vN.N.N (custom tag), --no-tag (skip), --force (skip non-UAT audit).'; then
   pass "vibe: Archive mode still defines --tag as a custom git tag"
 else
   fail "vibe: Archive mode no longer defines --tag as a custom git tag"
 fi
 
-if printf '%s\n' "$archive_block" | grep -Fq 'Override with `--tag` if provided.'; then
+if contains_literal "$archive_block" 'Override with `--tag` if provided.'; then
   fail "vibe: Archive mode still lets --tag override milestone slug"
 else
   pass "vibe: Archive mode keeps milestone slug separate from custom --tag"
@@ -856,9 +933,9 @@ else
   fail "vibe: Archive mode missing post-archive hook argument contract"
 fi
 
-archive_regen_line=$(printf '%s\n' "$archive_block" | awk '/9\. Regenerate CLAUDE\.md:/ && !found1 {print NR; found1=1}')
-archive_hook_line=$(printf '%s\n' "$archive_block" | awk '/9b\. Post-archive hook \(non-blocking\):/ && !found2 {print NR; found2=1}')
-archive_present_line=$(printf '%s\n' "$archive_block" | awk '/10\. Present:/ && !found3 {print NR; found3=1}')
+archive_regen_line=$(first_matching_line_number "$archive_block" '9. Regenerate CLAUDE.md:')
+archive_hook_line=$(first_matching_line_number "$archive_block" '9b. Post-archive hook (non-blocking):')
+archive_present_line=$(first_matching_line_number "$archive_block" '10. Present:')
 
 if [ -n "$archive_regen_line" ] && [ -n "$archive_hook_line" ] && [ -n "$archive_present_line" ] \
   && [ "$archive_regen_line" -lt "$archive_hook_line" ] \
@@ -1050,7 +1127,7 @@ for file in "${TRACKED_COMMAND_MARKDOWN_FILES[@]}"; do
     continue
   fi
 
-  ALLOWED="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^allowed-tools:[[:space:]]*//p' | head -1)"
+  ALLOWED="$(frontmatter_first_scalar "$FRONTMATTER" "allowed-tools")"
   if [ -z "$ALLOWED" ]; then
     continue
   fi
@@ -1073,7 +1150,8 @@ for skill_cmd in debug fix map qa research vibe; do
   [ -f "$skill_file" ] || continue
 
   if grep -Fq 'Call Skill(' "$skill_file"; then
-    if grep -F 'allowed-tools:' "$skill_file" | grep -Fq 'Skill'; then
+    skill_allowed="$(frontmatter_first_scalar_from_file "$skill_file" "allowed-tools")"
+    if has_allowed_tool "$skill_allowed" "Skill"; then
       pass "$skill_cmd: regression guard confirms Skill allowlist"
     else
       fail "$skill_cmd: regression guard found Call Skill(...) but allowed-tools is missing Skill"
@@ -1083,7 +1161,8 @@ done
 
 INIT_FILE="$COMMANDS_DIR/init.md"
 if [ -f "$INIT_FILE" ] && grep -Fq 'WebSearch' "$INIT_FILE"; then
-  if grep -F 'allowed-tools:' "$INIT_FILE" | grep -Fq 'WebSearch'; then
+  init_allowed="$(frontmatter_first_scalar_from_file "$INIT_FILE" "allowed-tools")"
+  if has_allowed_tool "$init_allowed" "WebSearch"; then
     pass "init: regression guard confirms WebSearch allowlist"
   else
     fail "init: regression guard found WebSearch in body but allowed-tools is missing WebSearch"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -27,6 +27,28 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
+contains_literal() {
+  local haystack="$1"
+  local needle="$2"
+
+  [[ "$haystack" == *"$needle"* ]]
+}
+
+first_matching_line_number() {
+  local text="$1"
+  local needle="$2"
+
+  awk -v needle="$needle" '
+    index($0, needle) && first == 0 {
+      first = NR
+    }
+
+    END {
+      if (first > 0) print first
+    }
+  ' <<< "$text"
+}
+
 # — Template checks —
 
 TEMPLATE="$ROOT/templates/DEBUG-SESSION.md"
@@ -252,9 +274,9 @@ else
   fail "debug.md Path A missing fresh vbw-debugger implementation-owner contract"
 fi
 
-patha_teardown_line=$(printf '%s\n' "$DEBUG_PATH_A_BLOCK" | awk '/\*\*Teardown phase — HARD GATE before any implementation:\*\*/ { print NR; exit }')
-patha_zero_line=$(printf '%s\n' "$DEBUG_PATH_A_BLOCK" | awk '/Verify: after TeamDelete, there must be ZERO active teammates\./ { print NR; exit }')
-patha_impl_line=$(printf '%s\n' "$DEBUG_PATH_A_BLOCK" | awk '/If `RESOLUTION_OBSERVATION=needs_change`: spawn ONE fresh post-synthesis implementation owner/ { print NR; exit }')
+patha_teardown_line=$(first_matching_line_number "$DEBUG_PATH_A_BLOCK" '**Teardown phase — HARD GATE before any implementation:**')
+patha_zero_line=$(first_matching_line_number "$DEBUG_PATH_A_BLOCK" 'Verify: after TeamDelete, there must be ZERO active teammates.')
+patha_impl_line=$(first_matching_line_number "$DEBUG_PATH_A_BLOCK" 'If `RESOLUTION_OBSERVATION=needs_change`: spawn ONE fresh post-synthesis implementation owner')
 
 if [ -n "$patha_teardown_line" ] && [ -n "$patha_zero_line" ] && [ -n "$patha_impl_line" ] \
   && [ "$patha_teardown_line" -lt "$patha_zero_line" ] && [ "$patha_zero_line" -lt "$patha_impl_line" ]; then
@@ -278,10 +300,10 @@ else
 fi
 
 DEBUG_HINT_LINE="$(awk '/^argument-hint:/{print; exit}' "$DEBUG_CMD" 2>/dev/null || true)"
-if printf '%s\n' "$DEBUG_HINT_LINE" | grep -Eq 'bug description' \
-  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Eq 'todo number' \
-  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Fq -- '--resume' \
-  && printf '%s\n' "$DEBUG_HINT_LINE" | grep -Fq -- '--session ID'; then
+if contains_literal "$DEBUG_HINT_LINE" 'bug description' \
+  && contains_literal "$DEBUG_HINT_LINE" 'todo number' \
+  && contains_literal "$DEBUG_HINT_LINE" '--resume' \
+  && contains_literal "$DEBUG_HINT_LINE" '--session ID'; then
   pass "debug.md argument-hint advertises bug text, todo number, --resume, and --session"
 else
   fail "debug.md argument-hint missing one or more supported entry points"
@@ -290,10 +312,10 @@ fi
 DEBUG_USAGE_LINES="$(grep -F 'Usage:' "$DEBUG_CMD" 2>/dev/null || true)"
 DEBUG_USAGE_COUNT=$(printf '%s\n' "$DEBUG_USAGE_LINES" | grep -c 'Usage:' || true)
 if [ "$DEBUG_USAGE_COUNT" -ge 2 ] \
-  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug <todo-number>' \
-  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug --resume' \
-  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '/vbw:debug --session <id>' \
-  && printf '%s\n' "$DEBUG_USAGE_LINES" | grep -Fq '[--competing|--parallel|--serial]'; then
+  && contains_literal "$DEBUG_USAGE_LINES" '/vbw:debug <todo-number>' \
+  && contains_literal "$DEBUG_USAGE_LINES" '/vbw:debug --resume' \
+  && contains_literal "$DEBUG_USAGE_LINES" '/vbw:debug --session <id>' \
+  && contains_literal "$DEBUG_USAGE_LINES" '[--competing|--parallel|--serial]'; then
   pass "debug.md keeps both expanded Usage strings with resume/session and ambiguity flags"
 else
   fail "debug.md missing expanded Usage strings with resume/session and ambiguity flags"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -34,6 +34,13 @@ contains_literal() {
   [[ "$haystack" == *"$needle"* ]]
 }
 
+matches_ere() {
+  local haystack="$1"
+  local pattern="$2"
+
+  grep -Eq -- "$pattern" <<< "$haystack"
+}
+
 first_matching_line_number() {
   local text="$1"
   local needle="$2"
@@ -106,7 +113,7 @@ else
   pass "debug-session-state.sh metadata-read contract no longer exports bare status"
 fi
 
-if awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -Fq 'echo "status=$STATUS"'; then
+if contains_literal "$(awk '/set-status\)/,/;;/' "$STATE_SCRIPT" 2>/dev/null || true)" 'echo "status=$STATUS"'; then
   pass "debug-session-state.sh set-status keeps status output contract"
 else
   fail "debug-session-state.sh set-status output contract drifted from status=..."
@@ -130,19 +137,19 @@ else
   fail "debug-session-state.sh missing completed no-verification normalization helper"
 fi
 
-if awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$SESSION_PATH"'; then
+if contains_literal "$(awk '/set-status\)/,/;;/' "$STATE_SCRIPT" 2>/dev/null || true)" 'normalize_completed_no_verification_results "$SESSION_PATH"'; then
   pass "debug-session-state.sh set-status normalizes completed no-verification sessions before move"
 else
   fail "debug-session-state.sh set-status missing completed no-verification normalization"
 fi
 
-if awk '/reconcile_session_location\(\)/,/^}/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$file"'; then
+if contains_literal "$(awk '/reconcile_session_location\(\)/,/^}/' "$STATE_SCRIPT" 2>/dev/null || true)" 'normalize_completed_no_verification_results "$file"'; then
   pass "debug-session-state.sh reconcile path normalizes completed no-verification sessions"
 else
   fail "debug-session-state.sh reconcile path missing completed no-verification normalization"
 fi
 
-if awk '/migrate_legacy_session\(\)/,/^}/' "$STATE_SCRIPT" | grep -Fq 'normalize_completed_no_verification_results "$file"'; then
+if contains_literal "$(awk '/migrate_legacy_session\(\)/,/^}/' "$STATE_SCRIPT" 2>/dev/null || true)" 'normalize_completed_no_verification_results "$file"'; then
   pass "debug-session-state.sh legacy migration normalizes completed no-verification sessions"
 else
   fail "debug-session-state.sh legacy migration missing completed no-verification normalization"
@@ -643,7 +650,15 @@ else
   fail "debug.md missing inline UAT section (debug_inline_uat)"
 fi
 
-if sed -n '1,/^---$/p' "$ROOT/commands/debug.md" 2>/dev/null | grep -q 'AskUserQuestion'; then
+if contains_literal "$(awk '
+  BEGIN { delim=0 }
+  /^---$/ {
+    delim++
+    if (delim == 2) exit
+    next
+  }
+  delim == 1 { print }
+' "$ROOT/commands/debug.md" 2>/dev/null || true)" 'AskUserQuestion'; then
   pass "debug.md frontmatter includes AskUserQuestion tool"
 else
   fail "debug.md frontmatter missing AskUserQuestion tool"
@@ -737,16 +752,18 @@ else
 fi
 
 # Verify the set-status branch specifically handles complete → move to COMPLETED_DIR
-if awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -q '"\$STATUS" = "complete"' && \
-   awk '/set-status\)/,/;;/' "$STATE_SCRIPT" | grep -q 'safe_move_session.*\$COMPLETED_DIR'; then
+_set_status_block="$(awk '/set-status\)/,/;;/' "$STATE_SCRIPT" 2>/dev/null || true)"
+if matches_ere "$_set_status_block" '"\$STATUS" = "complete"' && \
+   matches_ere "$_set_status_block" 'safe_move_session.*\$COMPLETED_DIR'; then
   pass "debug-session-state.sh set-status branch moves complete sessions to COMPLETED_DIR"
 else
   fail "debug-session-state.sh set-status branch does not move complete sessions to COMPLETED_DIR"
 fi
 
 # list command should output both location fields for dual-directory listings
-if awk '/list\)/,/;;/' "$STATE_SCRIPT" | grep -q '|active' && \
-   awk '/list\)/,/;;/' "$STATE_SCRIPT" | grep -q '|completed'; then
+_list_block="$(awk '/list\)/,/;;/' "$STATE_SCRIPT" 2>/dev/null || true)"
+if contains_literal "$_list_block" '|active' && \
+   contains_literal "$_list_block" '|completed'; then
   pass "debug-session-state.sh list outputs both active and completed location fields"
 else
   fail "debug-session-state.sh list missing location field in output (must include both |active and |completed)"
@@ -754,7 +771,7 @@ fi
 
 # safe_move_session helper with destination-exists guard
 if grep -q 'safe_move_session()' "$STATE_SCRIPT" 2>/dev/null && \
-   awk '/safe_move_session\(\)/,/^}/' "$STATE_SCRIPT" | grep -q 'return 1'; then
+   contains_literal "$(awk '/safe_move_session\(\)/,/^}/' "$STATE_SCRIPT" 2>/dev/null || true)" 'return 1'; then
   pass "debug-session-state.sh has safe_move_session helper with collision guard"
 else
   fail "debug-session-state.sh missing safe_move_session helper or collision guard"

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -31,7 +31,7 @@ contains_literal() {
   local haystack="$1"
   local needle="$2"
 
-  [[ "$haystack" == *"$needle"* ]]
+  grep -Fq -- "$needle" <<< "$haystack"
 }
 
 matches_ere() {

--- a/testing/verify-lead-research-conditional.sh
+++ b/testing/verify-lead-research-conditional.sh
@@ -90,13 +90,14 @@ fi
 # --- compile-context.sh: codebase mapping hint conditional on research ---
 
 LEAD_SECTION=$(sed -n '/^  lead)/,/^  ;;$/p' "$COMPILE")
-if echo "$LEAD_SECTION" | grep -B5 "emit_codebase_mapping_hint ARCHITECTURE CONCERNS STRUCTURE" | grep -q "else"; then
+LEAD_HINT_CONTEXT=$(grep -B5 "emit_codebase_mapping_hint ARCHITECTURE CONCERNS STRUCTURE" <<< "$LEAD_SECTION" || true)
+if grep -q "else" <<< "$LEAD_HINT_CONTEXT"; then
   pass "compile-context: hint is in else branch of research check"
 else
   fail "compile-context: hint not in else branch of research check"
 fi
 
-if echo "$LEAD_SECTION" | grep -q "no research exists"; then
+if grep -q "no research exists" <<< "$LEAD_SECTION"; then
   pass "compile-context: codebase mapping hint conditional on no-research"
 else
   fail "compile-context: codebase mapping hint not conditional on research"

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -67,7 +67,8 @@ assert_no_quiet_grep_pipe() {
     return
   fi
 
-  if match="$(awk -v producer="$producer_pattern" '
+  # Capture match and use external check to bypass command-substitution subshell exit suppression
+  match="$(awk -v producer="$producer_pattern" '
     function has_quiet_grep(line) {
       return line ~ /(^|[^|])[|][[:space:]]*grep([[:space:]]|$)/ \
         && (line ~ /[[:space:]]--(quiet|silent)([[:space:]]|$)/ \
@@ -78,14 +79,10 @@ assert_no_quiet_grep_pipe() {
       printf "%d:%s\n", NR, $0
       exit
     }
-  ' "$file" 2>/dev/null)"; then
-    awk_status=0
-  else
-    awk_status=$?
-  fi
+  ' "$file" 2>/dev/null)" || awk_status=$?
 
   if [ "$awk_status" -ne 0 ]; then
-    fail "$label (awk scan error on: $rel_path)"
+    fail "$label (awk scan error $awk_status on: $rel_path)"
     return
   fi
 

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -59,6 +59,7 @@ assert_no_quiet_grep_pipe() {
   local label="$3"
   local file="$ROOT/$rel_path"
   local match=""
+  local awk_status=0
   local first_line=""
 
   if [ ! -f "$file" ] || [ ! -r "$file" ]; then
@@ -66,7 +67,7 @@ assert_no_quiet_grep_pipe() {
     return
   fi
 
-  match="$(awk -v producer="$producer_pattern" '
+  if match="$(awk -v producer="$producer_pattern" '
     function has_quiet_grep(line) {
       return line ~ /(^|[^|])[|][[:space:]]*grep([[:space:]]|$)/ \
         && (line ~ /[[:space:]]--(quiet|silent)([[:space:]]|$)/ \
@@ -77,7 +78,16 @@ assert_no_quiet_grep_pipe() {
       printf "%d:%s\n", NR, $0
       exit
     }
-  ' "$file" 2>/dev/null || true)"
+  ' "$file" 2>/dev/null)"; then
+    awk_status=0
+  else
+    awk_status=$?
+  fi
+
+  if [ "$awk_status" -ne 0 ]; then
+    fail "$label (awk scan error on: $rel_path)"
+    return
+  fi
 
   if [ -z "$match" ]; then
     pass "$label"

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -107,7 +107,7 @@ assert_no_quiet_grep_pipe \
 
 assert_no_match \
   "testing/verify-commands-contract.sh" \
-  'printf .*[[:space:]][|][[:space:]]*sed .*[[:space:]][|][[:space:]]*head -1' \
+  'printf .*[[:space:]][|][[:space:]]*sed .*[[:space:]][|][[:space:]]*head([[:space:]]+(-n[[:space:]]*1|-[[:space:]]*1))' \
   "commands-contract avoids printf-to-sed-to-head extraction pipelines"
 
 assert_no_quiet_grep_pipe \

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-pipefail-safety.sh — Focused guard against early-closing verifier pipelines
+#
+# Related: #535
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_no_match() {
+  local rel_path="$1"
+  local pattern="$2"
+  local label="$3"
+  local file="$ROOT/$rel_path"
+  local match=""
+  local first_line=""
+
+  match="$(grep -nE "$pattern" "$file" 2>/dev/null || true)"
+  if [ -z "$match" ]; then
+    pass "$label"
+    return
+  fi
+
+  first_line="${match%%$'\n'*}"
+  fail "$label (found: $first_line)"
+}
+
+echo "=== Pipefail safety verification ==="
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
+  'printf .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "commands-contract avoids printf-to-grep early-close pipelines"
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
+  'printf .*[[:space:]][|][[:space:]]*awk .*(exit|print NR)' \
+  "commands-contract avoids printf-to-awk early-exit lookups"
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
+  'printf .*[[:space:]][|][[:space:]]*sed .*[[:space:]][|][[:space:]]*head -1' \
+  "commands-contract avoids printf-to-sed-to-head extraction pipelines"
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
+  'grep .*[[:space:]][|][[:space:]]*grep -(Fq|q)' \
+  "commands-contract avoids grep-to-grep early-close pipelines"
+
+assert_no_match \
+  "testing/verify-debug-session-contract.sh" \
+  'printf .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "debug-session-contract avoids printf-to-grep early-close pipelines"
+
+assert_no_match \
+  "testing/verify-debug-session-contract.sh" \
+  'printf .*[[:space:]][|][[:space:]]*awk .*(exit|print NR)' \
+  "debug-session-contract avoids printf-to-awk early-exit lookups"
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "Pipefail safety checks passed."

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -26,15 +26,30 @@ assert_no_match() {
   local label="$3"
   local file="$ROOT/$rel_path"
   local match=""
-  local first_line=""
+  local grep_status=0
 
-  match="$(grep -nE "$pattern" "$file" 2>/dev/null || true)"
-  if [ -z "$match" ]; then
+  if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+    fail "$label (target missing or unreadable: $rel_path)"
+    return
+  fi
+
+  if match="$(grep -nE "$pattern" "$file" 2>/dev/null)"; then
+    grep_status=0
+  else
+    grep_status=$?
+  fi
+
+  if [ "$grep_status" -eq 1 ]; then
     pass "$label"
     return
   fi
 
-  first_line="${match%%$'\n'*}"
+  if [ "$grep_status" -ne 0 ]; then
+    fail "$label (grep error on: $rel_path)"
+    return
+  fi
+
+  local first_line="${match%%$'\n'*}"
   fail "$label (found: $first_line)"
 }
 

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -52,8 +52,18 @@ assert_no_match \
 
 assert_no_match \
   "testing/verify-commands-contract.sh" \
+  'awk .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "commands-contract avoids awk-to-grep early-close pipelines"
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
   'printf .*[[:space:]][|][[:space:]]*sed .*[[:space:]][|][[:space:]]*head -1' \
   "commands-contract avoids printf-to-sed-to-head extraction pipelines"
+
+assert_no_match \
+  "testing/verify-commands-contract.sh" \
+  'sed .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "commands-contract avoids sed-to-grep early-close pipelines"
 
 assert_no_match \
   "testing/verify-commands-contract.sh" \
@@ -69,6 +79,16 @@ assert_no_match \
   "testing/verify-debug-session-contract.sh" \
   'printf .*[[:space:]][|][[:space:]]*awk .*(exit|print NR)' \
   "debug-session-contract avoids printf-to-awk early-exit lookups"
+
+assert_no_match \
+  "testing/verify-debug-session-contract.sh" \
+  'awk .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "debug-session-contract avoids awk-to-grep early-close pipelines"
+
+assert_no_match \
+  "testing/verify-debug-session-contract.sh" \
+  'sed .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  "debug-session-contract avoids sed-to-grep early-close pipelines"
 
 echo ""
 echo "==============================="

--- a/testing/verify-pipefail-safety.sh
+++ b/testing/verify-pipefail-safety.sh
@@ -53,11 +53,46 @@ assert_no_match() {
   fail "$label (found: $first_line)"
 }
 
+assert_no_quiet_grep_pipe() {
+  local rel_path="$1"
+  local producer_pattern="$2"
+  local label="$3"
+  local file="$ROOT/$rel_path"
+  local match=""
+  local first_line=""
+
+  if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+    fail "$label (target missing or unreadable: $rel_path)"
+    return
+  fi
+
+  match="$(awk -v producer="$producer_pattern" '
+    function has_quiet_grep(line) {
+      return line ~ /(^|[^|])[|][[:space:]]*grep([[:space:]]|$)/ \
+        && (line ~ /[[:space:]]--(quiet|silent)([[:space:]]|$)/ \
+          || line ~ /[[:space:]]-[^[:space:]]*q[^[:space:]]*([[:space:]]|$)/)
+    }
+
+    $0 ~ producer && has_quiet_grep($0) {
+      printf "%d:%s\n", NR, $0
+      exit
+    }
+  ' "$file" 2>/dev/null || true)"
+
+  if [ -z "$match" ]; then
+    pass "$label"
+    return
+  fi
+
+  first_line="${match%%$'\n'*}"
+  fail "$label (found: $first_line)"
+}
+
 echo "=== Pipefail safety verification ==="
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-commands-contract.sh" \
-  'printf .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'printf .*' \
   "commands-contract avoids printf-to-grep early-close pipelines"
 
 assert_no_match \
@@ -65,9 +100,9 @@ assert_no_match \
   'printf .*[[:space:]][|][[:space:]]*awk .*(exit|print NR)' \
   "commands-contract avoids printf-to-awk early-exit lookups"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-commands-contract.sh" \
-  'awk .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'awk .*' \
   "commands-contract avoids awk-to-grep early-close pipelines"
 
 assert_no_match \
@@ -75,19 +110,19 @@ assert_no_match \
   'printf .*[[:space:]][|][[:space:]]*sed .*[[:space:]][|][[:space:]]*head -1' \
   "commands-contract avoids printf-to-sed-to-head extraction pipelines"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-commands-contract.sh" \
-  'sed .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'sed .*' \
   "commands-contract avoids sed-to-grep early-close pipelines"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-commands-contract.sh" \
-  'grep .*[[:space:]][|][[:space:]]*grep -(Fq|q)' \
+  'grep .*' \
   "commands-contract avoids grep-to-grep early-close pipelines"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-debug-session-contract.sh" \
-  'printf .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'printf .*' \
   "debug-session-contract avoids printf-to-grep early-close pipelines"
 
 assert_no_match \
@@ -95,15 +130,20 @@ assert_no_match \
   'printf .*[[:space:]][|][[:space:]]*awk .*(exit|print NR)' \
   "debug-session-contract avoids printf-to-awk early-exit lookups"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-debug-session-contract.sh" \
-  'awk .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'awk .*' \
   "debug-session-contract avoids awk-to-grep early-close pipelines"
 
-assert_no_match \
+assert_no_quiet_grep_pipe \
   "testing/verify-debug-session-contract.sh" \
-  'sed .*[[:space:]][|][[:space:]]*grep -(Fq|Eq|q)' \
+  'sed .*' \
   "debug-session-contract avoids sed-to-grep early-close pipelines"
+
+assert_no_quiet_grep_pipe \
+  "testing/verify-debug-session-contract.sh" \
+  'grep .*' \
+  "debug-session-contract avoids grep-to-grep early-close pipelines"
 
 echo ""
 echo "==============================="


### PR DESCRIPTION
Fixes #535

## What

This PR hardens the verifier shell logic against `set -euo pipefail` + early-closing reader failures in the touched contract tests, adds a focused regression guard for that bug class, and fixes one adjacent same-class CI failure exposed during final remote validation.

Modified files:
- `testing/verify-commands-contract.sh` — replaces early-closing helper pipelines with full-input helpers for normalized block checks, frontmatter scalar extraction, continuation detection, and archive-order line lookups.
- `testing/verify-debug-session-contract.sh` — removes remaining same-class `awk|grep` / `sed|grep` assertions in the touched sibling verifier and hardens literal matching.
- `testing/verify-pipefail-safety.sh` — adds and then iteratively hardens a focused regression verifier so future edits cannot quietly reintroduce these pipeline hazards or fail open on internal scan errors.
- `testing/list-contract-tests.sh` — registers `verify-pipefail-safety.sh` in the contract-test registry used by local and CI runners.
- `testing/verify-lead-research-conditional.sh` — fixes a remote-CI-discovered sibling `pipefail` hazard in adjacent verifier logic so the full suite is green on the PR head.

## Why

The root cause was not the archive-order assertion alone. The real failure mode was verifier code that combined `set -euo pipefail` with pipelines whose downstream reader could exit early (`awk ... exit`, `grep -q`, `grep -Fq`, and adjacent variants), causing the upstream producer to receive `SIGPIPE` and fail the contract script even though the logical assertion had already succeeded.

The durable fix is to remove those early-closing pipeline shapes from the touched verifier logic, harden sibling verifiers where the same pattern was still live, and add an automated regression guard that fails closed instead of silently passing on internal scan errors.

## How

- `testing/verify-commands-contract.sh` now uses local full-input helpers (`contains_literal`, `frontmatter_first_scalar`, `frontmatter_continuation_lines`, `first_matching_line_number`) instead of `printf ... | grep/awk/sed ...` shapes that can terminate early under `pipefail`.
- `testing/verify-debug-session-contract.sh` now evaluates extracted blocks through safe helpers and fixed-string matching instead of piping `awk`/`sed` output into early-closing `grep -q` readers or using glob-style substring checks.
- `testing/verify-pipefail-safety.sh` now checks for `printf|grep`, `printf|awk`, `awk|grep`, `sed|grep`, `printf|sed|head`, and `grep|grep` shapes in the touched verifier scripts, handles quiet-`grep` flag variants regardless of order, and fails closed on internal `grep`/`awk` scan errors.
- `testing/list-contract-tests.sh` registers the new verifier so `testing/run-all.sh` and CI execute it automatically.
- `testing/verify-lead-research-conditional.sh` now captures the relevant context before checking it, avoiding another early-closing `grep -q` pipeline in a sibling contract test.

## Acceptance criteria verification

1. `bash testing/verify-commands-contract.sh` no longer fails with `Broken pipe` when the archive-order assertions match early.
   - Satisfied by helper-based line lookup in `testing/verify-commands-contract.sh:152,936-938`.
   - Verified by repeated direct runs of `bash testing/verify-commands-contract.sh` during implementation and QA.
2. The fix removes or neutralizes same-class early-closing pipelines in `testing/verify-commands-contract.sh`, not only the three originally reported line-number lookups.
   - Satisfied by the helper-based rewrite in `testing/verify-commands-contract.sh:90-165` and the updated call sites at `testing/verify-commands-contract.sh:936-938` plus related frontmatter/helper call sites.
3. Any sibling verifier updated for the same pattern (currently `testing/verify-debug-session-contract.sh`) preserves its existing assertions and passes cleanly.
   - Satisfied by the safe helper/check rewrite in `testing/verify-debug-session-contract.sh:30-44,662,758,767`.
   - Verified by `bash testing/verify-debug-session-contract.sh`.
4. An automated regression check exists so future verifier edits cannot silently reintroduce this `pipefail` + early-closing-reader bug class.
   - Satisfied by `testing/verify-pipefail-safety.sh:23,56,117` and its registration in `testing/list-contract-tests.sh:19`.
5. `bash testing/run-lint.sh` and `bash testing/run-all.sh` pass after the fix.
   - Verified locally on the final branch head and remotely in GitHub Actions on PR #537.

## Testing

- [x] `bash testing/verify-pipefail-safety.sh`
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] repeated direct runs of `bash testing/verify-commands-contract.sh`
- [x] `bash testing/verify-lead-research-conditional.sh`
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh`

Validation summary:
- Local final `bash testing/run-all.sh` → lint `1/1`, contract checks `47/47`, BATS `3105 passed / 0 failed`
- Remote GitHub Actions on final head `abaa03f25ac85b141ef612ddf2bb1a0e92e3d401` → all checks green

## QA summary

### Primary QA (`qa-investigator`)
- Rounds completed: 2
- Round 1: 1 legitimate medium-severity contract finding fixed in `9f15eed2e02ba7dec4370b23148a1ba5fc084586`
- Round 2: clean, recorded in `9466873823c832e4441c95c4096193b6ecfd0c6f`
- False positives: 0

### Cross-model QA (`qa-investigator-gpt-54`)
- Skipped: GPT-class session model, so no cross-family review was available under the workflow gate.

### Copilot PR review
- Rounds completed: 7
- Round 1 (`9466873823c832e4441c95c4096193b6ecfd0c6f`): 1 finding fixed in `eea17771187d2a293b92c0cd41cd9ba9342c7af7`, evidence commit `5242698818ec017ab1be7075e35b2ec4ade36bf7`
- Round 2 (`5242698818ec017ab1be7075e35b2ec4ade36bf7`): 1 finding fixed in `d6e15fc21dd10cd22ee4ff9c8036294cc538f287`
- Round 3 (`d6e15fc21dd10cd22ee4ff9c8036294cc538f287`): 2 findings fixed in `c32ac30797d3071d44e72859b75dc2c4bfd02d70`
- Round 4 (`c32ac30797d3071d44e72859b75dc2c4bfd02d70`): 1 finding fixed in `79fbdcd33580a840522d4fea8c031a06787b9c42`
- Round 5 (`79fbdcd33580a840522d4fea8c031a06787b9c42`): 2 findings fixed in `5116764d8a8c7c8825529c1cf38430f449587cfd`
- Round 6 (`5116764d8a8c7c8825529c1cf38430f449587cfd`): clean review, but remote CI exposed a sibling verifier failure fixed in `abaa03f25ac85b141ef612ddf2bb1a0e92e3d401`
- Round 7 (`abaa03f25ac85b141ef612ddf2bb1a0e92e3d401`): clean, no new comments
- Copilot false positives: 0

## Commits in this branch

- `d6f92be5721c80b7a685d02a12fa5fee49edf074` — `fix(testing): harden verifier pipelines under pipefail`
- `9f15eed2e02ba7dec4370b23148a1ba5fc084586` — `fix(testing): address QA round 1`
- `9466873823c832e4441c95c4096193b6ecfd0c6f` — `fix(testing): address QA round 2`
- `eea17771187d2a293b92c0cd41cd9ba9342c7af7` — `Update verify-pipefail-safety.sh with robust grep handling from PR review`
- `5242698818ec017ab1be7075e35b2ec4ade36bf7` — `fix(testing): address Copilot review round 1`
- `d6e15fc21dd10cd22ee4ff9c8036294cc538f287` — `fix(testing): address Copilot review round 2`
- `c32ac30797d3071d44e72859b75dc2c4bfd02d70` — `Address review comments: align whitespace and improve regex for head extraction pipelines`
- `79fbdcd33580a840522d4fea8c031a06787b9c42` — `fix(testing): address Copilot review round 3`
- `5116764d8a8c7c8825529c1cf38430f449587cfd` — `fix(testing): address Copilot review round 4`
- `abaa03f25ac85b141ef612ddf2bb1a0e92e3d401` — `fix(testing): address CI failure`
