### PR TITLE
feat(rtk): add explicit RTK managed integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ cat "$CLAUDE_PROJECT_DIR"/<session-id>/subagents/agent-*.jsonl
 
 ## Architecture
 
-- **Commands** (`commands/*.md`): 25 slash commands with YAML frontmatter. Command `name` values are explicitly prefixed (e.g. `name: vbw:init`) so slash commands appear as `/vbw:*`. The frontmatter `description` must be single-line (multi-line breaks plugin discovery).
+- **Commands** (`commands/*.md`): Slash commands with YAML frontmatter. Command `name` values are explicitly prefixed (e.g. `name: vbw:init`) so slash commands appear as `/vbw:*`. The frontmatter `description` must be single-line (multi-line breaks plugin discovery).
 - **Agents** (`agents/vbw-{role}.md`): 7 agents (Scout, Architect, Lead, Dev, QA, Debugger, Docs) with platform-enforced tool permissions via YAML `tools`/`disallowedTools`. Scout and QA are read-only (`permissionMode: plan`).
 - **Hooks** (`hooks/hooks.json`): 24 handlers across 11 event types (SessionStart, Stop, PreToolUse, PostToolUse, SubagentStart, SubagentStop, Notification, PreCompact, TaskCompleted, TeammateIdle, UserPromptSubmit). All route through `scripts/hook-wrapper.sh` which resolves from plugin cache via `ls | sort -V | tail -1` with a `CLAUDE_PLUGIN_ROOT` fallback for `--plugin-dir` installs, logs failures, and always exits 0 — no hook can break a session.
 - **Scripts** (`scripts/*.sh`): bash scripts for hook handlers, context compilation, state management, bootstrap, metrics, diagnostics, and codebase mapping. Target bash (not POSIX sh). Use `set -euo pipefail` for critical scripts, `set -u` minimum otherwise.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Closed your terminal? Switched branches? Came back after a weekend of pretending
 >
 > **If you accidentally `/clear`**, run `/vbw:resume` immediately. It restores project context from ground truth files in `.vbw-planning/` — state, roadmap, plans, summaries — and tells you exactly where to pick up.
 >
-> **For advanced users:** The [full command reference](#commands) below has 25 commands for granular control — `/vbw:vibe` with flags for explicit mode selection (`--plan`, `--execute`, `--discuss`, `--assumptions`), `/vbw:discuss` for standalone phase discussions, `/vbw:debug` for systematic bug investigation, and more. But you never *need* the flags. `/vbw:vibe` with no arguments handles the entire lifecycle on its own.
+> **For advanced users:** The [full command reference](#commands) below has granular controls — `/vbw:vibe` with flags for explicit mode selection (`--plan`, `--execute`, `--discuss`, `--assumptions`), `/vbw:discuss` for standalone phase discussions, `/vbw:debug` for systematic bug investigation, and more. But you never *need* the flags. `/vbw:vibe` with no arguments handles the entire lifecycle on its own.
 
 ---
 
@@ -421,13 +421,20 @@ These are the commands you'll use every day. This is the job now.
 | `/vbw:pause` | Save session notes for next time. State auto-persists in `.vbw-planning/` -- pause just lets you leave a sticky note for future you. |
 | `/vbw:resume` | Restore project context from `.vbw-planning/` ground truth. Reads state, roadmap, plans, and summaries directly -- no prior `/vbw:pause` needed. |
 | `/vbw:skills` | Browse and install community skills from skills.sh based on your project's tech stack. Detects your stack, suggests relevant skills, and installs them with one command. |
+| `/vbw:rtk [status\|install\|init\|verify\|update\|uninstall]` | Optional RTK tool-output compression management. Binary install/update and Claude Code hook activation are separate, explicit steps. |
 | `/vbw:config` | View and toggle VBW settings: effort profiles, autonomy levels (cautious/standard/confident/pure-vibe), plain-language summaries (`plain_summary`), skill suggestions, auto-install behavior, and skill-hook wiring. Detects profile drift and offers to save as new profile. |
 | `/vbw:compress` | Compress a natural language file (`.md`, `.txt`) into caveman format. Creates an `.original` backup preserving the original extension. Uses caveman language rules for token-efficient compression. |
 | `/vbw:profile` | Switch between work profiles or create custom ones. 4 built-in presets (default, prototype, production, yolo) change effort, autonomy, and verification in one command. Interactive profile creation for custom workflows. |
 | `/vbw:report` | Collect diagnostic context and file a GitHub issue. Captures VBW version, environment, hook errors, session logs, config, and project state. |
 | `/vbw:teach` | View, add, or manage project conventions. Auto-detected from codebase during init, manually teachable anytime. Shows what VBW already knows and warns about conflicts before adding. Conventions are injected into agent context via CLAUDE.md and verified by QA. |
-| `/vbw:doctor` | Run 10 health checks on your VBW installation: jq, VERSION sync, plugin cache, hooks validity, agent files, config, script permissions, gh CLI, sort -V support. Diagnoses issues before they become mysteries. |
+| `/vbw:doctor` | Run VBW installation and project health checks: jq, version sync, plugin cache, hook validity, agent files, config, script permissions, gh CLI, runtime cleanup state, CLAUDE.md staleness, state consistency, and optional RTK integration. Diagnoses issues before they become mysteries. |
 | `/vbw:help` | Command reference with usage examples. You are reading its output's spiritual ancestor right now. |
+
+### Optional RTK tool-output compression
+
+VBW can optionally manage [RTK](https://github.com/rtk-ai/rtk) setup through `/vbw:rtk install` and keep VBW-managed RTK current through `/vbw:rtk update`. You can also follow RTK's upstream install docs yourself and use `/vbw:rtk status` or `/vbw:rtk verify` for diagnostics.
+
+VBW treats RTK binary installation/update and Claude Code hook activation as separate steps. VBW-managed install/update pulls the latest `rtk-ai/rtk` GitHub release asset for your platform and verifies `checksums.txt` when available. Hook activation runs RTK's `rtk init -g`, which can mutate user-level Claude Code config, so VBW shows a separate preflight and asks separately before doing it. RTK/VBW hook coexistence remains a WARN/unverified state until a real runtime smoke test proves `updatedInput` behavior works with both tools active. RTK savings are shown as external RTK metrics, not VBW savings.
 
 ### Advanced -- For When You're Feeling Ambitious
 
@@ -1068,7 +1075,7 @@ See **[Model Profiles Reference](references/model-profiles.md)** for preset defi
 ```text
 .claude-plugin/    Plugin manifest (plugin.json)
 agents/            7 agent definitions with native tool permissions
-commands/          25 slash commands (23 user-visible, 2 hidden protocol files)
+commands/          Slash-command definitions
 config/            Default settings and stack-to-skill mappings
 hooks/             Plugin hooks for continuous verification
 scripts/           Hook handler scripts (security, validation, QA gates)

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -14,40 +14,44 @@ Working directory:
 ```
 !`pwd`
 ```
+Plugin root:
+```
+!`VBW_CACHE_ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/vbw-marketplace/vbw"; SESSION_KEY="${CLAUDE_SESSION_ID:-default}"; SESSION_LINK="/tmp/.vbw-plugin-root-link-${SESSION_KEY}"; R=""; if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/hook-wrapper.sh" ]; then R="${CLAUDE_PLUGIN_ROOT}"; fi; if [ -z "$R" ] && [ -f "${VBW_CACHE_ROOT}/local/scripts/hook-wrapper.sh" ]; then R="${VBW_CACHE_ROOT}/local"; fi; if [ -z "$R" ]; then V=$(find "${VBW_CACHE_ROOT}" -maxdepth 1 -mindepth 1 2>/dev/null | awk -F/ '{print $NF}' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); [ -n "$V" ] && [ -f "${VBW_CACHE_ROOT}/${V}/scripts/hook-wrapper.sh" ] && R="${VBW_CACHE_ROOT}/${V}"; fi; if [ -z "$R" ]; then L=$(find "${VBW_CACHE_ROOT}" -maxdepth 1 -mindepth 1 2>/dev/null | awk -F/ '{print $NF}' | sort | tail -1); [ -n "$L" ] && [ -f "${VBW_CACHE_ROOT}/${L}/scripts/hook-wrapper.sh" ] && R="${VBW_CACHE_ROOT}/${L}"; fi; if [ -z "$R" ] && [ -f "${SESSION_LINK}/scripts/hook-wrapper.sh" ]; then R="${SESSION_LINK}"; fi; if [ -z "$R" ]; then ANY_LINK=$(command find -H /tmp -maxdepth 1 -name '.vbw-plugin-root-link-*' -print 2>/dev/null | LC_ALL=C sort | while IFS= read -r link; do if [ -f "$link/scripts/hook-wrapper.sh" ]; then printf '%s\n' "$link"; break; fi; done || true); [ -n "$ANY_LINK" ] && R="$ANY_LINK"; fi; if [ -z "$R" ]; then D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- "--plugin-dir [^ ]+" | head -1); D="${D#--plugin-dir }"; [ -n "$D" ] && [ -f "$D/scripts/hook-wrapper.sh" ] && R="$D"; fi; if [ -z "$R" ] || [ ! -d "$R" ]; then echo "VBW: plugin root resolution failed" >&2; exit 1; fi; LINK="${SESSION_LINK}"; REAL_R=$(cd "$R" 2>/dev/null && pwd -P) || REAL_R="$R"; bash "$REAL_R/scripts/ensure-plugin-root-link.sh" "$LINK" "$REAL_R" >/dev/null 2>&1 || { echo "VBW: plugin root link failed" >&2; exit 1; }; echo "$LINK"`
+```
 Version:
 ```text
-!`cat VERSION 2>/dev/null || echo "none"`
+!`cat "/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/VERSION" 2>/dev/null || echo "none"`
 ```
 
 ## Checks
 
-Run ALL checks below. For each, report PASS or FAIL with a one-line detail.
+Run ALL checks below. For each, report PASS or FAIL with a one-line detail. Replace `{plugin-root}` with the literal Plugin root value from Context.
 
 ### 1. jq installed
 `jq --version 2>/dev/null || echo "MISSING"`
 FAIL if missing: "Install jq: brew install jq (macOS) or apt install jq (Linux)"
 
 ### 2. VERSION file exists
-Check `VERSION` in repo root. FAIL if missing.
+Check `{plugin-root}/VERSION`. FAIL if missing.
 
 ### 3. Version sync
-`bash scripts/bump-version.sh --verify 2>&1`
+`bash "{plugin-root}/scripts/bump-version.sh" --verify 2>&1`
 FAIL if mismatch detected.
 
 ### 4. Plugin cache present
 Check `${CLAUDE_CONFIG_DIR:-~/.claude}/plugins/cache/vbw-marketplace/vbw/` exists and has at least one version directory. FAIL if empty or missing.
 
 ### 5. hooks.json valid
-Parse `hooks/hooks.json` with `jq empty`. FAIL if parse error.
+Parse `{plugin-root}/hooks/hooks.json` with `jq empty`. FAIL if parse error.
 
 ### 6. Agent files present
-Glob `agents/vbw-*.md`. Expect 7 files (lead, dev, qa, scout, debugger, architect, docs). FAIL if any missing.
+Glob `{plugin-root}/agents/vbw-*.md`. Expect 7 files (lead, dev, qa, scout, debugger, architect, docs). FAIL if any missing.
 
 ### 7. Config valid (project only)
 If `.vbw-planning/config.json` exists, parse with `jq empty`. FAIL if parse error. SKIP if no project initialized.
 
 ### 8. Scripts executable
-Check all `scripts/*.sh` files. WARN if any lack execute permission.
+Check all `{plugin-root}/scripts/*.sh` files. WARN if any lack execute permission.
 
 ### 9. gh CLI available
 `gh --version 2>/dev/null || echo "MISSING"`
@@ -60,7 +64,7 @@ PASS if result is "1.0.10". WARN if sort -V unavailable (fallback will be used).
 ### Runtime Health
 
 ### 11. Stale teams
-Run `bash scripts/doctor-cleanup.sh scan 2>/dev/null` and count lines starting with `stale_team|`.
+Run `bash "{plugin-root}/scripts/doctor-cleanup.sh" scan 2>/dev/null` and count lines starting with `stale_team|`.
 PASS if 0. WARN if any, show count.
 
 ### 12. Orphaned processes
@@ -81,24 +85,24 @@ PASS if alive or not in tmux. WARN if dead watchdog in tmux.
 
 ### 16. CLAUDE.md sections
 If `.vbw-planning/` exists (project initialized):
-- Run `bash scripts/check-claude-md-staleness.sh --json 2>/dev/null`
+- Run `bash "{plugin-root}/scripts/check-claude-md-staleness.sh" --json 2>/dev/null`
 - Parse JSON output: `stale`, `missing_sections`, `version_mismatch`, `installed_version`, `marker_version`
 - PASS if `stale` is false
 - WARN if `stale` is true — show missing sections and/or version mismatch detail
 - SKIP if no `.vbw-planning/` directory (not bootstrapped)
 
-If user invoked with `--cleanup`: run `bash scripts/check-claude-md-staleness.sh --fix 2>&1` and report result. The fix must refresh only VBW-owned sections in place, preserve all other `CLAUDE.md` content verbatim, and add `## Code Intelligence` only when no Code Intelligence heading/guidance already exists.
+If user invoked with `--cleanup`: run `bash "{plugin-root}/scripts/check-claude-md-staleness.sh" --fix 2>&1` and report result. The fix must refresh only VBW-owned sections in place, preserve all other `CLAUDE.md` content verbatim, and add `## Code Intelligence` only when no Code Intelligence heading/guidance already exists.
 
 ### 17. State consistency
 If `.vbw-planning/` exists:
-- Run `bash scripts/verify-state-consistency.sh .vbw-planning --mode advisory 2>/dev/null`
+- Run `bash "{plugin-root}/scripts/verify-state-consistency.sh" .vbw-planning --mode advisory 2>/dev/null`
 - Parse JSON output with jq: `.verdict`
 - PASS if verdict is `"pass"`
 - WARN if verdict is `"fail"` — show `.failed_checks` array
 - SKIP if no `.vbw-planning/` directory (not bootstrapped)
 
 ### 18. RTK integration
-Run `bash scripts/rtk-manager.sh doctor-json 2>/dev/null`.
+Run `bash "{plugin-root}/scripts/rtk-manager.sh" doctor-json 2>/dev/null`.
 - Parse JSON output: `doctor_status`, `doctor_detail`, `compatibility`, `updated_input_risk`, `proof_source`
 - SKIP when RTK is absent and no local RTK project files exist
 - WARN when binary-only, hook-active-unverified, multiple Bash `PreToolUse` hooks exist, `updatedInput` risk applies, or a cached explicit update check says RTK is outdated
@@ -141,7 +145,7 @@ If any WARN from checks 11-14, 16, or 17:
 - Display: "Run `/vbw:doctor --cleanup` to apply cleanup"
 
 If user invoked with `--cleanup` (check for this in the command arguments):
-- Run `bash scripts/doctor-cleanup.sh cleanup 2>&1` for runtime findings
-- Run `bash scripts/check-claude-md-staleness.sh --fix 2>&1` for stale CLAUDE.md (non-destructive in-place refresh of VBW-owned sections only)
+- Run `bash "{plugin-root}/scripts/doctor-cleanup.sh" cleanup 2>&1` for runtime findings
+- Run `bash "{plugin-root}/scripts/check-claude-md-staleness.sh" --fix 2>&1` for stale CLAUDE.md (non-destructive in-place refresh of VBW-owned sections only)
 - Report what was cleaned
 - Show updated counts

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -104,8 +104,8 @@ If `.vbw-planning/` exists:
 ### 18. RTK integration
 Run `bash "{plugin-root}/scripts/rtk-manager.sh" doctor-json 2>/dev/null`.
 - Parse JSON output: `doctor_status`, `doctor_detail`, `compatibility`, `updated_input_risk`, `proof_source`
-- SKIP when RTK is absent and no local RTK project files exist
-- WARN when binary-only, hook-active-unverified, multiple Bash `PreToolUse` hooks exist, `updatedInput` risk applies, or a cached explicit update check says RTK is outdated
+- SKIP only when RTK is absent and helper JSON reports no local/global RTK artifacts, no VBW RTK receipt, and no partial install evidence
+- WARN when binary-only, hook-active-unverified, artifact-only, multiple Bash `PreToolUse` hooks exist, `updatedInput` risk applies, or a cached explicit update check says RTK is outdated
 - PASS only when `compatibility` is `"verified"` with a concrete `proof_source`
 - Doctor must not query the network; update availability may only come from cached explicit `/vbw:rtk status --check-updates` or `/vbw:rtk update` data
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -97,6 +97,14 @@ If `.vbw-planning/` exists:
 - WARN if verdict is `"fail"` — show `.failed_checks` array
 - SKIP if no `.vbw-planning/` directory (not bootstrapped)
 
+### 18. RTK integration
+Run `bash scripts/rtk-manager.sh doctor-json 2>/dev/null`.
+- Parse JSON output: `doctor_status`, `doctor_detail`, `compatibility`, `updated_input_risk`, `proof_source`
+- SKIP when RTK is absent and no local RTK project files exist
+- WARN when binary-only, hook-active-unverified, multiple Bash `PreToolUse` hooks exist, `updatedInput` risk applies, or a cached explicit update check says RTK is outdated
+- PASS only when `compatibility` is `"verified"` with a concrete `proof_source`
+- Doctor must not query the network; update availability may only come from cached explicit `/vbw:rtk status --check-updates` or `/vbw:rtk update` data
+
 ## Output Format
 
 ```
@@ -119,8 +127,9 @@ VBW Doctor v{version}
  15. Watchdog status      {PASS|WARN}
  16. CLAUDE.md sections   {PASS|WARN|SKIP}
  17. State consistency    {PASS|WARN|SKIP}
+ 18. RTK integration      {PASS|WARN|SKIP} {detail}
 
-Result: {N}/17 passed, {W} warnings, {F} failures
+Result: {N}/18 passed, {W} warnings, {F} failures
 ```
 
 Use checkmark for PASS, warning triangle for WARN, X for FAIL.

--- a/commands/rtk.md
+++ b/commands/rtk.md
@@ -1,0 +1,155 @@
+---
+name: vbw:rtk
+category: supporting
+disable-model-invocation: true
+description: Install, update, verify, and manage optional RTK tool-output compression.
+argument-hint: [status|install|init|verify|update|uninstall]
+allowed-tools: Read, Bash, AskUserQuestion
+---
+
+# VBW RTK $ARGUMENTS
+
+## Context
+
+Plugin root:
+```
+!`VBW_CACHE_ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/vbw-marketplace/vbw"; SESSION_KEY="${CLAUDE_SESSION_ID:-default}"; SESSION_LINK="/tmp/.vbw-plugin-root-link-${SESSION_KEY}"; R=""; if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/hook-wrapper.sh" ]; then R="${CLAUDE_PLUGIN_ROOT}"; fi; if [ -z "$R" ] && [ -f "${VBW_CACHE_ROOT}/local/scripts/hook-wrapper.sh" ]; then R="${VBW_CACHE_ROOT}/local"; fi; if [ -z "$R" ]; then V=$(find "${VBW_CACHE_ROOT}" -maxdepth 1 -mindepth 1 2>/dev/null | awk -F/ '{print $NF}' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); [ -n "$V" ] && [ -f "${VBW_CACHE_ROOT}/${V}/scripts/hook-wrapper.sh" ] && R="${VBW_CACHE_ROOT}/${V}"; fi; if [ -z "$R" ]; then L=$(find "${VBW_CACHE_ROOT}" -maxdepth 1 -mindepth 1 2>/dev/null | awk -F/ '{print $NF}' | sort | tail -1); [ -n "$L" ] && [ -f "${VBW_CACHE_ROOT}/${L}/scripts/hook-wrapper.sh" ] && R="${VBW_CACHE_ROOT}/${L}"; fi; if [ -z "$R" ] && [ -f "${SESSION_LINK}/scripts/hook-wrapper.sh" ]; then R="${SESSION_LINK}"; fi; if [ -z "$R" ]; then ANY_LINK=$(command find -H /tmp -maxdepth 1 -name '.vbw-plugin-root-link-*' -print 2>/dev/null | LC_ALL=C sort | while IFS= read -r link; do if [ -f "$link/scripts/hook-wrapper.sh" ]; then printf '%s\n' "$link"; break; fi; done || true); [ -n "$ANY_LINK" ] && R="$ANY_LINK"; fi; if [ -z "$R" ]; then D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- "--plugin-dir [^ ]+" | head -1); D="${D#--plugin-dir }"; [ -n "$D" ] && [ -f "$D/scripts/hook-wrapper.sh" ] && R="$D"; fi; if [ -z "$R" ] || [ ! -d "$R" ]; then echo "VBW: plugin root resolution failed" >&2; exit 1; fi; LINK="${SESSION_LINK}"; REAL_R=$(cd "$R" 2>/dev/null && pwd -P) || REAL_R="$R"; bash "$REAL_R/scripts/ensure-plugin-root-link.sh" "$LINK" "$REAL_R" >/dev/null 2>&1 || { echo "VBW: plugin root link failed" >&2; exit 1; }; echo "$LINK"`
+```
+
+RTK state:
+```json
+!`PLUGIN_ROOT="/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}"; bash "$PLUGIN_ROOT/scripts/rtk-manager.sh" status --json 2>/dev/null || echo '{"summary":"RTK status unavailable","next_action":"status","compatibility":"unknown"}'`
+```
+
+AskUserQuestion reference: @${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md
+
+## Guard
+
+- Store the Plugin root output above as `{plugin-root}`.
+- Do not run RTK install, update, hook activation, or uninstall unless the user explicitly invoked the matching RTK subcommand or confirmed the no-args menu.
+- Binary install/update and Claude Code hook activation are separate operations. Never combine them into one confirmation.
+- Default `status` is read-only and offline. Only `status --check-updates`, `install`, or `update` may query GitHub release metadata.
+
+## Behavior
+
+### Step 1: Parse intent
+
+Recognized subcommands: `status`, `install`, `init`, `verify`, `update`, `uninstall`.
+
+If no subcommand is provided, use the RTK state JSON to present one bounded AskUserQuestion:
+
+- header: `RTK setup`
+- question: `What do you want to do?`
+- options: choose 2–4 relevant visible options only:
+  - `Install RTK binary` when `rtk_present=false`
+  - `Update RTK binary` when `update_available=true`
+  - `Enable Claude Code hook` when `rtk_present=true` and `global_hook_present=false`
+  - `Verify RTK/VBW coexistence` when `global_hook_present=true` and `compatibility` is not `verified`
+  - `Uninstall/manage RTK` when `managed_by_vbw=true` or `global_hook_present=true`
+  - `Exit` when no action is wanted
+
+For bounded AskUserQuestion replies:
+- accept direct option intent that clearly matches a visible choice
+- accept unambiguous visible option-number replies such as `#1`, `option 2`, or `2`
+- accept hybrid replies anchored to a visible option number such as `#2 please`
+- re-ask only when the reply is ambiguous or invalid for the same question
+- do NOT add an extra visible `Other` option
+
+### Step 2: Status
+
+For `/vbw:rtk status`:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" status --json
+```
+
+For `/vbw:rtk status --check-updates`:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" status --json --check-updates
+```
+
+Display `summary`, `rtk_version`, `latest_version` when present, `compatibility`, and `next_action`. Do not run `rtk gain` unless the user explicitly asks for stats/metrics.
+
+### Step 3: Install or update binary
+
+For install/update, first run the dry-run preflight and show it verbatim:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" install --dry-run
+```
+
+or:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" update --dry-run
+```
+
+The preflight must show `Installed`, `Latest`, `Method`, `Will run`, `Writes`, `Does not do`, `Next step`, and `Risk`. It must state that VBW-managed code does not use `sudo`, does not edit shell profiles, does not edit Claude settings, does not run `rtk init -g`, and does not pipe downloaded shell scripts into sh.
+
+Ask for one explicit confirmation after the preflight. If confirmed, run exactly one mutating helper command:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" install --yes
+```
+
+or:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" update --yes
+```
+
+If the helper reports the install directory is not on `PATH`, show the PATH line and do not offer hook activation until the user has made the binary visible.
+
+### Step 4: Enable hook
+
+Before hook activation, run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" init --dry-run
+```
+
+Show the `RTK hook preflight` verbatim. It must mention `rtk init -g`, possible writes to Claude Code user config, restart requirement, and the PreToolUse `updatedInput` risk from Claude Code issue #15897.
+
+Ask for a separate explicit confirmation. If confirmed, run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" init --yes
+```
+
+Do not disable, reorder, or weaken VBW `bash-guard.sh`.
+
+### Step 5: Verify
+
+For `/vbw:rtk verify`:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" verify
+```
+
+Static verification may confirm binary, settings hook, RTK docs/artifacts, and VBW hook presence. Runtime compatibility is PASS only when a concrete smoke proof source exists. Otherwise report `hook_active_unverified` or `risk` and show the manual smoke steps.
+
+### Step 6: Uninstall/manage
+
+For `/vbw:rtk uninstall`, first run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --dry-run
+```
+
+Ask for confirmation. If confirmed, run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --yes
+```
+
+For externally managed installs, do not delete the binary. Show package-manager/manual uninstall guidance from the helper output instead.
+
+## Output
+
+Keep output compact:
+
+- current RTK state
+- preflight details for mutating operations
+- exact next action
+- compatibility caveat when hook is active but unverified

--- a/commands/rtk.md
+++ b/commands/rtk.md
@@ -127,7 +127,7 @@ For `/vbw:rtk verify`:
 bash "{plugin-root}/scripts/rtk-manager.sh" verify
 ```
 
-Static verification may confirm binary, settings hook, RTK docs/artifacts, and VBW hook presence. Runtime compatibility is PASS only when a concrete smoke proof source exists. Otherwise report `hook_active_unverified` or `risk` and show the manual smoke steps.
+Static verification may confirm binary, settings hook, RTK docs/artifacts, and VBW hook presence. Runtime compatibility is PASS only when the helper reports `compatibility=verified` with a validated runtime smoke proof source. Otherwise report `hook_active_unverified` or `risk` and show the manual smoke steps.
 
 ### Step 6: Uninstall/manage
 

--- a/commands/rtk.md
+++ b/commands/rtk.md
@@ -44,6 +44,7 @@ If no subcommand is provided, use the RTK state JSON to present one bounded AskU
   - `Install RTK binary` when `rtk_present=false`
   - `Update RTK binary` when `update_available=true`
   - `Enable Claude Code hook` when `rtk_present=true` and `global_hook_present=false`
+  - `Show PATH guidance` when `managed_by_vbw=true` and `binary_install_state="installed_not_on_path"`
   - `Verify RTK/VBW coexistence` when `global_hook_present=true` and `compatibility` is not `verified`
   - `Uninstall/manage RTK` when `managed_by_vbw=true` or `global_hook_present=true`
   - `Exit` when no action is wanted
@@ -131,7 +132,21 @@ Static verification may confirm binary, settings hook, RTK docs/artifacts, and V
 
 ### Step 6: Uninstall/manage
 
-For `/vbw:rtk uninstall`, first run:
+For `/vbw:rtk uninstall`, choose the helper path from RTK state:
+
+- If `managed_by_vbw=true` and `global_hook_present=true`, first run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --dry-run --deactivate-hook
+```
+
+Ask for one explicit confirmation that names both Claude Code hook deactivation and VBW-managed binary removal. If confirmed, run:
+
+```bash
+bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --yes --deactivate-hook
+```
+
+- If `managed_by_vbw=true` and `global_hook_present=false`, first run:
 
 ```bash
 bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --dry-run
@@ -143,7 +158,7 @@ Ask for confirmation. If confirmed, run:
 bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --yes
 ```
 
-For externally managed installs, do not delete the binary. Show package-manager/manual uninstall guidance from the helper output instead.
+- For externally managed installs, do not delete the binary. Show package-manager/manual uninstall guidance from the helper output instead.
 
 ## Output
 

--- a/commands/rtk.md
+++ b/commands/rtk.md
@@ -134,13 +134,13 @@ Static verification may confirm binary, settings hook, RTK docs/artifacts, and V
 
 For `/vbw:rtk uninstall`, choose the helper path from RTK state:
 
-- If `managed_by_vbw=true` and `global_hook_present=true`, first run:
+- If `managed_by_vbw=true` and either `global_hook_present=true` or `settings_json_valid=false`, first run:
 
 ```bash
 bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --dry-run --deactivate-hook
 ```
 
-Ask for one explicit confirmation that names both Claude Code hook deactivation and VBW-managed binary removal. If confirmed, run:
+Ask for one explicit confirmation that names both Claude Code hook deactivation/settings repair risk and VBW-managed binary removal. If confirmed, run:
 
 ```bash
 bash "{plugin-root}/scripts/rtk-manager.sh" uninstall --yes --deactivate-hook

--- a/commands/status.md
+++ b/commands/status.md
@@ -180,4 +180,6 @@ Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
     Cache hit rate: {percent}%
 ```
 
+  **RTK external metrics** (only when `--metrics` is explicit): run `bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/rtk-manager.sh status --json --stats`. If RTK is absent, show nothing. If RTK is present, show one compact line labeled external, for example `RTK external: active, 47% avg savings` or `RTK external: hook active, compatibility unverified`. RTK savings are external RTK savings, not VBW savings. Default `/vbw:status` must not advertise RTK when absent and must not run RTK stats or network checks.
+
 **Next Up:** Run `bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/suggest-next.sh status` and display.

--- a/docs/vbw-vs-paul-analysis.md
+++ b/docs/vbw-vs-paul-analysis.md
@@ -401,7 +401,7 @@ PAUL's argument applies to stock subagent spawning. It does not apply to VBW's a
 | Is VBW more like PAUL than GSD? | VBW shares PAUL's quality-first philosophy but implements it with mechanically stronger enforcement than PAUL provides. VBW also retains (and improves upon) GSD's execution speed through context-compiled parallel Agent Teams. |
 | Does VBW address PAUL's criticisms of GSD? | Yes, every one of them — and in most cases goes further than PAUL does. |
 | Should VBW users worry about PAUL's claims? | No. Every claimed advantage in PAUL-VS-GSD.md is already present in VBW, typically with stronger implementation. |
-| Is PAUL a competitor to VBW? | PAUL is a lightweight framework (~26 commands, markdown-only, single-agent) with good principles. VBW is a full-stack development lifecycle platform (24 commands, 85 scripts, 21 hooks, 7 agents, 845 tests). They operate at different scales. |
+| Is PAUL a competitor to VBW? | PAUL is a lightweight framework (markdown-only, single-agent) with good principles. VBW is a full-stack development lifecycle platform with commands, scripts, hooks, specialized agents, and a broad test suite. They operate at different scales. |
 
 **VBW is not PAUL. VBW is not GSD. VBW is what happens when you take the best ideas from both — mandatory loop closure, token efficiency, acceptance-driven verification, structured session continuity — and implement them with platform-level enforcement, parallel execution, and comprehensive automation.**
 

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -522,7 +522,7 @@ status_json() {
     --argjson legacy_hook_file_present "$(bool_to_json "$legacy_hook")" \
     --argjson project_local_present "$(bool_to_json "$project_local")" \
     --argjson vbw_bash_hook_present "$(bool_to_json "$vbw_hook")" \
-    --argjson multiple_bash_pretookuse_hooks_detected "$(bool_to_json "$multiple_bash")" \
+    --argjson multiple_bash_pretooluse_hooks_detected "$(bool_to_json "$multiple_bash")" \
     --argjson updated_input_risk "$(bool_to_json "$updated_input_risk")" \
     --arg compatibility "$compatibility" \
     --arg proof_source "$proof_source" \
@@ -555,7 +555,7 @@ status_json() {
       legacy_hook_file_present: $legacy_hook_file_present,
       project_local_present: $project_local_present,
       vbw_bash_hook_present: $vbw_bash_hook_present,
-      multiple_bash_pretookuse_hooks_detected: $multiple_bash_pretookuse_hooks_detected,
+      multiple_bash_pretooluse_hooks_detected: $multiple_bash_pretooluse_hooks_detected,
       updated_input_risk: $updated_input_risk,
       compatibility: $compatibility,
       proof_source: $proof_source,

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -23,6 +23,7 @@ RTK_GLOBAL_MD="${RTK_GLOBAL_MD:-$CLAUDE_DIR/RTK.md}"
 RTK_CLAUDE_MD="${RTK_CLAUDE_MD:-$CLAUDE_DIR/CLAUDE.md}"
 RTK_INSTALL_DIR_DEFAULT="${RTK_INSTALL_DIR:-$HOME/.local/bin}"
 RTK_LEGACY_CLAUDE_DIR="${RTK_LEGACY_CLAUDE_DIR:-${HOME}/.claude}"
+RTK_CURL_MAX_TIME="${RTK_CURL_MAX_TIME:-15}"
 RTK_TEMP_DIR=""
 
 cleanup_temp_dir() {
@@ -254,9 +255,13 @@ os_arch_target() {
   esac
 }
 
+curl_bounded() {
+  curl -fsSL --max-time "$RTK_CURL_MAX_TIME" "$@"
+}
+
 curl_json() {
   local url="$1"
-  curl -fsSL "$url"
+  curl_bounded "$url"
 }
 
 fetch_latest_release() {
@@ -790,9 +795,9 @@ install_or_update() {
   trap cleanup_temp_dir EXIT
   asset_file="$temp_dir/$asset_name"
   checksums_file="$temp_dir/checksums.txt"
-  curl -fsSL -o "$asset_file" "$asset_url"
+  curl_bounded -o "$asset_file" "$asset_url"
   if [ -n "$checksums_url" ]; then
-    curl -fsSL -o "$checksums_file" "$checksums_url"
+    curl_bounded -o "$checksums_file" "$checksums_url"
   else
     : > "$checksums_file"
   fi

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -714,15 +714,47 @@ verify_download_checksum() {
   echo "$actual"
 }
 
-extract_rtk_binary() {
-  local asset="$1" temp_dir="$2" found
-  mkdir -p "$temp_dir"
-  tar -xzf "$asset" -C "$temp_dir"
-  found="$(find "$temp_dir" -type f -name rtk -perm -u+x -print 2>/dev/null | head -1 || true)"
-  if [ -z "$found" ]; then
-    found="$(find "$temp_dir" -type f -name rtk -print 2>/dev/null | head -1 || true)"
+rtk_archive_member_safe() {
+  local member="$1"
+  [ -n "$member" ] || return 1
+  case "$member" in
+    /*|..|../*|*/..|*/../*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+validate_rtk_archive_members() {
+  local asset="$1" member rtk_member="" rtk_count=0
+  while IFS= read -r member; do
+    [ -n "$member" ] || continue
+    if ! rtk_archive_member_safe "$member"; then
+      die 1 "unsafe RTK archive member path: $member"
+    fi
+    case "$member" in
+      */) continue ;;
+    esac
+    if [ "$(basename "$member")" = "rtk" ]; then
+      rtk_member="$member"
+      rtk_count=$((rtk_count + 1))
+    fi
+  done < <(tar -tzf "$asset" 2>/dev/null || die 1 "failed to read RTK release archive")
+
+  if [ "$rtk_count" -eq 0 ]; then
+    die 1 "downloaded RTK asset did not contain an rtk binary"
   fi
-  [ -n "$found" ] || die 1 "downloaded RTK asset did not contain an rtk binary"
+  if [ "$rtk_count" -gt 1 ]; then
+    die 1 "RTK release archive contains multiple rtk binaries; refusing ambiguous extraction"
+  fi
+  printf '%s\n' "$rtk_member"
+}
+
+extract_rtk_binary() {
+  local asset="$1" temp_dir="$2" rtk_member found
+  mkdir -p "$temp_dir"
+  rtk_member="$(validate_rtk_archive_members "$asset")"
+  tar -xzf "$asset" -C "$temp_dir" -- "$rtk_member"
+  found="$temp_dir/$rtk_member"
+  [ -f "$found" ] || die 1 "downloaded RTK asset did not contain an rtk binary"
   chmod +x "$found" 2>/dev/null || true
   printf '%s\n' "$found"
 }

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -325,7 +325,7 @@ status_json() {
   local rtk_path rtk_present rtk_version latest_json latest_version latest_checked_at update_available version_source
   local managed_by_vbw install_receipt receipt_binary binary_install_state can_install preferred_install_method
   local settings_json_valid hook_command hook_matcher global_hook_present global_claude_ref global_rtk_md legacy_hook project_local vbw_hook bash_hook_count multiple_bash updated_input_risk
-  local proof_source compatibility restart_required summary next_action stats_json
+  local settings_hook_state proof_source compatibility restart_required summary next_action stats_json
 
   rtk_path="$(rtk_path_detect)"
   rtk_present=false
@@ -368,11 +368,14 @@ status_json() {
 
   settings_json_valid=true
   if ! settings_valid; then settings_json_valid=false; fi
+  settings_hook_state="inactive"
   hook_command=""
   hook_matcher=""
   if [ "$settings_json_valid" = "true" ]; then
     hook_command="$(settings_hook_command)"
     hook_matcher="$(settings_hook_matcher)"
+  else
+    settings_hook_state="unknown"
   fi
   global_claude_ref=false
   if global_claude_ref_present; then global_claude_ref=true; fi
@@ -385,7 +388,10 @@ status_json() {
   vbw_hook=false
   if vbw_bash_hook_present; then vbw_hook=true; fi
   global_hook_present=false
-  if [ -n "$hook_command" ]; then global_hook_present=true; fi
+  if [ -n "$hook_command" ]; then
+    global_hook_present=true
+    settings_hook_state="active"
+  fi
   bash_hook_count=0
   if [ "$settings_json_valid" = "true" ]; then bash_hook_count="$(settings_bash_hook_count)"; fi
   multiple_bash=false
@@ -402,7 +408,9 @@ status_json() {
 
   compatibility="absent"
   restart_required=false
-  if [ -n "$proof_source" ] && [ "$global_hook_present" = "true" ]; then
+  if [ "$settings_hook_state" = "unknown" ]; then
+    compatibility="settings_unreadable"
+  elif [ -n "$proof_source" ] && [ "$global_hook_present" = "true" ]; then
     compatibility="verified"
   elif [ "$global_hook_present" = "true" ] && [ "$updated_input_risk" = "true" ]; then
     compatibility="risk"
@@ -427,6 +435,10 @@ status_json() {
         summary="RTK not installed; optional: /vbw:rtk install"
         next_action="install"
       fi
+      ;;
+    settings_unreadable)
+      summary="Claude settings unreadable; RTK hook state cannot be determined from ${RTK_SETTINGS_JSON}"
+      next_action="repair_settings"
       ;;
     binary_only)
       summary="RTK binary installed; Claude Code hook inactive"
@@ -470,6 +482,7 @@ status_json() {
     --argjson can_install "$(bool_to_json "$can_install")" \
     --arg binary_install_state "$binary_install_state" \
     --argjson settings_json_valid "$(bool_to_json "$settings_json_valid")" \
+    --arg settings_hook_state "$settings_hook_state" \
     --argjson global_hook_present "$(bool_to_json "$global_hook_present")" \
     --arg global_hook_command "$hook_command" \
     --arg global_hook_matcher "$hook_matcher" \
@@ -500,6 +513,7 @@ status_json() {
       can_install: $can_install,
       binary_install_state: $binary_install_state,
       settings_json_valid: $settings_json_valid,
+      settings_hook_state: $settings_hook_state,
       global_hook_present: $global_hook_present,
       global_hook_command: $global_hook_command,
       global_hook_matcher: $global_hook_matcher,
@@ -523,13 +537,15 @@ doctor_json() {
   status_json false false | jq '
     . as $s
     | .doctor_status = (
-        if ($s.compatibility == "absent" and ($s.project_local_present | not) and ($s.legacy_hook_file_present | not)) then "SKIP"
+        if ($s.settings_json_valid == false) then "WARN"
+        elif ($s.compatibility == "absent" and ($s.project_local_present | not) and ($s.legacy_hook_file_present | not)) then "SKIP"
         elif ($s.update_available == true) then "WARN"
         elif ($s.compatibility == "verified") then "PASS"
         else "WARN" end
       )
     | .doctor_detail = (
-        if .update_available == true then "outdated from cached RTK release check; run /vbw:rtk update"
+        if .settings_json_valid == false then "Claude settings unreadable; RTK hook state cannot be determined from settings.json"
+        elif .update_available == true then "outdated from cached RTK release check; run /vbw:rtk update"
         elif .doctor_status == "PASS" then "verified by " + ($s.proof_source // "smoke proof")
         elif .compatibility == "absent" then "not installed; optional: /vbw:rtk install"
         elif .compatibility == "binary_only" then "binary installed; hook inactive"
@@ -802,10 +818,10 @@ verify_rtk() {
     esac
   done
   if [ "$as_json" = "true" ]; then
-    status_json false true
+    status_json false false
     return 0
   fi
-  status_json false true | jq -r '
+  status_json false false | jq -r '
     "RTK verify\n" +
     "Static: " + .summary + "\n" +
     "Runtime: " + (if .compatibility == "verified" then "verified by " + .proof_source else "manual Claude Code smoke required before PASS" end) + "\n" +
@@ -814,7 +830,7 @@ verify_rtk() {
 }
 
 uninstall_rtk() {
-  local dry_run=false yes=false deactivate_hook=false binary_path managed rtk_path active_hook will_run
+  local dry_run=false yes=false deactivate_hook=false binary_path managed rtk_path active_hook settings_unknown will_run
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --dry-run) dry_run=true; shift ;;
@@ -827,15 +843,20 @@ uninstall_rtk() {
   if receipt_managed; then managed=true; fi
   binary_path="$(rtk_path_from_receipt)"
   active_hook=""
-  if settings_valid; then active_hook="$(settings_hook_command)"; fi
+  settings_unknown=false
+  if settings_valid; then
+    active_hook="$(settings_hook_command)"
+  else
+    settings_unknown=true
+  fi
   echo "RTK uninstall preflight"
   if [ "$managed" = "true" ] && [ -n "$binary_path" ]; then
     echo "Will remove: $binary_path (VBW receipt-owned)"
   else
     echo "Will remove: no binary; external installs are not deleted by VBW"
   fi
-  if [ "$managed" = "true" ] && [ -n "$active_hook" ] && [ "$deactivate_hook" != "true" ]; then
-    will_run="hook deactivation required before binary removal; rerun with --deactivate-hook"
+  if [ "$managed" = "true" ] && { [ -n "$active_hook" ] || [ "$settings_unknown" = "true" ]; } && [ "$deactivate_hook" != "true" ]; then
+    will_run="hook deactivation or settings repair required before binary removal; rerun with --deactivate-hook after confirming settings intent"
   elif [ "$deactivate_hook" = "true" ]; then
     will_run="rtk init -g --uninstall before binary removal"
   elif [ "$managed" = "true" ] && [ -n "$binary_path" ]; then
@@ -847,8 +868,8 @@ uninstall_rtk() {
   echo "Writes: receipt/backups under ${VBW_RTK_DIR}; RTK may edit Claude settings only when --deactivate-hook is used"
   ensure_confirmation "$yes" "$dry_run" "uninstall"
   [ "$dry_run" = "true" ] && exit 0
-  if [ "$managed" = "true" ] && [ -n "$active_hook" ] && [ "$deactivate_hook" != "true" ]; then
-    echo "RTK: active RTK settings hook detected; pass --deactivate-hook before removing the VBW-managed binary" >&2
+  if [ "$managed" = "true" ] && { [ -n "$active_hook" ] || [ "$settings_unknown" = "true" ]; } && [ "$deactivate_hook" != "true" ]; then
+    echo "RTK: active or unreadable RTK settings hook state detected; pass --deactivate-hook before removing the VBW-managed binary" >&2
     exit 1
   fi
   if [ "$deactivate_hook" = "true" ]; then

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -120,7 +120,7 @@ rtk_path_detect() {
 rtk_version_detect() {
   local path="$1" out
   [ -n "$path" ] || return 0
-  out="$($path --version 2>/dev/null || true)"
+  out="$("$path" --version 2>/dev/null || true)"
   normalize_version "$out"
 }
 
@@ -620,6 +620,12 @@ backup_if_present() {
   cp -p "$path" "$dest" 2>/dev/null || cp "$path" "$dest"
 }
 
+backup_rtk_global_config_files() {
+  backup_if_present "$RTK_SETTINGS_JSON"
+  backup_if_present "$RTK_CLAUDE_MD"
+  backup_if_present "$RTK_GLOBAL_MD"
+}
+
 write_receipt() {
   local operation="$1" binary_path="$2" previous_version="$3" installed_version="$4" metadata="$5" checksum="$6" tmp
   mkdir -p "$VBW_RTK_DIR"
@@ -765,7 +771,7 @@ install_or_update() {
   previous_version="$installed_version"
   cp "$extracted" "$target_path"
   chmod +x "$target_path"
-  installed_version="$($target_path --version 2>/dev/null | awk 'match($0, /[0-9]+([.][0-9]+)+/) {print substr($0, RSTART, RLENGTH); exit}' || true)"
+  installed_version="$("$target_path" --version 2>/dev/null | awk 'match($0, /[0-9]+([.][0-9]+)+/) {print substr($0, RSTART, RLENGTH); exit}' || true)"
   write_receipt "$operation" "$target_path" "$previous_version" "$installed_version" "$metadata" "$checksum"
   cache_latest_release "$metadata"
   echo "✓ RTK ${operation} complete: $target_path (${installed_version:-version unknown})"
@@ -807,9 +813,7 @@ init_hook() {
   echo "Risk: Claude Code issue #15897 reports updatedInput can fail when multiple PreToolUse hooks match; compatibility remains unverified until a runtime smoke proof exists."
   ensure_confirmation "$yes" "$dry_run" "init"
   [ "$dry_run" = "true" ] && exit 0
-  backup_if_present "$RTK_SETTINGS_JSON"
-  backup_if_present "$RTK_CLAUDE_MD"
-  backup_if_present "$RTK_GLOBAL_MD"
+  backup_rtk_global_config_files
   args=(init -g)
   [ "$auto_patch" = "true" ] && args+=(--auto-patch)
   [ "$hook_only" = "true" ] && args+=(--hook-only)
@@ -889,6 +893,7 @@ uninstall_rtk() {
       echo "RTK: cannot deactivate hook because no runnable RTK binary was found; preserved existing files" >&2
       exit 1
     fi
+    backup_rtk_global_config_files
     if ! "$rtk_path" init -g --uninstall; then
       echo "RTK: hook deactivation failed; preserved RTK binary and receipt for retry" >&2
       exit 1

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -110,16 +110,10 @@ rtk_path_from_receipt() {
 }
 
 rtk_path_detect() {
-  local path receipt_path
+  local path
   path="$(command_path rtk)"
   if [ -n "$path" ]; then
     printf '%s\n' "$path"
-    return 0
-  fi
-
-  receipt_path="$(rtk_path_from_receipt)"
-  if [ -n "$receipt_path" ] && [ -x "$receipt_path" ]; then
-    printf '%s\n' "$receipt_path"
   fi
 }
 
@@ -361,7 +355,9 @@ status_json() {
   if [ "$rtk_present" = "true" ]; then
     binary_install_state="present"
   elif [ -n "$receipt_binary" ] && [ -x "$receipt_binary" ]; then
-    binary_install_state="installed_path_missing"
+    binary_install_state="installed_not_on_path"
+  elif [ -n "$receipt_binary" ]; then
+    binary_install_state="receipt_missing_binary"
   fi
 
   can_install=true
@@ -421,8 +417,16 @@ status_json() {
 
   case "$compatibility" in
     absent)
-      summary="RTK not installed; optional: /vbw:rtk install"
-      next_action="install"
+      if [ "$binary_install_state" = "installed_not_on_path" ]; then
+        summary="RTK binary installed by VBW but not on PATH; add $(dirname "$receipt_binary") to PATH before hook activation"
+        next_action="path"
+      elif [ "$binary_install_state" = "receipt_missing_binary" ]; then
+        summary="VBW RTK receipt exists but binary is missing; run /vbw:rtk install or uninstall/manage"
+        next_action="repair"
+      else
+        summary="RTK not installed; optional: /vbw:rtk install"
+        next_action="install"
+      fi
       ;;
     binary_only)
       summary="RTK binary installed; Claude Code hook inactive"
@@ -614,6 +618,16 @@ write_receipt() {
   mv "$tmp" "$RTK_RECEIPT_FILE"
 }
 
+retire_install_receipt() {
+  local stamp dest
+  [ -f "$RTK_RECEIPT_FILE" ] || return 0
+  mkdir -p "$RTK_BACKUP_DIR"
+  stamp="$(now_utc | tr ':T' '--')"
+  dest="$RTK_BACKUP_DIR/rtk-install.$stamp.retired.json"
+  cp -p "$RTK_RECEIPT_FILE" "$dest" 2>/dev/null || cp "$RTK_RECEIPT_FILE" "$dest"
+  rm -f "$RTK_RECEIPT_FILE"
+}
+
 verify_download_checksum() {
   local asset="$1" asset_name="$2" checksums="$3" allow_missing="$4" expected actual
   if [ ! -s "$checksums" ]; then
@@ -740,7 +754,7 @@ install_or_update() {
 }
 
 init_hook() {
-  local dry_run=false yes=false auto_patch=false hook_only=false rtk_path args
+  local dry_run=false yes=false auto_patch=false hook_only=false rtk_path receipt_path args display_cmd
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --dry-run) dry_run=true; shift ;;
@@ -750,10 +764,19 @@ init_hook() {
       *) die 2 "unknown init option: $1" ;;
     esac
   done
-  rtk_path="$(rtk_path_detect)"
-  [ -n "$rtk_path" ] || die 1 "RTK binary not found; run /vbw:rtk install first or install RTK manually"
+  rtk_path="$(command_path rtk)"
+  if [ -z "$rtk_path" ]; then
+    receipt_path="$(rtk_path_from_receipt)"
+    if [ -n "$receipt_path" ] && [ -x "$receipt_path" ]; then
+      die 1 "RTK binary exists at $receipt_path but is not on PATH; add $(dirname "$receipt_path") to PATH before hook activation"
+    fi
+    die 1 "RTK binary not found on PATH; run /vbw:rtk install first or install RTK manually"
+  fi
+  display_cmd="$rtk_path init -g"
+  if [ "$auto_patch" = "true" ]; then display_cmd="$display_cmd --auto-patch"; fi
+  if [ "$hook_only" = "true" ]; then display_cmd="$display_cmd --hook-only"; fi
   echo "RTK hook preflight"
-  echo "Will run: $rtk_path init -g${auto_patch:+ --auto-patch}${hook_only:+ --hook-only}"
+  echo "Will run: $display_cmd"
   echo "Writes: ${RTK_SETTINGS_JSON}, ${RTK_GLOBAL_MD}, and @RTK.md references inside ${RTK_CLAUDE_MD} when RTK patches Claude Code"
   echo "Does not do: disable, reorder, or weaken VBW bash-guard.sh"
   echo "Next step: restart Claude Code after hook activation, then run /vbw:rtk verify"
@@ -791,7 +814,7 @@ verify_rtk() {
 }
 
 uninstall_rtk() {
-  local dry_run=false yes=false deactivate_hook=false binary_path managed rtk_path
+  local dry_run=false yes=false deactivate_hook=false binary_path managed rtk_path active_hook will_run
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --dry-run) dry_run=true; shift ;;
@@ -803,16 +826,31 @@ uninstall_rtk() {
   managed=false
   if receipt_managed; then managed=true; fi
   binary_path="$(rtk_path_from_receipt)"
+  active_hook=""
+  if settings_valid; then active_hook="$(settings_hook_command)"; fi
   echo "RTK uninstall preflight"
   if [ "$managed" = "true" ] && [ -n "$binary_path" ]; then
     echo "Will remove: $binary_path (VBW receipt-owned)"
   else
     echo "Will remove: no binary; external installs are not deleted by VBW"
   fi
-  echo "Will run: ${deactivate_hook:+rtk init -g --uninstall before binary removal}${deactivate_hook:-no hook deactivation unless --deactivate-hook is passed}"
+  if [ "$managed" = "true" ] && [ -n "$active_hook" ] && [ "$deactivate_hook" != "true" ]; then
+    will_run="hook deactivation required before binary removal; rerun with --deactivate-hook"
+  elif [ "$deactivate_hook" = "true" ]; then
+    will_run="rtk init -g --uninstall before binary removal"
+  elif [ "$managed" = "true" ] && [ -n "$binary_path" ]; then
+    will_run="remove VBW receipt-owned binary only; no hook deactivation requested"
+  else
+    will_run="external/no-receipt guidance only; no binary deletion"
+  fi
+  echo "Will run: $will_run"
   echo "Writes: receipt/backups under ${VBW_RTK_DIR}; RTK may edit Claude settings only when --deactivate-hook is used"
   ensure_confirmation "$yes" "$dry_run" "uninstall"
   [ "$dry_run" = "true" ] && exit 0
+  if [ "$managed" = "true" ] && [ -n "$active_hook" ] && [ "$deactivate_hook" != "true" ]; then
+    echo "RTK: active RTK settings hook detected; pass --deactivate-hook before removing the VBW-managed binary" >&2
+    exit 1
+  fi
   if [ "$deactivate_hook" = "true" ]; then
     rtk_path="$(rtk_path_detect)"
     if [ -z "$rtk_path" ] && [ -n "$binary_path" ] && [ -x "$binary_path" ]; then
@@ -829,6 +867,9 @@ uninstall_rtk() {
   fi
   if [ "$managed" = "true" ] && [ -n "$binary_path" ] && [ -e "$binary_path" ]; then
     rm -f "$binary_path"
+  fi
+  if [ "$managed" = "true" ]; then
+    retire_install_receipt
   fi
   echo "✓ RTK uninstall complete"
 }

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -124,6 +124,21 @@ rtk_version_detect() {
   normalize_version "$out"
 }
 
+rtk_path_from_hook_command() {
+  local command="$1" executable=""
+  [ -n "$command" ] || return 0
+  case "$command" in
+    "\""*) executable="${command#\"}"; executable="${executable%%\"*}" ;;
+    "'"*) executable="${command#\'}"; executable="${executable%%\'*}" ;;
+    *) executable="${command%%[[:space:]]*}" ;;
+  esac
+  case "$executable" in
+    rtk) command_path rtk ;;
+    */rtk) if [ -x "$executable" ]; then printf '%s\n' "$executable"; fi ;;
+    *) return 0 ;;
+  esac
+}
+
 receipt_managed() {
   [ -f "$RTK_RECEIPT_FILE" ] || return 1
   jq -e '.manager == "vbw"' "$RTK_RECEIPT_FILE" >/dev/null 2>&1
@@ -333,7 +348,7 @@ status_json() {
   local rtk_path rtk_present rtk_version latest_json latest_version latest_checked_at update_available version_source
   local managed_by_vbw install_receipt receipt_binary binary_install_state can_install preferred_install_method
   local settings_json_valid hook_command hook_matcher global_hook_present global_claude_ref global_rtk_md legacy_hook project_local vbw_hook bash_hook_count multiple_bash updated_input_risk
-  local settings_hook_state proof_source compatibility restart_required summary next_action stats_json
+  local settings_hook_state active_hook_rtk_path active_hook_rtk_version proof_source compatibility restart_required summary next_action stats_json
 
   rtk_path="$(rtk_path_detect)"
   rtk_present=false
@@ -400,6 +415,12 @@ status_json() {
     global_hook_present=true
     settings_hook_state="active"
   fi
+  active_hook_rtk_path=""
+  active_hook_rtk_version=""
+  if [ -n "$hook_command" ]; then
+    active_hook_rtk_path="$(rtk_path_from_hook_command "$hook_command")"
+    active_hook_rtk_version="$(rtk_version_detect "$active_hook_rtk_path")"
+  fi
   bash_hook_count=0
   if [ "$settings_json_valid" = "true" ]; then bash_hook_count="$(settings_bash_hook_count)"; fi
   multiple_bash=false
@@ -410,7 +431,7 @@ status_json() {
   [ "$multiple_bash" = "true" ] && updated_input_risk=true
 
   proof_source=""
-  if [ "$rtk_present" = "true" ] && [ -n "$hook_command" ] && valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$rtk_version" "$hook_command"; then
+  if [ -n "$hook_command" ] && [ -n "$active_hook_rtk_path" ] && valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$active_hook_rtk_version" "$hook_command"; then
     proof_source="$RTK_PROOF_FILE"
   fi
 
@@ -494,6 +515,8 @@ status_json() {
     --argjson global_hook_present "$(bool_to_json "$global_hook_present")" \
     --arg global_hook_command "$hook_command" \
     --arg global_hook_matcher "$hook_matcher" \
+    --arg active_hook_rtk_path "$active_hook_rtk_path" \
+    --arg active_hook_rtk_version "$active_hook_rtk_version" \
     --argjson global_claude_ref_present "$(bool_to_json "$global_claude_ref")" \
     --argjson global_rtk_md_present "$(bool_to_json "$global_rtk_md")" \
     --argjson legacy_hook_file_present "$(bool_to_json "$legacy_hook")" \
@@ -525,6 +548,8 @@ status_json() {
       global_hook_present: $global_hook_present,
       global_hook_command: $global_hook_command,
       global_hook_matcher: $global_hook_matcher,
+      active_hook_rtk_path: $active_hook_rtk_path,
+      active_hook_rtk_version: $active_hook_rtk_version,
       global_claude_ref_present: $global_claude_ref_present,
       global_rtk_md_present: $global_rtk_md_present,
       legacy_hook_file_present: $legacy_hook_file_present,

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -304,6 +304,8 @@ release_metadata() {
 valid_runtime_smoke_proof() {
   local proof_file="$1" current_version="$2" active_hook_command="$3"
   [ -f "$proof_file" ] || return 1
+  [ -n "$current_version" ] || return 1
+  [ -n "$active_hook_command" ] || return 1
   jq -e \
     --arg current_version "$current_version" \
     --arg active_hook_command "$active_hook_command" '
@@ -315,8 +317,10 @@ valid_runtime_smoke_proof() {
       and ((.updated_input_verified // .updatedInput_verified // false) == true)
       and ((.rtk_rewrite_observed // .rewrite_observed // false) == true)
       and ((.vbw_bash_guard_verified // .bash_guard_verified // false) == true)
-      and (($current_version == "") or ((.rtk_version // $current_version) == $current_version))
-      and (($active_hook_command == "") or ((.hook_command // $active_hook_command) == $active_hook_command))
+      and (((.rtk_version // "") | type) == "string")
+      and ((.rtk_version // "") == $current_version)
+      and (((.hook_command // "") | type) == "string")
+      and ((.hook_command // "") == $active_hook_command)
       and (
         (((.commands // .smoke_commands // .results // []) | type) == "array" and ((.commands // .smoke_commands // .results // []) | length > 0))
         or ((((.summary // .evidence // "") | type) == "string") and ((.summary // .evidence // "") | length > 0))
@@ -406,7 +410,7 @@ status_json() {
   [ "$multiple_bash" = "true" ] && updated_input_risk=true
 
   proof_source=""
-  if valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$rtk_version" "$hook_command"; then
+  if [ "$rtk_present" = "true" ] && [ -n "$hook_command" ] && valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$rtk_version" "$hook_command"; then
     proof_source="$RTK_PROOF_FILE"
   fi
 

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -1,0 +1,794 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# rtk-manager.sh — Explicit, opt-in RTK management for VBW.
+#
+# Default status is intentionally read-only and offline. Network access is
+# limited to explicit install/update/check-updates flows. Mutating operations
+# require --yes or --dry-run so VBW never changes global RTK/Claude Code state
+# as an incidental side effect of status, doctor, SessionStart, or normal use.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=resolve-claude-dir.sh
+. "$SCRIPT_DIR/resolve-claude-dir.sh"
+
+RTK_REPO_API="${RTK_REPO_API:-https://api.github.com/repos/rtk-ai/rtk/releases/latest}"
+VBW_RTK_DIR="${VBW_RTK_DIR:-$CLAUDE_DIR/vbw}"
+RTK_RECEIPT_FILE="${RTK_RECEIPT_FILE:-$VBW_RTK_DIR/rtk-install.json}"
+RTK_LATEST_CACHE="${RTK_LATEST_CACHE:-$VBW_RTK_DIR/rtk-latest-release.json}"
+RTK_PROOF_FILE="${RTK_PROOF_FILE:-$VBW_RTK_DIR/rtk-compatibility-proof.json}"
+RTK_BACKUP_DIR="${RTK_BACKUP_DIR:-$VBW_RTK_DIR/backups}"
+RTK_SETTINGS_JSON="${RTK_SETTINGS_JSON:-$CLAUDE_DIR/settings.json}"
+RTK_GLOBAL_MD="${RTK_GLOBAL_MD:-$CLAUDE_DIR/RTK.md}"
+RTK_CLAUDE_MD="${RTK_CLAUDE_MD:-$CLAUDE_DIR/CLAUDE.md}"
+RTK_INSTALL_DIR_DEFAULT="${RTK_INSTALL_DIR:-$HOME/.local/bin}"
+RTK_LEGACY_CLAUDE_DIR="${RTK_LEGACY_CLAUDE_DIR:-${HOME}/.claude}"
+RTK_TEMP_DIR=""
+
+cleanup_temp_dir() {
+  [ -n "${RTK_TEMP_DIR:-}" ] || return 0
+  rm -rf "$RTK_TEMP_DIR" 2>/dev/null || true
+}
+
+usage() {
+  cat <<'EOF'
+Usage: rtk-manager.sh <command> [options]
+
+Commands:
+  status --json [--check-updates] [--stats]
+  doctor-json
+  install [--dry-run] [--yes] [--allow-missing-checksum]
+  update [--dry-run] [--yes] [--allow-missing-checksum]
+  init [--dry-run] [--yes] [--auto-patch] [--hook-only]
+  verify [--json]
+  uninstall [--dry-run] [--yes] [--deactivate-hook]
+
+Mutating commands require --yes. Use --dry-run to inspect planned effects.
+EOF
+}
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown"
+}
+
+die() {
+  local code="$1"
+  shift
+  echo "RTK: $*" >&2
+  exit "$code"
+}
+
+bool_to_json() {
+  if [ "${1:-false}" = "true" ]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+normalize_version() {
+  local value="$1"
+  value="${value#v}"
+  awk -v s="$value" 'BEGIN { if (match(s, /[0-9]+([.][0-9]+)+/)) print substr(s, RSTART, RLENGTH); }'
+}
+
+version_gt() {
+  local left right
+  left="$(normalize_version "$1")"
+  right="$(normalize_version "$2")"
+  [ -n "$left" ] && [ -n "$right" ] || return 1
+  awk -v a="$left" -v b="$right" '
+    BEGIN {
+      split(a, av, "."); split(b, bv, ".");
+      for (i = 1; i <= 4; i++) {
+        ai = (av[i] == "" ? 0 : av[i] + 0);
+        bi = (bv[i] == "" ? 0 : bv[i] + 0);
+        if (ai > bi) exit 0;
+        if (ai < bi) exit 1;
+      }
+      exit 1;
+    }
+  '
+}
+
+path_contains_dir() {
+  local dir="$1"
+  case ":${PATH:-}:" in
+    *":$dir:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+command_path() {
+  command -v "$1" 2>/dev/null || true
+}
+
+rtk_path_from_receipt() {
+  if [ -f "$RTK_RECEIPT_FILE" ] && jq empty "$RTK_RECEIPT_FILE" >/dev/null 2>&1; then
+    jq -r '.binary_path // empty' "$RTK_RECEIPT_FILE" 2>/dev/null || true
+  fi
+}
+
+rtk_path_detect() {
+  local path receipt_path
+  path="$(command_path rtk)"
+  if [ -n "$path" ]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+
+  receipt_path="$(rtk_path_from_receipt)"
+  if [ -n "$receipt_path" ] && [ -x "$receipt_path" ]; then
+    printf '%s\n' "$receipt_path"
+  fi
+}
+
+rtk_version_detect() {
+  local path="$1" out
+  [ -n "$path" ] || return 0
+  out="$($path --version 2>/dev/null || true)"
+  normalize_version "$out"
+}
+
+receipt_managed() {
+  [ -f "$RTK_RECEIPT_FILE" ] || return 1
+  jq -e '.manager == "vbw"' "$RTK_RECEIPT_FILE" >/dev/null 2>&1
+}
+
+receipt_field() {
+  local field="$1"
+  [ -f "$RTK_RECEIPT_FILE" ] || return 0
+  jq -r --arg field "$field" '.[$field] // empty' "$RTK_RECEIPT_FILE" 2>/dev/null || true
+}
+
+settings_valid() {
+  [ -f "$RTK_SETTINGS_JSON" ] || return 0
+  jq empty "$RTK_SETTINGS_JSON" >/dev/null 2>&1
+}
+
+settings_hook_command() {
+  [ -f "$RTK_SETTINGS_JSON" ] || return 0
+  jq -r '
+    [
+      .hooks.PreToolUse[]? as $group
+      | ($group.matcher // "") as $matcher
+      | $group.hooks[]?
+      | select((.command // "") | test("(^|[[:space:]/])rtk[[:space:]]+hook[[:space:]]+claude($|[[:space:];])|rtk-rewrite[.]sh"))
+      | {matcher: $matcher, command: (.command // "")}
+    ][0].command // ""
+  ' "$RTK_SETTINGS_JSON" 2>/dev/null || true
+}
+
+settings_hook_matcher() {
+  [ -f "$RTK_SETTINGS_JSON" ] || return 0
+  jq -r '
+    [
+      .hooks.PreToolUse[]? as $group
+      | ($group.matcher // "") as $matcher
+      | $group.hooks[]?
+      | select((.command // "") | test("(^|[[:space:]/])rtk[[:space:]]+hook[[:space:]]+claude($|[[:space:];])|rtk-rewrite[.]sh"))
+      | {matcher: $matcher, command: (.command // "")}
+    ][0].matcher // ""
+  ' "$RTK_SETTINGS_JSON" 2>/dev/null || true
+}
+
+settings_bash_hook_count() {
+  [ -f "$RTK_SETTINGS_JSON" ] || { echo 0; return 0; }
+  jq -r '
+    [
+      .hooks.PreToolUse[]?
+      | select((.matcher // "") == "Bash" or (.matcher // "") == "")
+      | .hooks[]?
+      | select((.type // "command") == "command" and (.command // "") != "")
+    ] | length
+  ' "$RTK_SETTINGS_JSON" 2>/dev/null || echo 0
+}
+
+legacy_hook_present() {
+  [ -f "$CLAUDE_DIR/hooks/rtk-rewrite.sh" ] || [ -f "$RTK_LEGACY_CLAUDE_DIR/hooks/rtk-rewrite.sh" ]
+}
+
+global_claude_ref_present() {
+  [ -f "$RTK_CLAUDE_MD" ] || return 1
+  grep -Fq '@RTK.md' "$RTK_CLAUDE_MD" 2>/dev/null
+}
+
+project_local_present() {
+  [ -d ".rtk" ] || [ -f ".rtk/filters.toml" ]
+}
+
+vbw_bash_hook_present() {
+  local hooks_json="$SCRIPT_DIR/../hooks/hooks.json"
+  [ -f "$hooks_json" ] || return 1
+  jq -e '
+    .. | objects
+    | select((.matcher? // "") == "Bash" or ((.command? // "") | contains("bash-guard.sh")))
+  ' "$hooks_json" >/dev/null 2>&1
+}
+
+checksum_tool() {
+  if command -v shasum >/dev/null 2>&1; then
+    echo "shasum"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    echo "sha256sum"
+  fi
+}
+
+sha256_file() {
+  local file="$1" tool
+  tool="$(checksum_tool)"
+  [ -n "$tool" ] || die 1 "no SHA-256 tool found (need shasum or sha256sum)"
+  case "$tool" in
+    shasum) shasum -a 256 "$file" | awk '{print $1}' ;;
+    sha256sum) sha256sum "$file" | awk '{print $1}' ;;
+  esac
+}
+
+os_arch_target() {
+  local os arch
+  os="$(uname -s 2>/dev/null || echo unknown)"
+  arch="$(uname -m 2>/dev/null || echo unknown)"
+  case "$arch" in
+    arm64|aarch64) arch="aarch64" ;;
+    x86_64|amd64) arch="x86_64" ;;
+  esac
+  case "$os:$arch" in
+    Darwin:aarch64) echo "aarch64-apple-darwin" ;;
+    Darwin:x86_64) echo "x86_64-apple-darwin" ;;
+    Linux:aarch64) echo "aarch64-unknown-linux-gnu" ;;
+    Linux:x86_64) echo "x86_64-unknown-linux-musl" ;;
+    *) echo "" ;;
+  esac
+}
+
+curl_json() {
+  local url="$1"
+  curl -fsSL "$url"
+}
+
+query_latest_release() {
+  local release_json tag version target asset_name asset_url checksums_url checked tmp
+  release_json="$(curl_json "$RTK_REPO_API")" || die 1 "failed to query latest RTK release metadata"
+  tag="$(printf '%s' "$release_json" | jq -r '.tag_name // .tagName // empty')"
+  version="$(normalize_version "$tag")"
+  target="$(os_arch_target)"
+  [ -n "$target" ] || die 1 "unsupported platform for VBW-managed RTK release install"
+  asset_name="$(printf '%s' "$release_json" | jq -r --arg target "$target" '[.assets[]? | select((.name | contains($target)) and (.name | endswith(".tar.gz")))][0].name // empty')"
+  asset_url="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" '[.assets[]? | select(.name == $name)][0].browser_download_url // empty')"
+  checksums_url="$(printf '%s' "$release_json" | jq -r '[.assets[]? | select(.name == "checksums.txt")][0].browser_download_url // empty')"
+  [ -n "$tag" ] && [ -n "$version" ] || die 1 "latest RTK release metadata did not include a tag"
+  [ -n "$asset_name" ] && [ -n "$asset_url" ] || die 1 "latest RTK release has no asset for target $target"
+  checked="$(now_utc)"
+  mkdir -p "$VBW_RTK_DIR"
+  tmp="$(mktemp "$VBW_RTK_DIR/rtk-latest.XXXXXX")"
+  jq -n \
+    --arg tag "$tag" \
+    --arg version "$version" \
+    --arg checked_at "$checked" \
+    --arg target "$target" \
+    --arg asset_name "$asset_name" \
+    --arg asset_url "$asset_url" \
+    --arg checksums_url "$checksums_url" \
+    '{tag:$tag, version:$version, checked_at:$checked_at, target:$target, asset_name:$asset_name, asset_url:$asset_url, checksums_url:$checksums_url}' > "$tmp"
+  chmod 600 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$RTK_LATEST_CACHE"
+  cat "$RTK_LATEST_CACHE"
+}
+
+latest_from_cache() {
+  [ -f "$RTK_LATEST_CACHE" ] || return 0
+  jq empty "$RTK_LATEST_CACHE" >/dev/null 2>&1 || return 0
+  cat "$RTK_LATEST_CACHE"
+}
+
+release_metadata() {
+  local check_updates="$1" metadata
+  if [ "$check_updates" = "true" ]; then
+    query_latest_release
+    return 0
+  fi
+  metadata="$(latest_from_cache)"
+  [ -n "$metadata" ] && printf '%s\n' "$metadata"
+  return 0
+}
+
+status_json() {
+  local check_updates="${1:-false}" include_stats="${2:-false}"
+  local rtk_path rtk_present rtk_version latest_json latest_version latest_checked_at update_available version_source
+  local managed_by_vbw install_receipt receipt_binary binary_install_state can_install preferred_install_method
+  local settings_json_valid hook_command hook_matcher global_hook_present global_claude_ref global_rtk_md legacy_hook project_local vbw_hook bash_hook_count multiple_bash updated_input_risk
+  local proof_source compatibility restart_required summary next_action stats_json
+
+  rtk_path="$(rtk_path_detect)"
+  rtk_present=false
+  [ -n "$rtk_path" ] && rtk_present=true
+  rtk_version="$(rtk_version_detect "$rtk_path")"
+
+  latest_json="$(release_metadata "$check_updates")"
+  latest_version=""
+  latest_checked_at=""
+  if [ -n "$latest_json" ]; then
+    latest_version="$(printf '%s' "$latest_json" | jq -r '.version // empty' 2>/dev/null || true)"
+    latest_checked_at="$(printf '%s' "$latest_json" | jq -r '.checked_at // empty' 2>/dev/null || true)"
+  fi
+  update_available=false
+  if [ -n "$latest_version" ] && [ -n "$rtk_version" ] && version_gt "$latest_version" "$rtk_version"; then
+    update_available=true
+  fi
+  version_source="none"
+  [ -n "$latest_version" ] && version_source="explicit-check-or-cache"
+
+  managed_by_vbw=false
+  if receipt_managed; then managed_by_vbw=true; fi
+  install_receipt=""
+  [ -f "$RTK_RECEIPT_FILE" ] && install_receipt="$RTK_RECEIPT_FILE"
+  receipt_binary="$(rtk_path_from_receipt)"
+  binary_install_state="absent"
+  if [ "$rtk_present" = "true" ]; then
+    binary_install_state="present"
+  elif [ -n "$receipt_binary" ] && [ -x "$receipt_binary" ]; then
+    binary_install_state="installed_path_missing"
+  fi
+
+  can_install=true
+  command -v curl >/dev/null 2>&1 || can_install=false
+  command -v jq >/dev/null 2>&1 || can_install=false
+  [ -n "$(checksum_tool)" ] || can_install=false
+  preferred_install_method="github-release"
+
+  settings_json_valid=true
+  if ! settings_valid; then settings_json_valid=false; fi
+  hook_command=""
+  hook_matcher=""
+  if [ "$settings_json_valid" = "true" ]; then
+    hook_command="$(settings_hook_command)"
+    hook_matcher="$(settings_hook_matcher)"
+  fi
+  global_claude_ref=false
+  if global_claude_ref_present; then global_claude_ref=true; fi
+  global_rtk_md=false
+  [ -f "$RTK_GLOBAL_MD" ] && global_rtk_md=true
+  legacy_hook=false
+  if legacy_hook_present; then legacy_hook=true; fi
+  project_local=false
+  if project_local_present; then project_local=true; fi
+  vbw_hook=false
+  if vbw_bash_hook_present; then vbw_hook=true; fi
+  global_hook_present=false
+  if [ -n "$hook_command" ] || [ "$legacy_hook" = "true" ]; then global_hook_present=true; fi
+  bash_hook_count=0
+  if [ "$settings_json_valid" = "true" ]; then bash_hook_count="$(settings_bash_hook_count)"; fi
+  multiple_bash=false
+  if [ "$global_hook_present" = "true" ] && { [ "$vbw_hook" = "true" ] || [ "${bash_hook_count:-0}" -gt 1 ]; }; then
+    multiple_bash=true
+  fi
+  updated_input_risk=false
+  [ "$multiple_bash" = "true" ] && updated_input_risk=true
+
+  proof_source=""
+  if [ -f "$RTK_PROOF_FILE" ] && jq empty "$RTK_PROOF_FILE" >/dev/null 2>&1; then
+    proof_source="$RTK_PROOF_FILE"
+  fi
+
+  compatibility="absent"
+  restart_required=false
+  if [ -n "$proof_source" ] && [ "$global_hook_present" = "true" ]; then
+    compatibility="verified"
+  elif [ "$global_hook_present" = "true" ] && [ "$updated_input_risk" = "true" ]; then
+    compatibility="risk"
+  elif [ "$global_hook_present" = "true" ]; then
+    compatibility="hook_active_unverified"
+  elif [ "$rtk_present" = "true" ]; then
+    compatibility="binary_only"
+  fi
+  if [ "$global_hook_present" = "true" ] && [ -z "$proof_source" ]; then
+    restart_required=true
+  fi
+
+  case "$compatibility" in
+    absent)
+      summary="RTK not installed; optional: /vbw:rtk install"
+      next_action="install"
+      ;;
+    binary_only)
+      summary="RTK binary installed; Claude Code hook inactive"
+      next_action="init"
+      ;;
+    hook_active_unverified)
+      summary="RTK hook active; runtime compatibility unverified"
+      next_action="verify"
+      ;;
+    risk)
+      summary="RTK hook active; multiple Bash PreToolUse hooks make updatedInput compatibility risky"
+      next_action="verify"
+      ;;
+    verified)
+      summary="RTK/VBW coexistence verified by smoke proof"
+      next_action="status"
+      ;;
+    *)
+      summary="RTK status unknown"
+      next_action="status"
+      ;;
+  esac
+
+  stats_json="null"
+  if [ "$include_stats" = "true" ] && [ -n "$rtk_path" ]; then
+    stats_json="$($rtk_path gain --json 2>/dev/null || echo null)"
+    printf '%s' "$stats_json" | jq empty >/dev/null 2>&1 || stats_json="null"
+  fi
+
+  jq -n \
+    --argjson rtk_present "$(bool_to_json "$rtk_present")" \
+    --arg rtk_path "$rtk_path" \
+    --arg rtk_version "$rtk_version" \
+    --arg latest_version "$latest_version" \
+    --arg latest_checked_at "$latest_checked_at" \
+    --argjson update_available "$(bool_to_json "$update_available")" \
+    --arg version_source "$version_source" \
+    --argjson managed_by_vbw "$(bool_to_json "$managed_by_vbw")" \
+    --arg install_receipt "$install_receipt" \
+    --arg preferred_install_method "$preferred_install_method" \
+    --argjson can_install "$(bool_to_json "$can_install")" \
+    --arg binary_install_state "$binary_install_state" \
+    --argjson settings_json_valid "$(bool_to_json "$settings_json_valid")" \
+    --argjson global_hook_present "$(bool_to_json "$global_hook_present")" \
+    --arg global_hook_command "$hook_command" \
+    --arg global_hook_matcher "$hook_matcher" \
+    --argjson global_claude_ref_present "$(bool_to_json "$global_claude_ref")" \
+    --argjson global_rtk_md_present "$(bool_to_json "$global_rtk_md")" \
+    --argjson legacy_hook_file_present "$(bool_to_json "$legacy_hook")" \
+    --argjson project_local_present "$(bool_to_json "$project_local")" \
+    --argjson vbw_bash_hook_present "$(bool_to_json "$vbw_hook")" \
+    --argjson multiple_bash_pretookuse_hooks_detected "$(bool_to_json "$multiple_bash")" \
+    --argjson updated_input_risk "$(bool_to_json "$updated_input_risk")" \
+    --arg compatibility "$compatibility" \
+    --arg proof_source "$proof_source" \
+    --argjson restart_required "$(bool_to_json "$restart_required")" \
+    --arg summary "$summary" \
+    --arg next_action "$next_action" \
+    --argjson stats "$stats_json" \
+    '{
+      rtk_present: $rtk_present,
+      rtk_path: $rtk_path,
+      rtk_version: $rtk_version,
+      latest_version: $latest_version,
+      latest_checked_at: $latest_checked_at,
+      update_available: $update_available,
+      version_source: $version_source,
+      managed_by_vbw: $managed_by_vbw,
+      install_receipt: $install_receipt,
+      preferred_install_method: $preferred_install_method,
+      can_install: $can_install,
+      binary_install_state: $binary_install_state,
+      settings_json_valid: $settings_json_valid,
+      global_hook_present: $global_hook_present,
+      global_hook_command: $global_hook_command,
+      global_hook_matcher: $global_hook_matcher,
+      global_claude_ref_present: $global_claude_ref_present,
+      global_rtk_md_present: $global_rtk_md_present,
+      legacy_hook_file_present: $legacy_hook_file_present,
+      project_local_present: $project_local_present,
+      vbw_bash_hook_present: $vbw_bash_hook_present,
+      multiple_bash_pretookuse_hooks_detected: $multiple_bash_pretookuse_hooks_detected,
+      updated_input_risk: $updated_input_risk,
+      compatibility: $compatibility,
+      proof_source: $proof_source,
+      restart_required: $restart_required,
+      summary: $summary,
+      next_action: $next_action,
+      stats: $stats
+    }'
+}
+
+doctor_json() {
+  status_json false false | jq '
+    . as $s
+    | .doctor_status = (
+        if ($s.compatibility == "verified") then "PASS"
+        elif ($s.compatibility == "absent" and ($s.project_local_present | not)) then "SKIP"
+        else "WARN" end
+      )
+    | .doctor_detail = (
+        if .doctor_status == "PASS" then "verified by " + ($s.proof_source // "smoke proof")
+        elif .compatibility == "absent" then "not installed; optional: /vbw:rtk install"
+        elif .compatibility == "binary_only" then "binary installed; hook inactive"
+        elif .compatibility == "risk" then "hook active; PreToolUse updatedInput compatibility unverified"
+        elif .update_available == true then "outdated; run /vbw:rtk update"
+        else "hook active; compatibility unverified" end
+      )'
+}
+
+ensure_confirmation() {
+  local yes="$1" dry_run="$2" operation="$3"
+  [ "$dry_run" = "true" ] && return 0
+  [ "$yes" = "true" ] && return 0
+  die 2 "$operation requires explicit confirmation; rerun with --dry-run to preview or --yes after user approval"
+}
+
+latest_metadata_or_die() {
+  local metadata
+  metadata="$(query_latest_release)"
+  [ -n "$metadata" ] || die 1 "latest release metadata unavailable"
+  printf '%s\n' "$metadata"
+}
+
+print_install_preflight() {
+  local operation="$1" metadata="$2" install_dir="$3" installed_version="$4"
+  local tag asset_name checksums_url path_state next_step risk
+  tag="$(printf '%s' "$metadata" | jq -r '.tag // empty')"
+  asset_name="$(printf '%s' "$metadata" | jq -r '.asset_name // empty')"
+  checksums_url="$(printf '%s' "$metadata" | jq -r '.checksums_url // empty')"
+  path_state="on PATH"
+  if ! path_contains_dir "$install_dir"; then
+    path_state="not on PATH"
+  fi
+  next_step="Run /vbw:rtk init after the binary is visible on PATH."
+  risk="No Claude Code settings are edited by this ${operation}; checksum is required when checksums.txt exists."
+  echo "RTK ${operation} preflight"
+  echo "Installed: ${installed_version:-absent}"
+  echo "Latest: ${tag:-unknown}"
+  echo "Method: latest GitHub release asset from rtk-ai/rtk"
+  echo "Will run: query latest release metadata, download ${asset_name:-matching asset}, download checksums.txt, verify SHA-256, install rtk"
+  echo "Writes: ${install_dir}/rtk (${path_state}); receipt ${RTK_RECEIPT_FILE}; backups under ${RTK_BACKUP_DIR}"
+  echo "Does not do: edit Claude settings, edit shell profiles, use sudo, pipe downloaded shell scripts into sh, or run rtk init -g"
+  echo "Next step: ${next_step}"
+  echo "Risk: ${risk}"
+  if [ -z "$checksums_url" ]; then
+    echo "Checksum: unavailable; operation will abort unless --allow-missing-checksum is explicitly provided"
+  else
+    echo "Checksum: ${checksums_url}"
+  fi
+  if ! path_contains_dir "$install_dir"; then
+    echo "PATH note: add this yourself before hook activation: export PATH=\"${install_dir}:\$PATH\""
+  fi
+}
+
+backup_if_present() {
+  local path="$1" stamp dest
+  [ -e "$path" ] || return 0
+  mkdir -p "$RTK_BACKUP_DIR"
+  stamp="$(now_utc | tr ':T' '--')"
+  dest="$RTK_BACKUP_DIR/$(basename "$path").$stamp.bak"
+  cp -p "$path" "$dest" 2>/dev/null || cp "$path" "$dest"
+}
+
+write_receipt() {
+  local operation="$1" binary_path="$2" previous_version="$3" installed_version="$4" metadata="$5" checksum="$6" tmp
+  mkdir -p "$VBW_RTK_DIR"
+  tmp="$(mktemp "$VBW_RTK_DIR/rtk-install.XXXXXX")"
+  jq -n \
+    --arg manager "vbw" \
+    --arg operation "$operation" \
+    --arg method "github-release" \
+    --arg binary_path "$binary_path" \
+    --arg previous_version "$previous_version" \
+    --arg installed_version "$installed_version" \
+    --arg release_tag "$(printf '%s' "$metadata" | jq -r '.tag // empty')" \
+    --arg asset_url "$(printf '%s' "$metadata" | jq -r '.asset_url // empty')" \
+    --arg checksum_url "$(printf '%s' "$metadata" | jq -r '.checksums_url // empty')" \
+    --arg verified_checksum "$checksum" \
+    --arg timestamp "$(now_utc)" \
+    --arg claude_dir "$CLAUDE_DIR" \
+    '{manager:$manager, operation:$operation, method:$method, binary_path:$binary_path, previous_version:$previous_version, installed_version:$installed_version, release_tag:$release_tag, asset_url:$asset_url, checksum_url:$checksum_url, verified_checksum:$verified_checksum, timestamp:$timestamp, claude_dir:$claude_dir}' > "$tmp"
+  chmod 600 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$RTK_RECEIPT_FILE"
+}
+
+verify_download_checksum() {
+  local asset="$1" asset_name="$2" checksums="$3" allow_missing="$4" expected actual
+  if [ ! -s "$checksums" ]; then
+    [ "$allow_missing" = "true" ] || die 1 "checksums.txt unavailable; aborting managed install/update"
+    echo ""
+    return 0
+  fi
+  expected="$(awk -v n="$asset_name" '($2 == n || $NF == n) {print $1; exit}' "$checksums")"
+  if [ -z "$expected" ]; then
+    [ "$allow_missing" = "true" ] || die 1 "checksums.txt did not include $asset_name"
+    echo ""
+    return 0
+  fi
+  actual="$(sha256_file "$asset")"
+  [ "$actual" = "$expected" ] || die 1 "checksum mismatch for $asset_name"
+  echo "$actual"
+}
+
+extract_rtk_binary() {
+  local asset="$1" temp_dir="$2" found
+  mkdir -p "$temp_dir"
+  tar -xzf "$asset" -C "$temp_dir"
+  found="$(find "$temp_dir" -type f -name rtk -perm -u+x -print 2>/dev/null | head -1 || true)"
+  if [ -z "$found" ]; then
+    found="$(find "$temp_dir" -type f -name rtk -print 2>/dev/null | head -1 || true)"
+  fi
+  [ -n "$found" ] || die 1 "downloaded RTK asset did not contain an rtk binary"
+  chmod +x "$found" 2>/dev/null || true
+  printf '%s\n' "$found"
+}
+
+install_or_update() {
+  local operation="$1" dry_run=false yes=false allow_missing=false install_dir metadata installed_path installed_version previous_version
+  local temp_dir asset_name asset_url checksums_url asset_file checksums_file checksum extracted target_path
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      install|update) shift ;;
+      --dry-run) dry_run=true; shift ;;
+      --yes) yes=true; shift ;;
+      --allow-missing-checksum) allow_missing=true; shift ;;
+      --install-dir) install_dir="${2:-}"; [ -n "$install_dir" ] || die 2 "--install-dir requires a value"; shift 2 ;;
+      *) die 2 "unknown ${operation} option: $1" ;;
+    esac
+  done
+
+  install_dir="${install_dir:-$RTK_INSTALL_DIR_DEFAULT}"
+  installed_path="$(rtk_path_detect)"
+  installed_version="$(rtk_version_detect "$installed_path")"
+
+  if [ "$operation" = "update" ] && [ -f "$RTK_RECEIPT_FILE" ] && ! receipt_managed; then
+    echo "RTK update preflight"
+    echo "Installed: ${installed_version:-present}"
+    echo "Method: external install detected"
+    echo "Will run: no VBW-managed overwrite"
+    echo "Next step: update RTK with the package manager or install method that owns ${installed_path:-the binary}."
+    exit 0
+  fi
+
+  metadata="$(latest_metadata_or_die)"
+  print_install_preflight "$operation" "$metadata" "$install_dir" "$installed_version"
+  ensure_confirmation "$yes" "$dry_run" "$operation"
+  [ "$dry_run" = "true" ] && exit 0
+
+  asset_name="$(printf '%s' "$metadata" | jq -r '.asset_name')"
+  asset_url="$(printf '%s' "$metadata" | jq -r '.asset_url')"
+  checksums_url="$(printf '%s' "$metadata" | jq -r '.checksums_url // empty')"
+  temp_dir="$(mktemp -d)"
+  RTK_TEMP_DIR="$temp_dir"
+  trap cleanup_temp_dir EXIT
+  asset_file="$temp_dir/$asset_name"
+  checksums_file="$temp_dir/checksums.txt"
+  curl -fsSL -o "$asset_file" "$asset_url"
+  if [ -n "$checksums_url" ]; then
+    curl -fsSL -o "$checksums_file" "$checksums_url"
+  else
+    : > "$checksums_file"
+  fi
+  checksum="$(verify_download_checksum "$asset_file" "$asset_name" "$checksums_file" "$allow_missing")"
+  extracted="$(extract_rtk_binary "$asset_file" "$temp_dir/extract")"
+  mkdir -p "$install_dir"
+  target_path="$install_dir/rtk"
+  backup_if_present "$target_path"
+  previous_version="$installed_version"
+  cp "$extracted" "$target_path"
+  chmod +x "$target_path"
+  installed_version="$($target_path --version 2>/dev/null | awk 'match($0, /[0-9]+([.][0-9]+)+/) {print substr($0, RSTART, RLENGTH); exit}' || true)"
+  write_receipt "$operation" "$target_path" "$previous_version" "$installed_version" "$metadata" "$checksum"
+  echo "✓ RTK ${operation} complete: $target_path (${installed_version:-version unknown})"
+  if ! path_contains_dir "$install_dir"; then
+    echo "⚠ $install_dir is not on PATH. Add: export PATH=\"${install_dir}:\$PATH\""
+  fi
+  cleanup_temp_dir
+  RTK_TEMP_DIR=""
+  trap - EXIT
+}
+
+init_hook() {
+  local dry_run=false yes=false auto_patch=false hook_only=false rtk_path args
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry_run=true; shift ;;
+      --yes) yes=true; shift ;;
+      --auto-patch) auto_patch=true; shift ;;
+      --hook-only) hook_only=true; shift ;;
+      *) die 2 "unknown init option: $1" ;;
+    esac
+  done
+  rtk_path="$(rtk_path_detect)"
+  [ -n "$rtk_path" ] || die 1 "RTK binary not found; run /vbw:rtk install first or install RTK manually"
+  echo "RTK hook preflight"
+  echo "Will run: $rtk_path init -g${auto_patch:+ --auto-patch}${hook_only:+ --hook-only}"
+  echo "Writes: ${RTK_SETTINGS_JSON}, ${RTK_GLOBAL_MD}, and @RTK.md references inside ${RTK_CLAUDE_MD} when RTK patches Claude Code"
+  echo "Does not do: disable, reorder, or weaken VBW bash-guard.sh"
+  echo "Next step: restart Claude Code after hook activation, then run /vbw:rtk verify"
+  echo "Risk: Claude Code issue #15897 reports updatedInput can fail when multiple PreToolUse hooks match; compatibility remains unverified until a runtime smoke proof exists."
+  ensure_confirmation "$yes" "$dry_run" "init"
+  [ "$dry_run" = "true" ] && exit 0
+  backup_if_present "$RTK_SETTINGS_JSON"
+  backup_if_present "$RTK_CLAUDE_MD"
+  backup_if_present "$RTK_GLOBAL_MD"
+  args=(init -g)
+  [ "$auto_patch" = "true" ] && args+=(--auto-patch)
+  [ "$hook_only" = "true" ] && args+=(--hook-only)
+  "$rtk_path" "${args[@]}"
+  status_json false false | jq -r '.summary'
+}
+
+verify_rtk() {
+  local as_json=false
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json) as_json=true; shift ;;
+      *) die 2 "unknown verify option: $1" ;;
+    esac
+  done
+  if [ "$as_json" = "true" ]; then
+    status_json false true
+    return 0
+  fi
+  status_json false true | jq -r '
+    "RTK verify\n" +
+    "Static: " + .summary + "\n" +
+    "Runtime: " + (if .compatibility == "verified" then "verified by " + .proof_source else "manual Claude Code smoke required before PASS" end) + "\n" +
+    "Manual smoke: restart Claude Code, run representative Bash commands, confirm RTK rewrites and VBW bash-guard behavior, then record proof."
+  '
+}
+
+uninstall_rtk() {
+  local dry_run=false yes=false deactivate_hook=false binary_path managed
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry_run=true; shift ;;
+      --yes) yes=true; shift ;;
+      --deactivate-hook) deactivate_hook=true; shift ;;
+      *) die 2 "unknown uninstall option: $1" ;;
+    esac
+  done
+  managed=false
+  if receipt_managed; then managed=true; fi
+  binary_path="$(rtk_path_from_receipt)"
+  echo "RTK uninstall preflight"
+  if [ "$managed" = "true" ] && [ -n "$binary_path" ]; then
+    echo "Will remove: $binary_path (VBW receipt-owned)"
+  else
+    echo "Will remove: no binary; external installs are not deleted by VBW"
+  fi
+  echo "Will run: ${deactivate_hook:+rtk init -g --uninstall}${deactivate_hook:-no hook deactivation unless --deactivate-hook is passed}"
+  echo "Writes: receipt/backups under ${VBW_RTK_DIR}; RTK may edit Claude settings only when --deactivate-hook is used"
+  ensure_confirmation "$yes" "$dry_run" "uninstall"
+  [ "$dry_run" = "true" ] && exit 0
+  if [ "$managed" = "true" ] && [ -n "$binary_path" ] && [ -e "$binary_path" ]; then
+    rm -f "$binary_path"
+  fi
+  if [ "$deactivate_hook" = "true" ]; then
+    local rtk_path
+    rtk_path="$(rtk_path_detect)"
+    [ -n "$rtk_path" ] || rtk_path="rtk"
+    "$rtk_path" init -g --uninstall
+  fi
+  echo "✓ RTK uninstall complete"
+}
+
+status_command() {
+  local json=false check_updates=false include_stats=false
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json) json=true; shift ;;
+      --check-updates) check_updates=true; shift ;;
+      --stats) include_stats=true; shift ;;
+      *) die 2 "unknown status option: $1" ;;
+    esac
+  done
+  if [ "$json" = "true" ]; then
+    status_json "$check_updates" "$include_stats"
+  else
+    status_json "$check_updates" "$include_stats" | jq -r '.summary'
+  fi
+}
+
+main() {
+  local cmd="${1:-status}"
+  [ "$#" -gt 0 ] && shift || true
+  case "$cmd" in
+    status) status_command "$@" ;;
+    doctor-json) doctor_json "$@" ;;
+    install) install_or_update install "$@" ;;
+    update) install_or_update update "$@" ;;
+    init) init_hook "$@" ;;
+    verify) verify_rtk "$@" ;;
+    uninstall) uninstall_rtk "$@" ;;
+    help|-h|--help) usage ;;
+    *) usage >&2; die 2 "unknown command: $cmd" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -147,7 +147,9 @@ settings_hook_command() {
       .hooks.PreToolUse[]? as $group
       | ($group.matcher // "") as $matcher
       | $group.hooks[]?
-      | select((.command // "") | test("(^|[[:space:]/])rtk[[:space:]]+hook[[:space:]]+claude($|[[:space:];])|rtk-rewrite[.]sh"))
+      | (.command // "") as $command
+      | ($command | gsub("[\"'\'' ]"; "")) as $match_command
+      | select($match_command | test("(^|/)rtkhookclaude($|[;])|rtk-rewrite[.]sh"))
       | {matcher: $matcher, command: (.command // "")}
     ][0].command // ""
   ' "$RTK_SETTINGS_JSON" 2>/dev/null || true
@@ -160,7 +162,9 @@ settings_hook_matcher() {
       .hooks.PreToolUse[]? as $group
       | ($group.matcher // "") as $matcher
       | $group.hooks[]?
-      | select((.command // "") | test("(^|[[:space:]/])rtk[[:space:]]+hook[[:space:]]+claude($|[[:space:];])|rtk-rewrite[.]sh"))
+      | (.command // "") as $command
+      | ($command | gsub("[\"'\'' ]"; "")) as $match_command
+      | select($match_command | test("(^|/)rtkhookclaude($|[;])|rtk-rewrite[.]sh"))
       | {matcher: $matcher, command: (.command // "")}
     ][0].matcher // ""
   ' "$RTK_SETTINGS_JSON" 2>/dev/null || true
@@ -464,7 +468,7 @@ status_json() {
 
   stats_json="null"
   if [ "$include_stats" = "true" ] && [ -n "$rtk_path" ]; then
-    stats_json="$($rtk_path gain --json 2>/dev/null || echo null)"
+    stats_json="$("$rtk_path" gain --json 2>/dev/null || echo null)"
     printf '%s' "$stats_json" | jq empty >/dev/null 2>&1 || stats_json="null"
   fi
 

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -246,8 +246,8 @@ curl_json() {
   curl -fsSL "$url"
 }
 
-query_latest_release() {
-  local release_json tag version target asset_name asset_url checksums_url checked tmp
+fetch_latest_release() {
+  local release_json tag version target asset_name asset_url checksums_url checked
   release_json="$(curl_json "$RTK_REPO_API")" || die 1 "failed to query latest RTK release metadata"
   tag="$(printf '%s' "$release_json" | jq -r '.tag_name // .tagName // empty')"
   version="$(normalize_version "$tag")"
@@ -259,8 +259,6 @@ query_latest_release() {
   [ -n "$tag" ] && [ -n "$version" ] || die 1 "latest RTK release metadata did not include a tag"
   [ -n "$asset_name" ] && [ -n "$asset_url" ] || die 1 "latest RTK release has no asset for target $target"
   checked="$(now_utc)"
-  mkdir -p "$VBW_RTK_DIR"
-  tmp="$(mktemp "$VBW_RTK_DIR/rtk-latest.XXXXXX")"
   jq -n \
     --arg tag "$tag" \
     --arg version "$version" \
@@ -269,9 +267,22 @@ query_latest_release() {
     --arg asset_name "$asset_name" \
     --arg asset_url "$asset_url" \
     --arg checksums_url "$checksums_url" \
-    '{tag:$tag, version:$version, checked_at:$checked_at, target:$target, asset_name:$asset_name, asset_url:$asset_url, checksums_url:$checksums_url}' > "$tmp"
+    '{tag:$tag, version:$version, checked_at:$checked_at, target:$target, asset_name:$asset_name, asset_url:$asset_url, checksums_url:$checksums_url}'
+}
+
+cache_latest_release() {
+  local metadata="$1" tmp
+  mkdir -p "$VBW_RTK_DIR"
+  tmp="$(mktemp "$VBW_RTK_DIR/rtk-latest.XXXXXX")"
+  printf '%s\n' "$metadata" > "$tmp"
   chmod 600 "$tmp" 2>/dev/null || true
   mv "$tmp" "$RTK_LATEST_CACHE"
+}
+
+query_latest_release() {
+  local metadata
+  metadata="$(fetch_latest_release)"
+  cache_latest_release "$metadata"
   cat "$RTK_LATEST_CACHE"
 }
 
@@ -290,6 +301,29 @@ release_metadata() {
   metadata="$(latest_from_cache)"
   [ -n "$metadata" ] && printf '%s\n' "$metadata"
   return 0
+}
+
+valid_runtime_smoke_proof() {
+  local proof_file="$1" current_version="$2" active_hook_command="$3"
+  [ -f "$proof_file" ] || return 1
+  jq -e \
+    --arg current_version "$current_version" \
+    --arg active_hook_command "$active_hook_command" '
+      type == "object"
+      and (((.proof_type // .type // .source // "") | ascii_downcase) | test("runtime.*smoke|smoke.*runtime|manual.*smoke"))
+      and ((.verified == true) or (((.status // .result // .verdict // "") | ascii_downcase) | test("pass|verified")))
+      and (((.timestamp // .verified_at // .ts // "") | type) == "string")
+      and ((.timestamp // .verified_at // .ts // "") | length > 0)
+      and ((.updated_input_verified // .updatedInput_verified // false) == true)
+      and ((.rtk_rewrite_observed // .rewrite_observed // false) == true)
+      and ((.vbw_bash_guard_verified // .bash_guard_verified // false) == true)
+      and (($current_version == "") or ((.rtk_version // $current_version) == $current_version))
+      and (($active_hook_command == "") or ((.hook_command // $active_hook_command) == $active_hook_command))
+      and (
+        (((.commands // .smoke_commands // .results // []) | type) == "array" and ((.commands // .smoke_commands // .results // []) | length > 0))
+        or ((((.summary // .evidence // "") | type) == "string") and ((.summary // .evidence // "") | length > 0))
+      )
+    ' "$proof_file" >/dev/null 2>&1
 }
 
 status_json() {
@@ -355,7 +389,7 @@ status_json() {
   vbw_hook=false
   if vbw_bash_hook_present; then vbw_hook=true; fi
   global_hook_present=false
-  if [ -n "$hook_command" ] || [ "$legacy_hook" = "true" ]; then global_hook_present=true; fi
+  if [ -n "$hook_command" ]; then global_hook_present=true; fi
   bash_hook_count=0
   if [ "$settings_json_valid" = "true" ]; then bash_hook_count="$(settings_bash_hook_count)"; fi
   multiple_bash=false
@@ -366,7 +400,7 @@ status_json() {
   [ "$multiple_bash" = "true" ] && updated_input_risk=true
 
   proof_source=""
-  if [ -f "$RTK_PROOF_FILE" ] && jq empty "$RTK_PROOF_FILE" >/dev/null 2>&1; then
+  if valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$rtk_version" "$hook_command"; then
     proof_source="$RTK_PROOF_FILE"
   fi
 
@@ -485,16 +519,18 @@ doctor_json() {
   status_json false false | jq '
     . as $s
     | .doctor_status = (
-        if ($s.compatibility == "verified") then "PASS"
-        elif ($s.compatibility == "absent" and ($s.project_local_present | not)) then "SKIP"
+        if ($s.compatibility == "absent" and ($s.project_local_present | not) and ($s.legacy_hook_file_present | not)) then "SKIP"
+        elif ($s.update_available == true) then "WARN"
+        elif ($s.compatibility == "verified") then "PASS"
         else "WARN" end
       )
     | .doctor_detail = (
-        if .doctor_status == "PASS" then "verified by " + ($s.proof_source // "smoke proof")
+        if .update_available == true then "outdated from cached RTK release check; run /vbw:rtk update"
+        elif .doctor_status == "PASS" then "verified by " + ($s.proof_source // "smoke proof")
         elif .compatibility == "absent" then "not installed; optional: /vbw:rtk install"
         elif .compatibility == "binary_only" then "binary installed; hook inactive"
         elif .compatibility == "risk" then "hook active; PreToolUse updatedInput compatibility unverified"
-        elif .update_available == true then "outdated; run /vbw:rtk update"
+        elif .legacy_hook_file_present == true then "legacy RTK hook artifact found; settings hook inactive"
         else "hook active; compatibility unverified" end
       )'
 }
@@ -507,9 +543,12 @@ ensure_confirmation() {
 }
 
 latest_metadata_or_die() {
-  local metadata
-  metadata="$(query_latest_release)"
+  local write_cache="${1:-false}" metadata
+  metadata="$(fetch_latest_release)"
   [ -n "$metadata" ] || die 1 "latest release metadata unavailable"
+  if [ "$write_cache" = "true" ]; then
+    cache_latest_release "$metadata"
+  fi
   printf '%s\n' "$metadata"
 }
 
@@ -608,7 +647,7 @@ extract_rtk_binary() {
 
 install_or_update() {
   local operation="$1" dry_run=false yes=false allow_missing=false install_dir metadata installed_path installed_version previous_version
-  local temp_dir asset_name asset_url checksums_url asset_file checksums_file checksum extracted target_path
+  local temp_dir asset_name asset_url checksums_url asset_file checksums_file checksum extracted target_path receipt_binary latest_version
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -625,17 +664,44 @@ install_or_update() {
   installed_path="$(rtk_path_detect)"
   installed_version="$(rtk_version_detect "$installed_path")"
 
-  if [ "$operation" = "update" ] && [ -f "$RTK_RECEIPT_FILE" ] && ! receipt_managed; then
-    echo "RTK update preflight"
-    echo "Installed: ${installed_version:-present}"
-    echo "Method: external install detected"
-    echo "Will run: no VBW-managed overwrite"
-    echo "Next step: update RTK with the package manager or install method that owns ${installed_path:-the binary}."
-    exit 0
+  if [ "$operation" = "update" ]; then
+    receipt_binary="$(rtk_path_from_receipt)"
+    if receipt_managed; then
+      if [ -z "$receipt_binary" ] || [ ! -x "$receipt_binary" ]; then
+        echo "RTK update preflight"
+        echo "Installed: ${installed_version:-unknown}"
+        echo "Method: VBW receipt exists but its binary is missing"
+        echo "Will run: no update"
+        echo "Next step: run /vbw:rtk install or repair the receipt-owned binary path."
+        exit 1
+      fi
+      installed_path="$receipt_binary"
+      installed_version="$(rtk_version_detect "$installed_path")"
+      install_dir="$(dirname "$receipt_binary")"
+    elif [ -n "$installed_path" ]; then
+      echo "RTK update preflight"
+      echo "Installed: ${installed_version:-present}"
+      echo "Method: external install detected"
+      echo "Will run: no VBW-managed overwrite and no ownership takeover"
+      echo "Next step: update RTK with the package manager or install method that owns ${installed_path}."
+      exit 0
+    else
+      echo "RTK update preflight"
+      echo "Installed: absent"
+      echo "Method: no RTK binary detected"
+      echo "Will run: no update"
+      echo "Next step: run /vbw:rtk install."
+      exit 0
+    fi
   fi
 
-  metadata="$(latest_metadata_or_die)"
+  metadata="$(latest_metadata_or_die false)"
   print_install_preflight "$operation" "$metadata" "$install_dir" "$installed_version"
+  latest_version="$(printf '%s' "$metadata" | jq -r '.version // empty')"
+  if [ "$operation" = "update" ] && [ -n "$latest_version" ] && [ -n "$installed_version" ] && ! version_gt "$latest_version" "$installed_version"; then
+    echo "Update: installed RTK ${installed_version} is current for latest ${latest_version}; no replacement needed."
+    exit 0
+  fi
   ensure_confirmation "$yes" "$dry_run" "$operation"
   [ "$dry_run" = "true" ] && exit 0
 
@@ -663,6 +729,7 @@ install_or_update() {
   chmod +x "$target_path"
   installed_version="$($target_path --version 2>/dev/null | awk 'match($0, /[0-9]+([.][0-9]+)+/) {print substr($0, RSTART, RLENGTH); exit}' || true)"
   write_receipt "$operation" "$target_path" "$previous_version" "$installed_version" "$metadata" "$checksum"
+  cache_latest_release "$metadata"
   echo "✓ RTK ${operation} complete: $target_path (${installed_version:-version unknown})"
   if ! path_contains_dir "$install_dir"; then
     echo "⚠ $install_dir is not on PATH. Add: export PATH=\"${install_dir}:\$PATH\""
@@ -724,7 +791,7 @@ verify_rtk() {
 }
 
 uninstall_rtk() {
-  local dry_run=false yes=false deactivate_hook=false binary_path managed
+  local dry_run=false yes=false deactivate_hook=false binary_path managed rtk_path
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --dry-run) dry_run=true; shift ;;
@@ -742,18 +809,26 @@ uninstall_rtk() {
   else
     echo "Will remove: no binary; external installs are not deleted by VBW"
   fi
-  echo "Will run: ${deactivate_hook:+rtk init -g --uninstall}${deactivate_hook:-no hook deactivation unless --deactivate-hook is passed}"
+  echo "Will run: ${deactivate_hook:+rtk init -g --uninstall before binary removal}${deactivate_hook:-no hook deactivation unless --deactivate-hook is passed}"
   echo "Writes: receipt/backups under ${VBW_RTK_DIR}; RTK may edit Claude settings only when --deactivate-hook is used"
   ensure_confirmation "$yes" "$dry_run" "uninstall"
   [ "$dry_run" = "true" ] && exit 0
+  if [ "$deactivate_hook" = "true" ]; then
+    rtk_path="$(rtk_path_detect)"
+    if [ -z "$rtk_path" ] && [ -n "$binary_path" ] && [ -x "$binary_path" ]; then
+      rtk_path="$binary_path"
+    fi
+    if [ -z "$rtk_path" ]; then
+      echo "RTK: cannot deactivate hook because no runnable RTK binary was found; preserved existing files" >&2
+      exit 1
+    fi
+    if ! "$rtk_path" init -g --uninstall; then
+      echo "RTK: hook deactivation failed; preserved RTK binary and receipt for retry" >&2
+      exit 1
+    fi
+  fi
   if [ "$managed" = "true" ] && [ -n "$binary_path" ] && [ -e "$binary_path" ]; then
     rm -f "$binary_path"
-  fi
-  if [ "$deactivate_hook" = "true" ]; then
-    local rtk_path
-    rtk_path="$(rtk_path_detect)"
-    [ -n "$rtk_path" ] || rtk_path="rtk"
-    "$rtk_path" init -g --uninstall
   fi
   echo "✓ RTK uninstall complete"
 }

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -536,21 +536,29 @@ status_json() {
 doctor_json() {
   status_json false false | jq '
     . as $s
+    | ([
+        (if $s.legacy_hook_file_present then "legacy hook file" else empty end),
+        (if $s.global_rtk_md_present then "global RTK.md" else empty end),
+        (if $s.global_claude_ref_present then "CLAUDE.md @RTK.md reference" else empty end),
+        (if $s.project_local_present then "project .rtk files" else empty end),
+        (if (($s.install_receipt // "") != "") then "VBW install receipt" else empty end),
+        (if (($s.binary_install_state // "absent") != "absent") then "binary state: " + $s.binary_install_state else empty end)
+      ]) as $rtk_artifacts
     | .doctor_status = (
         if ($s.settings_json_valid == false) then "WARN"
-        elif ($s.compatibility == "absent" and ($s.project_local_present | not) and ($s.legacy_hook_file_present | not)) then "SKIP"
         elif ($s.update_available == true) then "WARN"
         elif ($s.compatibility == "verified") then "PASS"
+        elif ($s.compatibility == "absent" and ($rtk_artifacts | length) == 0) then "SKIP"
         else "WARN" end
       )
     | .doctor_detail = (
         if .settings_json_valid == false then "Claude settings unreadable; RTK hook state cannot be determined from settings.json"
         elif .update_available == true then "outdated from cached RTK release check; run /vbw:rtk update"
         elif .doctor_status == "PASS" then "verified by " + ($s.proof_source // "smoke proof")
+        elif ($rtk_artifacts | length) > 0 then "RTK artifacts present with no active settings hook: " + ($rtk_artifacts | join(", ")) + "; run /vbw:rtk status or /vbw:rtk uninstall/manage"
         elif .compatibility == "absent" then "not installed; optional: /vbw:rtk install"
         elif .compatibility == "binary_only" then "binary installed; hook inactive"
         elif .compatibility == "risk" then "hook active; PreToolUse updatedInput compatibility unverified"
-        elif .legacy_hook_file_present == true then "legacy RTK hook artifact found; settings hook inactive"
         else "hook active; compatibility unverified" end
       )'
 }

--- a/scripts/verify-vibe.sh
+++ b/scripts/verify-vibe.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # verify-vibe.sh — Automated verification of vibe command consolidation (Plan 03-01)
 #
-# Checks all 25 requirements (REQ-01 through REQ-25) across 6 groups.
+# Checks all 25 vibe consolidation requirements (REQ-01 through REQ-25) across 6 groups.
 # Read-only: never modifies any files.
 #
 # Usage: bash scripts/verify-vibe.sh
@@ -169,7 +169,7 @@ done
 
 # REQ-18: Exact tracked file count (ignore ignored/untracked local command artifacts)
 CMD_COUNT=$(tracked_markdown_count 'commands/*.md')
-check "REQ-18" "commands/ has exactly 25 .md files (found $CMD_COUNT)" test "$CMD_COUNT" -eq 25
+check "REQ-18" "commands/ has exactly 26 .md files (found $CMD_COUNT)" test "$CMD_COUNT" -eq 26
 
 # REQ-20: No stale "29 commands" in key files
 check_absent "REQ-20" "README.md has no '29 commands'" grep -q "29 commands" "$README"

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -49,6 +49,7 @@ printf '%s\t%s\n' \
   qa-persistence-contract      testing/verify-qa-persistence-contract.sh \
   report-template-contract     testing/verify-report-template-contract.sh \
   report-diag-handoff          testing/verify-report-diag-handoff.sh \
+  rtk-integration-contract     testing/verify-rtk-integration-contract.sh \
   discussion-engine-contract   testing/verify-discussion-engine-contract.sh \
   debug-session-contract       testing/verify-debug-session-contract.sh \
   todo-pickup-contract         testing/verify-todo-pickup-contract.sh \

--- a/testing/verify-plugin-root-resolution.sh
+++ b/testing/verify-plugin-root-resolution.sh
@@ -332,7 +332,7 @@ fi
 # Check 11: targeted command preambles use CLAUDE_SESSION_ID:-default session key
 # todo.md and list-todos.md intentionally have no shell preamble (fix for #201) — skip from preamble checks
 TARGET_COMMANDS=(
-  config.md debug.md discuss.md fix.md help.md init.md map.md qa.md
+  config.md debug.md discuss.md doctor.md fix.md help.md init.md map.md qa.md
   report.md research.md resume.md rtk.md skills.md status.md update.md verify.md vibe.md whats-new.md
 )
 for rel in "${TARGET_COMMANDS[@]}"; do
@@ -433,7 +433,7 @@ echo ""
 echo "=== Preamble Coverage Drift Detection ==="
 
 # Known non-preamble commands (no shell preamble by design)
-NON_PREAMBLE_COMMANDS="todo.md list-todos.md doctor.md pause.md profile.md teach.md uninstall.md"
+NON_PREAMBLE_COMMANDS="todo.md list-todos.md pause.md profile.md teach.md uninstall.md"
 
 DRIFT_FAIL=0
 for file in "$COMMANDS_DIR"/*.md; do

--- a/testing/verify-plugin-root-resolution.sh
+++ b/testing/verify-plugin-root-resolution.sh
@@ -333,7 +333,7 @@ fi
 # todo.md and list-todos.md intentionally have no shell preamble (fix for #201) — skip from preamble checks
 TARGET_COMMANDS=(
   config.md debug.md discuss.md fix.md help.md init.md map.md qa.md
-  report.md research.md resume.md skills.md status.md update.md verify.md vibe.md whats-new.md
+  report.md research.md resume.md rtk.md skills.md status.md update.md verify.md vibe.md whats-new.md
 )
 for rel in "${TARGET_COMMANDS[@]}"; do
   file="$COMMANDS_DIR/$rel"

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -172,6 +172,39 @@ else
   fail "rtk-manager uninstall order can remove binary before hook deactivation"
 fi
 
+if contains "$RTK_CMD" 'managed_by_vbw=true` and `global_hook_present=true' \
+  && contains "$RTK_CMD" 'uninstall --dry-run --deactivate-hook' \
+  && contains "$RTK_CMD" 'uninstall --yes --deactivate-hook'; then
+  pass "rtk command routes hook-active managed uninstall through deactivate-hook flow"
+else
+  fail "rtk command missing hook-active managed deactivate-hook uninstall flow"
+fi
+
+if contains "$RTK_MANAGER" 'active RTK settings hook detected; pass --deactivate-hook' \
+  && contains "$RTK_MANAGER" 'retire_install_receipt()' \
+  && contains "$RTK_MANAGER" 'retire_install_receipt'; then
+  pass "rtk-manager refuses unsafe managed uninstall and retires receipts after success"
+else
+  fail "rtk-manager missing unsafe-uninstall guard or receipt retirement"
+fi
+
+if ! contains "$RTK_MANAGER" '${auto_patch:+' \
+  && ! contains "$RTK_MANAGER" '${hook_only:+' \
+  && ! contains "$RTK_MANAGER" '${deactivate_hook:+'; then
+  pass "rtk-manager preflight output avoids non-empty-string boolean expansion bugs"
+else
+  fail "rtk-manager still uses buggy boolean parameter expansion in preflight output"
+fi
+
+if contains "$RTK_MANAGER" 'binary_install_state="installed_not_on_path"' \
+  && contains "$RTK_MANAGER" 'RTK binary exists at $receipt_path but is not on PATH' \
+  && contains "$RTK_CMD" 'Enable Claude Code hook` when `rtk_present=true` and `global_hook_present=false' \
+  && contains "$RTK_CMD" 'Show PATH guidance` when `managed_by_vbw=true` and `binary_install_state="installed_not_on_path"'; then
+  pass "rtk status and command menu keep hook activation gated on PATH-visible RTK"
+else
+  fail "rtk status/menu missing PATH-visible RTK hook activation invariant"
+fi
+
 if contains "$DOCTOR_CMD" '### 18. RTK integration' \
   && contains "$DOCTOR_CMD" 'bash "{plugin-root}/scripts/rtk-manager.sh" doctor-json' \
   && contains "$DOCTOR_CMD" 'Result: {N}/18 passed' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -115,6 +115,26 @@ else
   fail "rtk-manager missing ownership receipt contract"
 fi
 
+if contains "$RTK_MANAGER" '"$path" --version' \
+  && contains "$RTK_MANAGER" '"$target_path" --version' \
+  && ! contains "$RTK_MANAGER" '$path --version' \
+  && ! contains "$RTK_MANAGER" '$target_path --version'; then
+  pass "rtk-manager quotes executable paths for version probes"
+else
+  fail "rtk-manager has unquoted RTK executable version probes"
+fi
+
+backup_helper_refs=$(grep -c 'backup_rtk_global_config_files' "$RTK_MANAGER" 2>/dev/null || echo 0)
+if contains "$RTK_MANAGER" 'backup_rtk_global_config_files()' \
+  && contains "$RTK_MANAGER" 'backup_if_present "$RTK_SETTINGS_JSON"' \
+  && contains "$RTK_MANAGER" 'backup_if_present "$RTK_CLAUDE_MD"' \
+  && contains "$RTK_MANAGER" 'backup_if_present "$RTK_GLOBAL_MD"' \
+  && [ "${backup_helper_refs:-0}" -ge 3 ]; then
+  pass "rtk-manager backs up Claude config for activation and uninstall deactivation"
+else
+  fail "rtk-manager missing shared Claude config backup helper/calls"
+fi
+
 if contains "$RTK_MANAGER" 'ensure_confirmation' \
   && contains "$RTK_MANAGER" 'requires explicit confirmation' \
   && contains "$RTK_MANAGER" 'dry_run=true'; then

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+contains() {
+  local file="$1" needle="$2"
+  grep -Fq -- "$needle" "$file"
+}
+
+contains_re() {
+  local file="$1" regex="$2"
+  grep -Eq -- "$regex" "$file"
+}
+
+not_contains_re() {
+  local file="$1" regex="$2"
+  ! grep -Eq -- "$regex" "$file"
+}
+
+tracked_files() {
+  local pattern
+  for pattern in "$@"; do
+    git -C "$ROOT" ls-files -- "$pattern"
+  done | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s\n' "$ROOT/$rel"
+  done
+}
+
+echo "=== RTK Integration Contract Verification ==="
+
+RTK_CMD="$ROOT/commands/rtk.md"
+RTK_MANAGER="$ROOT/scripts/rtk-manager.sh"
+DOCTOR_CMD="$ROOT/commands/doctor.md"
+STATUS_CMD="$ROOT/commands/status.md"
+SESSION_START="$ROOT/scripts/session-start.sh"
+README="$ROOT/README.md"
+
+[ -f "$RTK_CMD" ] && pass "commands/rtk.md exists" || fail "commands/rtk.md missing"
+[ -x "$RTK_MANAGER" ] && pass "scripts/rtk-manager.sh exists and is executable" || fail "scripts/rtk-manager.sh missing or not executable"
+
+if contains "$RTK_CMD" 'name: vbw:rtk' \
+  && contains "$RTK_CMD" 'argument-hint: [status|install|init|verify|update|uninstall]' \
+  && contains "$RTK_CMD" 'allowed-tools: Read, Bash, AskUserQuestion'; then
+  pass "rtk command frontmatter exposes explicit management subcommands"
+else
+  fail "rtk command frontmatter missing explicit management contract"
+fi
+
+for subcommand in 'status --json' 'install --dry-run' 'install --yes' 'init --dry-run' 'init --yes' 'verify' 'uninstall --dry-run' 'uninstall --yes'; do
+  if contains "$RTK_CMD" "$subcommand"; then
+    pass "rtk command references helper flow: $subcommand"
+  else
+    fail "rtk command missing helper flow: $subcommand"
+  fi
+done
+
+if contains "$RTK_CMD" 'Binary install/update and Claude Code hook activation are separate operations' \
+  && contains "$RTK_CMD" 'Never combine them into one confirmation' \
+  && contains "$RTK_CMD" 'does not pipe downloaded shell scripts into sh'; then
+  pass "rtk command documents separate consent boundaries and no curl-to-shell piping"
+else
+  fail "rtk command missing consent/no-curl-to-shell wording"
+fi
+
+if contains "$RTK_MANAGER" 'status --json [--check-updates] [--stats]' \
+  && contains "$RTK_MANAGER" 'doctor-json' \
+  && contains "$RTK_MANAGER" 'install [--dry-run] [--yes] [--allow-missing-checksum]' \
+  && contains "$RTK_MANAGER" 'init [--dry-run] [--yes] [--auto-patch] [--hook-only]' \
+  && contains "$RTK_MANAGER" 'uninstall [--dry-run] [--yes] [--deactivate-hook]'; then
+  pass "rtk-manager exposes required subcommands and safety flags"
+else
+  fail "rtk-manager usage missing required subcommands or safety flags"
+fi
+
+if contains "$RTK_MANAGER" 'RTK_REPO_API="${RTK_REPO_API:-https://api.github.com/repos/rtk-ai/rtk/releases/latest}"' \
+  && contains "$RTK_MANAGER" 'checksums.txt' \
+  && contains "$RTK_MANAGER" 'verify_download_checksum' \
+  && contains "$RTK_MANAGER" 'checksum mismatch'; then
+  pass "rtk-manager uses latest GitHub release metadata with checksum verification"
+else
+  fail "rtk-manager missing latest-release checksum contract"
+fi
+
+if contains "$RTK_MANAGER" 'settings_hook_command()' \
+  && contains "$RTK_MANAGER" 'rtk[[:space:]]+hook[[:space:]]+claude' \
+  && contains "$RTK_MANAGER" 'rtk-rewrite[.]sh' \
+  && contains "$RTK_MANAGER" 'RTK_CLAUDE_MD' \
+  && contains "$RTK_MANAGER" 'RTK_GLOBAL_MD'; then
+  pass "rtk-manager detects current and legacy RTK hook/artifact shapes"
+else
+  fail "rtk-manager missing current/legacy RTK hook detection"
+fi
+
+if contains "$RTK_MANAGER" 'RTK_RECEIPT_FILE' \
+  && contains "$RTK_MANAGER" 'write_receipt()' \
+  && contains "$RTK_MANAGER" 'manager:$manager' \
+  && contains "$RTK_MANAGER" 'receipt_managed'; then
+  pass "rtk-manager records VBW ownership receipts for update/uninstall"
+else
+  fail "rtk-manager missing ownership receipt contract"
+fi
+
+if contains "$RTK_MANAGER" 'ensure_confirmation' \
+  && contains "$RTK_MANAGER" 'requires explicit confirmation' \
+  && contains "$RTK_MANAGER" 'dry_run=true'; then
+  pass "rtk-manager mutating operations require --yes or --dry-run"
+else
+  fail "rtk-manager missing explicit confirmation guard"
+fi
+
+if contains "$RTK_MANAGER" 'updatedInput' \
+  && contains "$RTK_MANAGER" '#15897' \
+  && contains "$RTK_MANAGER" 'compatibility="risk"' \
+  && contains "$RTK_MANAGER" 'hook_active_unverified'; then
+  pass "rtk-manager preserves PreToolUse updatedInput compatibility caveat"
+else
+  fail "rtk-manager missing updatedInput compatibility caveat"
+fi
+
+if contains "$DOCTOR_CMD" '### 18. RTK integration' \
+  && contains "$DOCTOR_CMD" 'rtk-manager.sh doctor-json' \
+  && contains "$DOCTOR_CMD" 'Result: {N}/18 passed' \
+  && contains "$DOCTOR_CMD" 'Doctor must not query the network'; then
+  pass "doctor command includes RTK check 18 via offline helper JSON"
+else
+  fail "doctor command missing RTK check 18 offline helper contract"
+fi
+
+if contains "$STATUS_CMD" 'RTK external metrics' \
+  && contains "$STATUS_CMD" 'status --json --stats' \
+  && contains "$STATUS_CMD" 'Default `/vbw:status` must not advertise RTK when absent'; then
+  pass "status command limits RTK to explicit external metrics"
+else
+  fail "status command missing explicit-only RTK metrics boundary"
+fi
+
+if contains "$README" '/vbw:rtk' \
+  && contains "$README" 'Binary install/update and Claude Code hook activation are separate' \
+  && contains "$README" 'checksums.txt' \
+  && contains "$README" 'RTK savings are shown as external RTK metrics'; then
+  pass "README documents optional RTK managed setup boundaries"
+else
+  fail "README missing RTK managed setup docs"
+fi
+
+if contains "$ROOT/testing/list-contract-tests.sh" 'rtk-integration-contract'; then
+  pass "RTK contract test is registered"
+else
+  fail "RTK contract test not registered"
+fi
+
+if contains "$ROOT/testing/verify-plugin-root-resolution.sh" 'rtk.md'; then
+  pass "rtk.md included in plugin-root preamble coverage"
+else
+  fail "rtk.md missing from plugin-root preamble coverage"
+fi
+
+if not_contains_re "$SESSION_START" '[Rr][Tt][Kk]'; then
+  pass "session-start has no recurring RTK context"
+else
+  fail "session-start must not mention RTK"
+fi
+
+implicit_targets=(
+  "$ROOT/commands/init.md"
+  "$ROOT/commands/vibe.md"
+  "$ROOT/commands/status.md"
+  "$ROOT/commands/doctor.md"
+  "$SESSION_START"
+)
+for target in "${implicit_targets[@]}"; do
+  rel="${target#$ROOT/}"
+  if not_contains_re "$target" 'rtk-manager[.]sh[[:space:]]+(install|update|init|uninstall)|rtk[[:space:]]+init[[:space:]]+-g|curl[[:space:]].*[|][[:space:]]*sh'; then
+    pass "$rel does not invoke implicit RTK setup"
+  else
+    fail "$rel invokes implicit RTK setup"
+  fi
+done
+
+curl_pipe_matches=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  if contains_re "$file" 'curl[[:space:]].*[|][[:space:]]*(ba)?sh'; then
+    curl_pipe_matches="${curl_pipe_matches}${file#$ROOT/}\n"
+  fi
+done < <(tracked_files 'scripts/*.sh')
+if [ -z "$curl_pipe_matches" ]; then
+  pass "managed shell scripts do not use curl-pipe-shell"
+else
+  fail "managed shell scripts contain curl-pipe-shell:\n$curl_pipe_matches"
+fi
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "RTK integration contract checks passed."
+exit 0

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -125,6 +125,16 @@ else
   fail "rtk-manager has unquoted RTK executable version probes"
 fi
 
+pretooluse_typo_key="multiple_bash_pre""tookuse_hooks_detected"
+if contains "$RTK_MANAGER" 'multiple_bash_pretooluse_hooks_detected' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'multiple_bash_pretooluse_hooks_detected' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'typo_key' \
+  && ! contains "$RTK_MANAGER" "$pretooluse_typo_key"; then
+  pass "rtk-manager status JSON spells PreToolUse correctly"
+else
+  fail "rtk-manager status JSON still contains misspelled PreToolUse key"
+fi
+
 if contains "$RTK_MANAGER" '"$rtk_path" gain --json' \
   && ! contains "$RTK_MANAGER" '$rtk_path gain --json'; then
   pass "rtk-manager quotes executable path for explicit stats"

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -142,7 +142,9 @@ else
   fail "rtk-manager proof validation is too weak"
 fi
 
-if contains "$RTK_MANAGER" 'if [ -n "$hook_command" ]; then global_hook_present=true; fi' \
+if contains "$RTK_MANAGER" 'if [ -n "$hook_command" ]; then' \
+  && contains "$RTK_MANAGER" 'global_hook_present=true' \
+  && contains "$RTK_MANAGER" 'settings_hook_state="active"' \
   && ! contains "$RTK_MANAGER" 'if [ -n "$hook_command" ] || [ "$legacy_hook" = "true" ]; then global_hook_present=true; fi'; then
   pass "rtk-manager treats settings JSON hook command as active-hook source of truth"
 else
@@ -172,7 +174,7 @@ else
   fail "rtk-manager uninstall order can remove binary before hook deactivation"
 fi
 
-if contains "$RTK_CMD" 'managed_by_vbw=true` and `global_hook_present=true' \
+if contains "$RTK_CMD" 'managed_by_vbw=true` and either `global_hook_present=true` or `settings_json_valid=false' \
   && contains "$RTK_CMD" 'uninstall --dry-run --deactivate-hook' \
   && contains "$RTK_CMD" 'uninstall --yes --deactivate-hook'; then
   pass "rtk command routes hook-active managed uninstall through deactivate-hook flow"
@@ -180,7 +182,7 @@ else
   fail "rtk command missing hook-active managed deactivate-hook uninstall flow"
 fi
 
-if contains "$RTK_MANAGER" 'active RTK settings hook detected; pass --deactivate-hook' \
+if contains "$RTK_MANAGER" 'active or unreadable RTK settings hook state detected; pass --deactivate-hook' \
   && contains "$RTK_MANAGER" 'retire_install_receipt()' \
   && contains "$RTK_MANAGER" 'retire_install_receipt'; then
   pass "rtk-manager refuses unsafe managed uninstall and retires receipts after success"
@@ -203,6 +205,23 @@ if contains "$RTK_MANAGER" 'binary_install_state="installed_not_on_path"' \
   pass "rtk status and command menu keep hook activation gated on PATH-visible RTK"
 else
   fail "rtk status/menu missing PATH-visible RTK hook activation invariant"
+fi
+
+if contains "$RTK_MANAGER" 'settings_hook_state="unknown"' \
+  && contains "$RTK_MANAGER" 'compatibility="settings_unreadable"' \
+  && contains "$RTK_MANAGER" 'if ($s.settings_json_valid == false) then "WARN"' \
+  && contains "$RTK_MANAGER" 'active or unreadable RTK settings hook state detected' \
+  && contains "$RTK_CMD" 'settings_json_valid=false'; then
+  pass "rtk-manager treats malformed settings as unknown/WARN and blocks unsafe uninstall"
+else
+  fail "rtk-manager missing malformed-settings unknown-state safety"
+fi
+
+if ! grep -Fq 'status_json false true' "$RTK_MANAGER" \
+  && contains "$RTK_MANAGER" 'status_json false false'; then
+  pass "rtk verify path does not implicitly collect RTK stats"
+else
+  fail "rtk verify path still enables implicit stats collection"
 fi
 
 if contains "$DOCTOR_CMD" '### 18. RTK integration' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -176,7 +176,10 @@ fi
 if ! contains "$RTK_MANAGER" '$current_version == ""' \
   && ! contains "$RTK_MANAGER" '.rtk_version // $current_version' \
   && ! contains "$RTK_MANAGER" '.hook_command // $active_hook_command' \
-  && contains "$RTK_MANAGER" '[ "$rtk_present" = "true" ] && [ -n "$hook_command" ] && valid_runtime_smoke_proof'; then
+  && contains "$RTK_MANAGER" 'rtk_path_from_hook_command()' \
+  && contains "$RTK_MANAGER" 'active_hook_rtk_path' \
+  && contains "$RTK_MANAGER" 'active_hook_rtk_version' \
+  && contains "$RTK_MANAGER" 'valid_runtime_smoke_proof "$RTK_PROOF_FILE" "$active_hook_rtk_version" "$hook_command"'; then
   pass "rtk-manager rejects stale proof without current RTK runtime state"
 else
   fail "rtk-manager can still accept stale proof without current RTK runtime state"

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -164,10 +164,22 @@ if contains "$RTK_MANAGER" 'valid_runtime_smoke_proof()' \
   && contains "$RTK_MANAGER" 'updated_input_verified' \
   && contains "$RTK_MANAGER" 'rtk_rewrite_observed' \
   && contains "$RTK_MANAGER" 'vbw_bash_guard_verified' \
+  && contains "$RTK_MANAGER" '[ -n "$current_version" ] || return 1' \
+  && contains "$RTK_MANAGER" '(.rtk_version // "") == $current_version' \
+  && contains "$RTK_MANAGER" '(.hook_command // "") == $active_hook_command' \
   && ! grep -Fq 'jq empty "$RTK_PROOF_FILE"' "$RTK_MANAGER"; then
   pass "rtk-manager requires concrete runtime smoke proof before verified compatibility"
 else
   fail "rtk-manager proof validation is too weak"
+fi
+
+if ! contains "$RTK_MANAGER" '$current_version == ""' \
+  && ! contains "$RTK_MANAGER" '.rtk_version // $current_version' \
+  && ! contains "$RTK_MANAGER" '.hook_command // $active_hook_command' \
+  && contains "$RTK_MANAGER" '[ "$rtk_present" = "true" ] && [ -n "$hook_command" ] && valid_runtime_smoke_proof'; then
+  pass "rtk-manager rejects stale proof without current RTK runtime state"
+else
+  fail "rtk-manager can still accept stale proof without current RTK runtime state"
 fi
 
 if contains "$RTK_MANAGER" 'if [ -n "$hook_command" ]; then' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -381,13 +381,13 @@ curl_pipe_matches=""
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   if contains_re "$file" 'curl[[:space:]].*[|][[:space:]]*(ba)?sh'; then
-    curl_pipe_matches="${curl_pipe_matches}${file#$ROOT/}\n"
+    curl_pipe_matches+="${file#$ROOT/}"$'\n'
   fi
 done < <(tracked_files 'scripts/*.sh')
 if [ -z "$curl_pipe_matches" ]; then
   pass "managed shell scripts do not use curl-pipe-shell"
 else
-  fail "managed shell scripts contain curl-pipe-shell:\n$curl_pipe_matches"
+  fail $'managed shell scripts contain curl-pipe-shell:\n'"$curl_pipe_matches"
 fi
 
 echo ""

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -110,6 +110,19 @@ else
   fail "rtk-manager has unbounded direct curl calls or missing timeout guard"
 fi
 
+unrestricted_tar_count=$(awk '/tar -xzf "\$asset" -C "\$temp_dir"$/ { count++ } END { print count + 0 }' "$RTK_MANAGER")
+if contains "$RTK_MANAGER" 'rtk_archive_member_safe()' \
+  && contains "$RTK_MANAGER" 'validate_rtk_archive_members()' \
+  && contains "$RTK_MANAGER" 'tar -tzf "$asset"' \
+  && contains "$RTK_MANAGER" 'unsafe RTK archive member path' \
+  && contains "$RTK_MANAGER" 'multiple rtk binaries' \
+  && contains "$RTK_MANAGER" 'tar -xzf "$asset" -C "$temp_dir" -- "$rtk_member"' \
+  && [ "${unrestricted_tar_count:-0}" -eq 0 ]; then
+  pass "rtk-manager validates tar members before single-member extraction"
+else
+  fail "rtk-manager missing safe tar member validation/extraction"
+fi
+
 if contains "$RTK_MANAGER" 'settings_hook_command()' \
   && contains "$RTK_MANAGER" 'as $match_command' \
   && contains "$RTK_MANAGER" 'rtkhookclaude' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -217,6 +217,19 @@ else
   fail "rtk-manager missing malformed-settings unknown-state safety"
 fi
 
+if contains "$RTK_MANAGER" '$rtk_artifacts' \
+  && contains "$RTK_MANAGER" 'legacy hook file' \
+  && contains "$RTK_MANAGER" 'global RTK.md' \
+  && contains "$RTK_MANAGER" 'CLAUDE.md @RTK.md reference' \
+  && contains "$RTK_MANAGER" 'project .rtk files' \
+  && contains "$RTK_MANAGER" 'VBW install receipt' \
+  && contains "$RTK_MANAGER" 'RTK artifacts present with no active settings hook' \
+  && contains "$DOCTOR_CMD" 'artifact-only'; then
+  pass "doctor-json surfaces artifact-only RTK states as WARN with concrete evidence"
+else
+  fail "doctor-json missing artifact-only RTK WARN/detail handling"
+fi
+
 if ! grep -Fq 'status_json false true' "$RTK_MANAGER" \
   && contains "$RTK_MANAGER" 'status_json false false'; then
   pass "rtk verify path does not implicitly collect RTK stats"

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -96,6 +96,20 @@ else
   fail "rtk-manager missing latest-release checksum contract"
 fi
 
+curl_direct_count=$(grep -c 'curl -fsSL' "$RTK_MANAGER" 2>/dev/null || echo 0)
+if contains "$RTK_MANAGER" 'RTK_CURL_MAX_TIME="${RTK_CURL_MAX_TIME:-15}"' \
+  && contains "$RTK_MANAGER" 'curl_bounded()' \
+  && contains "$RTK_MANAGER" 'curl -fsSL --max-time "$RTK_CURL_MAX_TIME" "$@"' \
+  && contains "$RTK_MANAGER" 'curl_json()' \
+  && contains "$RTK_MANAGER" 'curl_bounded "$url"' \
+  && contains "$RTK_MANAGER" 'curl_bounded -o "$asset_file" "$asset_url"' \
+  && contains "$RTK_MANAGER" 'curl_bounded -o "$checksums_file" "$checksums_url"' \
+  && [ "${curl_direct_count:-0}" -eq 1 ]; then
+  pass "rtk-manager bounds all managed curl calls with max-time"
+else
+  fail "rtk-manager has unbounded direct curl calls or missing timeout guard"
+fi
+
 if contains "$RTK_MANAGER" 'settings_hook_command()' \
   && contains "$RTK_MANAGER" 'as $match_command' \
   && contains "$RTK_MANAGER" 'rtkhookclaude' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -97,11 +97,12 @@ else
 fi
 
 if contains "$RTK_MANAGER" 'settings_hook_command()' \
-  && contains "$RTK_MANAGER" 'rtk[[:space:]]+hook[[:space:]]+claude' \
+  && contains "$RTK_MANAGER" 'as $match_command' \
+  && contains "$RTK_MANAGER" 'rtkhookclaude' \
   && contains "$RTK_MANAGER" 'rtk-rewrite[.]sh' \
   && contains "$RTK_MANAGER" 'RTK_CLAUDE_MD' \
   && contains "$RTK_MANAGER" 'RTK_GLOBAL_MD'; then
-  pass "rtk-manager detects current and legacy RTK hook/artifact shapes"
+  pass "rtk-manager detects current, quoted, and legacy RTK hook/artifact shapes"
 else
   fail "rtk-manager missing current/legacy RTK hook detection"
 fi
@@ -122,6 +123,13 @@ if contains "$RTK_MANAGER" '"$path" --version' \
   pass "rtk-manager quotes executable paths for version probes"
 else
   fail "rtk-manager has unquoted RTK executable version probes"
+fi
+
+if contains "$RTK_MANAGER" '"$rtk_path" gain --json' \
+  && ! contains "$RTK_MANAGER" '$rtk_path gain --json'; then
+  pass "rtk-manager quotes executable path for explicit stats"
+else
+  fail "rtk-manager has unquoted RTK executable stats invocation"
 fi
 
 backup_helper_refs=$(grep -c 'backup_rtk_global_config_files' "$RTK_MANAGER" 2>/dev/null || echo 0)

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -132,13 +132,53 @@ else
   fail "rtk-manager missing updatedInput compatibility caveat"
 fi
 
+if contains "$RTK_MANAGER" 'valid_runtime_smoke_proof()' \
+  && contains "$RTK_MANAGER" 'updated_input_verified' \
+  && contains "$RTK_MANAGER" 'rtk_rewrite_observed' \
+  && contains "$RTK_MANAGER" 'vbw_bash_guard_verified' \
+  && ! grep -Fq 'jq empty "$RTK_PROOF_FILE"' "$RTK_MANAGER"; then
+  pass "rtk-manager requires concrete runtime smoke proof before verified compatibility"
+else
+  fail "rtk-manager proof validation is too weak"
+fi
+
+if contains "$RTK_MANAGER" 'if [ -n "$hook_command" ]; then global_hook_present=true; fi' \
+  && ! contains "$RTK_MANAGER" 'if [ -n "$hook_command" ] || [ "$legacy_hook" = "true" ]; then global_hook_present=true; fi'; then
+  pass "rtk-manager treats settings JSON hook command as active-hook source of truth"
+else
+  fail "rtk-manager lets legacy hook files masquerade as active hooks"
+fi
+
+if contains "$RTK_MANAGER" 'fetch_latest_release()' \
+  && contains "$RTK_MANAGER" 'cache_latest_release()' \
+  && contains "$RTK_MANAGER" 'metadata="$(latest_metadata_or_die false)"' \
+  && contains "$RTK_MANAGER" 'cache_latest_release "$metadata"'; then
+  pass "rtk-manager separates metadata fetch from cache writes for dry-run/preflight safety"
+else
+  fail "rtk-manager does not clearly separate latest-release fetch and cache mutation"
+fi
+
+if contains "$RTK_MANAGER" 'no ownership takeover' \
+  && contains "$RTK_MANAGER" 'VBW receipt exists but its binary is missing'; then
+  pass "rtk-manager update path is ownership-aware for external and inconsistent installs"
+else
+  fail "rtk-manager update path missing ownership-aware guards"
+fi
+
+if contains "$RTK_MANAGER" 'rtk init -g --uninstall before binary removal' \
+  && contains "$RTK_MANAGER" 'hook deactivation failed; preserved RTK binary and receipt'; then
+  pass "rtk-manager uninstall deactivates hooks before removing managed binaries"
+else
+  fail "rtk-manager uninstall order can remove binary before hook deactivation"
+fi
+
 if contains "$DOCTOR_CMD" '### 18. RTK integration' \
-  && contains "$DOCTOR_CMD" 'rtk-manager.sh doctor-json' \
+  && contains "$DOCTOR_CMD" 'bash "{plugin-root}/scripts/rtk-manager.sh" doctor-json' \
   && contains "$DOCTOR_CMD" 'Result: {N}/18 passed' \
   && contains "$DOCTOR_CMD" 'Doctor must not query the network'; then
-  pass "doctor command includes RTK check 18 via offline helper JSON"
+  pass "doctor command includes RTK check 18 via plugin-root offline helper JSON"
 else
-  fail "doctor command missing RTK check 18 offline helper contract"
+  fail "doctor command missing plugin-root RTK check 18 offline helper contract"
 fi
 
 if contains "$STATUS_CMD" 'RTK external metrics' \

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -35,6 +35,12 @@ case "\${1:-}" in
     fi
     ;;
   init)
+    if [ "\${2:-}" = "-g" ] && [ "\${3:-}" = "--uninstall" ]; then
+      if [ -e "\$0" ]; then echo "uninstall_binary_exists=yes" >> "$TEST_TEMP_DIR/rtk-calls.log"; fi
+      if [ "\${FAKE_RTK_UNINSTALL_FAIL:-false}" = "true" ]; then exit 44; fi
+      rm -f "$CLAUDE_CONFIG_DIR/settings.json"
+      exit 0
+    fi
     mkdir -p "$CLAUDE_CONFIG_DIR"
     cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
 {"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
@@ -76,7 +82,7 @@ sha256_value() {
 }
 
 prepare_release_fixture() {
-  local version="${1:-9.9.9}" mismatch="${2:-false}"
+  local version="${1:-9.9.9}" mismatch="${2:-false}" checksum_mode="${3:-present}"
   local asset checksum
   asset="$(release_target_asset)"
   mkdir -p "$TEST_TEMP_DIR/release/payload"
@@ -93,16 +99,62 @@ EOF
   if [ "$mismatch" = "true" ]; then
     checksum="0000000000000000000000000000000000000000000000000000000000000000"
   fi
-  printf '%s  %s\n' "$checksum" "$asset" > "$TEST_TEMP_DIR/release/checksums.txt"
+  case "$checksum_mode" in
+    present) printf '%s  %s\n' "$checksum" "$asset" > "$TEST_TEMP_DIR/release/checksums.txt" ;;
+    missing-asset) printf '%s  %s\n' "$checksum" "other-asset.tar.gz" > "$TEST_TEMP_DIR/release/checksums.txt" ;;
+    empty) : > "$TEST_TEMP_DIR/release/checksums.txt" ;;
+    no-asset) : > "$TEST_TEMP_DIR/release/checksums.txt" ;;
+  esac
   cat > "$TEST_TEMP_DIR/release/release.json" <<EOF
 {
   "tag_name": "v$version",
   "assets": [
-    {"name": "$asset", "browser_download_url": "https://example.invalid/$asset"},
-    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"}
+    {"name": "$asset", "browser_download_url": "https://example.invalid/$asset"}
+    $(if [ "$checksum_mode" != "no-asset" ]; then printf ',\n    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"}'; fi)
   ]
 }
 EOF
+}
+
+create_managed_rtk() {
+  local version="${1:-0.1.0}" dir="$TEST_TEMP_DIR/managed-bin" binary
+  mkdir -p "$dir" "$VBW_RTK_DIR"
+  binary="$dir/rtk"
+  cat > "$binary" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TEST_TEMP_DIR/rtk-calls.log"
+case "\${1:-}" in
+  --version) echo "rtk $version" ;;
+  init)
+    if [ "\${2:-}" = "-g" ] && [ "\${3:-}" = "--uninstall" ]; then
+      if [ -e "\$0" ]; then echo "uninstall_binary_exists=yes" >> "$TEST_TEMP_DIR/rtk-calls.log"; fi
+      if [ "\${FAKE_RTK_UNINSTALL_FAIL:-false}" = "true" ]; then exit 44; fi
+      exit 0
+    fi
+    ;;
+esac
+EOF
+  chmod +x "$binary"
+  jq -n --arg binary "$binary" --arg version "$version" \
+    '{manager:"vbw", binary_path:$binary, installed_version:$version, method:"github-release"}' > "$VBW_RTK_DIR/rtk-install.json"
+  printf '%s\n' "$binary"
+}
+
+write_valid_smoke_proof() {
+  mkdir -p "$VBW_RTK_DIR"
+  cat > "$VBW_RTK_DIR/rtk-compatibility-proof.json" <<'JSON'
+{
+  "proof_type": "runtime_smoke",
+  "status": "pass",
+  "timestamp": "2026-04-27T00:00:00Z",
+  "rtk_version": "0.1.0",
+  "hook_command": "rtk hook claude",
+  "updated_input_verified": true,
+  "rtk_rewrite_observed": true,
+  "vbw_bash_guard_verified": true,
+  "commands": ["git status", "echo ok"]
+}
+JSON
 }
 
 write_release_curl() {
@@ -208,6 +260,7 @@ JSON
   [[ "$output" == *"pipe downloaded shell scripts into sh"* ]]
   [ ! -e "$HOME/.local/bin/rtk" ]
   [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
 }
 
 @test "rtk-manager: install without confirmation aborts after preflight" {
@@ -217,6 +270,7 @@ JSON
   [ "$status" -eq 2 ]
   [[ "$output" == *"requires explicit confirmation"* ]]
   [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
 }
 
 @test "rtk-manager: managed install verifies checksum and writes receipt" {
@@ -264,4 +318,131 @@ JSON
   run rtk_manager status --json --stats
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.stats.average_savings_pct == 47'
+}
+
+@test "rtk-manager: arbitrary valid proof JSON does not verify compatibility" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  mkdir -p "$VBW_RTK_DIR"
+  echo '{"anything":"valid json"}' > "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.proof_source == ""'
+  echo "$output" | jq -e '.compatibility == "risk"'
+}
+
+@test "rtk-manager: validated runtime smoke proof can produce doctor PASS" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  write_valid_smoke_proof
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.compatibility == "verified"'
+  echo "$output" | jq -e '.doctor_status == "PASS"'
+}
+
+@test "rtk-manager: cached newer release makes verified doctor status WARN" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  write_valid_smoke_proof
+  mkdir -p "$VBW_RTK_DIR"
+  echo '{"version":"9.9.9","checked_at":"2026-04-27T00:00:00Z"}' > "$VBW_RTK_DIR/rtk-latest-release.json"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.update_available == true'
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  echo "$output" | jq -e '.doctor_detail | test("outdated")'
+}
+
+@test "rtk-manager: legacy hook file alone is diagnostic not active hook" {
+  mkdir -p "$CLAUDE_CONFIG_DIR/hooks"
+  touch "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.legacy_hook_file_present == true'
+  echo "$output" | jq -e '.global_hook_present == false'
+  echo "$output" | jq -e '.compatibility == "absent"'
+}
+
+@test "rtk-manager: legacy command in settings JSON is active hook" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"$HOME/.claude/hooks/rtk-rewrite.sh"}]}]}}
+JSON
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.global_hook_present == true'
+  echo "$output" | jq -e '.global_hook_command | test("rtk-rewrite")'
+}
+
+@test "rtk-manager: managed update dry-run does not cache latest release" {
+  create_managed_rtk "0.1.0" >/dev/null
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager update --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RTK update preflight"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
+}
+
+@test "rtk-manager: external no-receipt update does not take ownership" {
+  write_fake_rtk "0.1.0"
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager update --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"external install detected"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
+}
+
+@test "rtk-manager: managed update replaces receipt-owned binary and records versions" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager update --yes
+  [ "$status" -eq 0 ]
+  [ -x "$binary" ]
+  "$binary" --version | grep -Fq "9.9.9"
+  jq -e '.previous_version == "0.1.0"' "$VBW_RTK_DIR/rtk-install.json"
+  jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
+}
+
+@test "rtk-manager: missing checksum aborts unless explicitly allowed" {
+  prepare_release_fixture "9.9.9" "false" "no-asset"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"checksums.txt unavailable"* ]]
+  run rtk_manager install --yes --allow-missing-checksum
+  [ "$status" -eq 0 ]
+  jq -e '.verified_checksum == ""' "$VBW_RTK_DIR/rtk-install.json"
+}
+
+@test "rtk-manager: uninstall deactivates hook before removing managed binary" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  run rtk_manager uninstall --yes --deactivate-hook
+  [ "$status" -eq 0 ]
+  grep -Fq 'init -g --uninstall' "$TEST_TEMP_DIR/rtk-calls.log"
+  grep -Fq 'uninstall_binary_exists=yes' "$TEST_TEMP_DIR/rtk-calls.log"
+  [ ! -e "$binary" ]
+}
+
+@test "rtk-manager: failed hook deactivation preserves managed binary" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  export FAKE_RTK_UNINSTALL_FAIL=true
+  run rtk_manager uninstall --yes --deactivate-hook
+  [ "$status" -eq 1 ]
+  [ -e "$binary" ]
+  [ -f "$VBW_RTK_DIR/rtk-install.json" ]
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -11,7 +11,8 @@ setup() {
     ln -sf "$(command -v jq)" "$TEST_TEMP_DIR/bin/jq"
   fi
   local clean_path="" path_dir
-  IFS=: read -r -a _rtk_path_parts <<< "$PATH"
+  local -a _rtk_path_parts=()
+  IFS=: read -r -a _rtk_path_parts <<< "${PATH:-}"
   for path_dir in "${_rtk_path_parts[@]}"; do
     [ -n "$path_dir" ] || continue
     [ -x "$path_dir/rtk" ] && continue
@@ -21,7 +22,7 @@ setup() {
       clean_path="$clean_path:$path_dir"
     fi
   done
-  export PATH="$TEST_TEMP_DIR/bin:$clean_path"
+  export PATH="$TEST_TEMP_DIR/bin${clean_path:+:$clean_path}"
 }
 
 teardown() {
@@ -30,6 +31,12 @@ teardown() {
 
 rtk_manager() {
   bash "$SCRIPTS_DIR/rtk-manager.sh" "$@"
+}
+
+@test "rtk-manager: test harness PATH has no empty segments" {
+  [[ "$PATH" == "$TEST_TEMP_DIR/bin" || "$PATH" == "$TEST_TEMP_DIR/bin:"* ]]
+  [[ "$PATH" != *: ]]
+  [[ ":$PATH:" != *::* ]]
 }
 
 write_fake_rtk() {

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -235,8 +235,9 @@ JSON
   run rtk_manager status --json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.settings_json_valid == false'
+  echo "$output" | jq -e '.settings_hook_state == "unknown"'
   echo "$output" | jq -e '.global_hook_present == false'
-  echo "$output" | jq -e '.compatibility == "binary_only"'
+  echo "$output" | jq -e '.compatibility == "settings_unreadable"'
 }
 
 @test "rtk-manager: check-updates queries latest release only on explicit flag" {
@@ -317,10 +318,12 @@ JSON
 }
 
 @test "rtk-manager: doctor-json skips absent RTK" {
+  write_failing_curl
   run rtk_manager doctor-json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.doctor_status == "SKIP"'
   echo "$output" | jq -e '.doctor_detail | test("not installed")'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
 }
 
 @test "rtk-manager: stats are explicit and labeled separately in JSON" {
@@ -328,6 +331,29 @@ JSON
   run rtk_manager status --json --stats
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.stats.average_savings_pct == 47'
+}
+
+@test "rtk-manager: verify does not collect RTK gain stats" {
+  write_fake_rtk "0.1.0"
+  : > "$TEST_TEMP_DIR/rtk-calls.log"
+  run rtk_manager verify
+  [ "$status" -eq 0 ]
+  ! grep -Fq 'gain --json' "$TEST_TEMP_DIR/rtk-calls.log"
+  run rtk_manager verify --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.stats == null'
+  ! grep -Fq 'gain --json' "$TEST_TEMP_DIR/rtk-calls.log"
+}
+
+@test "rtk-manager: doctor-json warns on malformed settings without network" {
+  write_failing_curl
+  printf '{not-json' > "$CLAUDE_CONFIG_DIR/settings.json"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.settings_json_valid == false'
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  echo "$output" | jq -e '.doctor_detail | test("settings unreadable|Settings unreadable|Claude settings unreadable")'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
 }
 
 @test "rtk-manager: arbitrary valid proof JSON does not verify compatibility" {
@@ -488,10 +514,24 @@ JSON
 JSON
   run rtk_manager uninstall --dry-run
   [ "$status" -eq 0 ]
-  [[ "$output" == *"hook deactivation required before binary removal"* ]]
+  [[ "$output" == *"hook deactivation or settings repair required before binary removal"* ]]
   run rtk_manager uninstall --yes
   [ "$status" -eq 1 ]
   [[ "$output" == *"pass --deactivate-hook"* ]]
+  [ -e "$binary" ]
+  [ -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: malformed settings blocks managed uninstall without deactivate flag" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  printf '{not-json' > "$CLAUDE_CONFIG_DIR/settings.json"
+  run rtk_manager uninstall --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"settings repair required"* ]]
+  run rtk_manager uninstall --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unreadable RTK settings hook state"* ]]
   [ -e "$binary" ]
   [ -f "$VBW_RTK_DIR/rtk-install.json" ]
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -473,6 +473,67 @@ JSON
   echo "$output" | jq -e '.compatibility == "risk"'
 }
 
+@test "rtk-manager: stale proof without runnable RTK does not verify doctor" {
+  write_failing_curl
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  mkdir -p "$VBW_RTK_DIR"
+  cat > "$VBW_RTK_DIR/rtk-compatibility-proof.json" <<'JSON'
+{
+  "proof_type": "runtime_smoke",
+  "status": "pass",
+  "timestamp": "2026-04-27T00:00:00Z",
+  "rtk_version": "0.1.0",
+  "hook_command": "rtk hook claude",
+  "updated_input_verified": true,
+  "rtk_rewrite_observed": true,
+  "vbw_bash_guard_verified": true,
+  "commands": ["git status"]
+}
+JSON
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == false'
+  echo "$output" | jq -e '.global_hook_present == true'
+  echo "$output" | jq -e '.proof_source == ""'
+  echo "$output" | jq -e '.compatibility != "verified"'
+  echo "$output" | jq -e '.restart_required == true'
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
+@test "rtk-manager: proof version must match current RTK version" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  mkdir -p "$VBW_RTK_DIR"
+  cat > "$VBW_RTK_DIR/rtk-compatibility-proof.json" <<'JSON'
+{
+  "proof_type": "runtime_smoke",
+  "status": "pass",
+  "timestamp": "2026-04-27T00:00:00Z",
+  "rtk_version": "9.9.9",
+  "hook_command": "rtk hook claude",
+  "updated_input_verified": true,
+  "rtk_rewrite_observed": true,
+  "vbw_bash_guard_verified": true,
+  "commands": ["git status"]
+}
+JSON
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == true'
+  echo "$output" | jq -e '.proof_source == ""'
+  echo "$output" | jq -e '.compatibility != "verified"'
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+}
+
 @test "rtk-manager: validated runtime smoke proof can produce doctor PASS" {
   write_fake_rtk "0.1.0"
   cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
@@ -481,6 +542,7 @@ JSON
   write_valid_smoke_proof
   run rtk_manager doctor-json
   [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == true'
   echo "$output" | jq -e '.compatibility == "verified"'
   echo "$output" | jq -e '.doctor_status == "PASS"'
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -1,0 +1,267 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  export CLAUDE_CONFIG_DIR="$TEST_TEMP_DIR/claude"
+  export VBW_RTK_DIR="$CLAUDE_CONFIG_DIR/vbw"
+  mkdir -p "$CLAUDE_CONFIG_DIR" "$TEST_TEMP_DIR/bin"
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+rtk_manager() {
+  bash "$SCRIPTS_DIR/rtk-manager.sh" "$@"
+}
+
+write_fake_rtk() {
+  local version="${1:-0.1.0}"
+  cat > "$TEST_TEMP_DIR/bin/rtk" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TEST_TEMP_DIR/rtk-calls.log"
+case "\${1:-}" in
+  --version)
+    echo "rtk $version"
+    ;;
+  gain)
+    if [ "\${2:-}" = "--json" ]; then
+      echo '{"average_savings_pct":47,"commands":3}'
+    else
+      echo 'average savings: 47%'
+    fi
+    ;;
+  init)
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+    cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+    ;;
+  *)
+    echo "fake rtk: unsupported \$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/rtk"
+}
+
+write_failing_curl() {
+  cat > "$TEST_TEMP_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$TEST_TEMP_DIR/curl-called.log"
+exit 99
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/curl"
+}
+
+release_target_asset() {
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64|Darwin:aarch64) echo "rtk-aarch64-apple-darwin.tar.gz" ;;
+    Darwin:x86_64) echo "rtk-x86_64-apple-darwin.tar.gz" ;;
+    Linux:arm64|Linux:aarch64) echo "rtk-aarch64-unknown-linux-gnu.tar.gz" ;;
+    *) echo "rtk-x86_64-unknown-linux-musl.tar.gz" ;;
+  esac
+}
+
+sha256_value() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+prepare_release_fixture() {
+  local version="${1:-9.9.9}" mismatch="${2:-false}"
+  local asset checksum
+  asset="$(release_target_asset)"
+  mkdir -p "$TEST_TEMP_DIR/release/payload"
+  cat > "$TEST_TEMP_DIR/release/payload/rtk" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  --version) echo "rtk $version" ;;
+  *) echo "installed fake rtk $version" ;;
+esac
+EOF
+  chmod +x "$TEST_TEMP_DIR/release/payload/rtk"
+  (cd "$TEST_TEMP_DIR/release/payload" && tar -czf "$TEST_TEMP_DIR/release/$asset" rtk)
+  checksum="$(sha256_value "$TEST_TEMP_DIR/release/$asset")"
+  if [ "$mismatch" = "true" ]; then
+    checksum="0000000000000000000000000000000000000000000000000000000000000000"
+  fi
+  printf '%s  %s\n' "$checksum" "$asset" > "$TEST_TEMP_DIR/release/checksums.txt"
+  cat > "$TEST_TEMP_DIR/release/release.json" <<EOF
+{
+  "tag_name": "v$version",
+  "assets": [
+    {"name": "$asset", "browser_download_url": "https://example.invalid/$asset"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"}
+  ]
+}
+EOF
+}
+
+write_release_curl() {
+  cat > "$TEST_TEMP_DIR/bin/curl" <<EOF
+#!/usr/bin/env bash
+out=""
+url=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -o)
+      out="\${2:-}"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="\$1"
+      shift
+      ;;
+  esac
+done
+case "\$url" in
+  *releases/latest)
+    cat "$TEST_TEMP_DIR/release/release.json"
+    ;;
+  *checksums.txt)
+    if [ -n "\$out" ]; then cp "$TEST_TEMP_DIR/release/checksums.txt" "\$out"; else cat "$TEST_TEMP_DIR/release/checksums.txt"; fi
+    ;;
+  *tar.gz)
+    if [ -n "\$out" ]; then cp "$TEST_TEMP_DIR/release/$(release_target_asset)" "\$out"; else cat "$TEST_TEMP_DIR/release/$(release_target_asset)"; fi
+    ;;
+  *)
+    echo "unexpected URL: \$url" >&2
+    exit 9
+    ;;
+esac
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/curl"
+}
+
+@test "rtk-manager: default status is offline and absent when RTK missing" {
+  write_failing_curl
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == false'
+  echo "$output" | jq -e '.compatibility == "absent"'
+  echo "$output" | jq -e '.version_source == "none"'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
+@test "rtk-manager: binary-only status does not call gain by default" {
+  write_fake_rtk "0.1.0"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == true'
+  echo "$output" | jq -e '.rtk_version == "0.1.0"'
+  echo "$output" | jq -e '.compatibility == "binary_only"'
+  ! grep -Fq 'gain --json' "$TEST_TEMP_DIR/rtk-calls.log"
+}
+
+@test "rtk-manager: detects current RTK settings hook and updatedInput risk with VBW hook" {
+  write_fake_rtk "0.1.0"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.global_hook_present == true'
+  echo "$output" | jq -e '.global_hook_command == "rtk hook claude"'
+  echo "$output" | jq -e '.updated_input_risk == true'
+  echo "$output" | jq -e '.compatibility == "risk"'
+}
+
+@test "rtk-manager: malformed settings JSON is reported without breaking status" {
+  write_fake_rtk "0.1.0"
+  printf '{not-json' > "$CLAUDE_CONFIG_DIR/settings.json"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.settings_json_valid == false'
+  echo "$output" | jq -e '.global_hook_present == false'
+  echo "$output" | jq -e '.compatibility == "binary_only"'
+}
+
+@test "rtk-manager: check-updates queries latest release only on explicit flag" {
+  write_fake_rtk "0.1.0"
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager status --json --check-updates
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.latest_version == "9.9.9"'
+  echo "$output" | jq -e '.update_available == true'
+  [ -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
+}
+
+@test "rtk-manager: install dry-run shows preflight and does not mutate" {
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager install --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RTK install preflight"* ]]
+  [[ "$output" == *"Does not do: edit Claude settings"* ]]
+  [[ "$output" == *"pipe downloaded shell scripts into sh"* ]]
+  [ ! -e "$HOME/.local/bin/rtk" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: install without confirmation aborts after preflight" {
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  run rtk_manager install
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires explicit confirmation"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: managed install verifies checksum and writes receipt" {
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 0 ]
+  [ -x "$TEST_TEMP_DIR/install-bin/rtk" ]
+  [ -f "$VBW_RTK_DIR/rtk-install.json" ]
+  jq -e '.manager == "vbw"' "$VBW_RTK_DIR/rtk-install.json"
+  jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
+  jq -e '.verified_checksum != ""' "$VBW_RTK_DIR/rtk-install.json"
+}
+
+@test "rtk-manager: managed install aborts on checksum mismatch" {
+  prepare_release_fixture "9.9.9" "true"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"checksum mismatch"* ]]
+  [ ! -e "$TEST_TEMP_DIR/install-bin/rtk" ]
+}
+
+@test "rtk-manager: init dry-run warns about hook mutation and compatibility" {
+  write_fake_rtk "0.1.0"
+  run rtk_manager init --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RTK hook preflight"* ]]
+  [[ "$output" == *"rtk init -g"* ]]
+  [[ "$output" == *"updatedInput"* ]]
+  [ ! -f "$CLAUDE_CONFIG_DIR/settings.json" ]
+}
+
+@test "rtk-manager: doctor-json skips absent RTK" {
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.doctor_status == "SKIP"'
+  echo "$output" | jq -e '.doctor_detail | test("not installed")'
+}
+
+@test "rtk-manager: stats are explicit and labeled separately in JSON" {
+  write_fake_rtk "0.1.0"
+  run rtk_manager status --json --stats
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.stats.average_savings_pct == 47'
+}

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -356,6 +356,48 @@ JSON
   [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
 }
 
+@test "rtk-manager: doctor-json warns on legacy hook artifact without network" {
+  write_failing_curl
+  mkdir -p "$CLAUDE_CONFIG_DIR/hooks"
+  touch "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.legacy_hook_file_present == true'
+  echo "$output" | jq -e '.global_hook_present == false'
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  echo "$output" | jq -e '.doctor_detail | test("legacy hook file")'
+  ! echo "$output" | jq -e '.doctor_detail | test("not installed; optional")'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
+@test "rtk-manager: doctor-json warns on global RTK docs artifacts without network" {
+  write_failing_curl
+  echo "RTK docs" > "$CLAUDE_CONFIG_DIR/RTK.md"
+  echo "@RTK.md" > "$CLAUDE_CONFIG_DIR/CLAUDE.md"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.global_rtk_md_present == true'
+  echo "$output" | jq -e '.global_claude_ref_present == true'
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  echo "$output" | jq -e '.doctor_detail | test("global RTK.md")'
+  echo "$output" | jq -e '.doctor_detail | test("CLAUDE.md @RTK.md reference")'
+  ! echo "$output" | jq -e '.doctor_detail | test("not installed; optional")'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
+@test "rtk-manager: doctor-json warns on project RTK artifact without network" {
+  write_failing_curl
+  mkdir -p "$TEST_TEMP_DIR/project/.rtk"
+  touch "$TEST_TEMP_DIR/project/.rtk/filters.toml"
+  cd "$TEST_TEMP_DIR/project"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.project_local_present == true'
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  echo "$output" | jq -e '.doctor_detail | test("project .rtk files")'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
 @test "rtk-manager: arbitrary valid proof JSON does not verify compatibility" {
   write_fake_rtk "0.1.0"
   cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -302,8 +302,18 @@ JSON
   [ "$status" -eq 0 ]
   [[ "$output" == *"RTK hook preflight"* ]]
   [[ "$output" == *"rtk init -g"* ]]
+  [[ "$output" != *"--auto-patch"* ]]
+  [[ "$output" != *"--hook-only"* ]]
   [[ "$output" == *"updatedInput"* ]]
   [ ! -f "$CLAUDE_CONFIG_DIR/settings.json" ]
+}
+
+@test "rtk-manager: init dry-run shows requested optional flags only" {
+  write_fake_rtk "0.1.0"
+  run rtk_manager init --dry-run --auto-patch --hook-only
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--auto-patch"* ]]
+  [[ "$output" == *"--hook-only"* ]]
 }
 
 @test "rtk-manager: doctor-json skips absent RTK" {
@@ -391,6 +401,22 @@ JSON
   [ ! -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
 }
 
+@test "rtk-manager: off-PATH managed receipt is not hook-activation-ready" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == false'
+  echo "$output" | jq -e '.managed_by_vbw == true'
+  echo "$output" | jq -e '.binary_install_state == "installed_not_on_path"'
+  echo "$output" | jq -e '.compatibility == "absent"'
+  echo "$output" | jq -e '.next_action == "path"'
+  run rtk_manager init --dry-run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not on PATH"* ]]
+  [[ "$output" == *"$(dirname "$binary")"* ]]
+}
+
 @test "rtk-manager: external no-receipt update does not take ownership" {
   write_fake_rtk "0.1.0"
   prepare_release_fixture "9.9.9"
@@ -430,19 +456,67 @@ JSON
 @test "rtk-manager: uninstall deactivates hook before removing managed binary" {
   local binary
   binary="$(create_managed_rtk "0.1.0")"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
   run rtk_manager uninstall --yes --deactivate-hook
   [ "$status" -eq 0 ]
   grep -Fq 'init -g --uninstall' "$TEST_TEMP_DIR/rtk-calls.log"
   grep -Fq 'uninstall_binary_exists=yes' "$TEST_TEMP_DIR/rtk-calls.log"
   [ ! -e "$binary" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
 }
 
 @test "rtk-manager: failed hook deactivation preserves managed binary" {
   local binary
   binary="$(create_managed_rtk "0.1.0")"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
   export FAKE_RTK_UNINSTALL_FAIL=true
   run rtk_manager uninstall --yes --deactivate-hook
   [ "$status" -eq 1 ]
   [ -e "$binary" ]
   [ -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: hook-active managed uninstall requires deactivate flag" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}]}}
+JSON
+  run rtk_manager uninstall --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hook deactivation required before binary removal"* ]]
+  run rtk_manager uninstall --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"pass --deactivate-hook"* ]]
+  [ -e "$binary" ]
+  [ -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: uninstall preflight text has no boolean suffix" {
+  create_managed_rtk "0.1.0" >/dev/null
+  run rtk_manager uninstall --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no hook deactivation requested"* ]]
+  [[ "$output" != *"before binary removalfalse"* ]]
+  run rtk_manager uninstall --dry-run --deactivate-hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rtk init -g --uninstall before binary removal"* ]]
+  [[ "$output" != *"false"* ]]
+}
+
+@test "rtk-manager: managed uninstall retires receipt and clears managed status" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0")"
+  run rtk_manager uninstall --yes
+  [ "$status" -eq 0 ]
+  [ ! -e "$binary" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.managed_by_vbw == false'
+  echo "$output" | jq -e '.install_receipt == ""'
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -122,7 +122,7 @@ EOF
 }
 
 create_managed_rtk() {
-  local version="${1:-0.1.0}" dir="$TEST_TEMP_DIR/managed-bin" binary
+  local version="${1:-0.1.0}" dir="${2:-$TEST_TEMP_DIR/managed-bin}" binary
   mkdir -p "$dir" "$VBW_RTK_DIR"
   binary="$dir/rtk"
   cat > "$binary" <<EOF
@@ -243,6 +243,29 @@ EOF
   echo "$output" | jq -e '.rtk_present == true'
   echo "$output" | jq -e --arg path "$spaced_bin/rtk" '.rtk_path == $path'
   echo "$output" | jq -e '.rtk_version == "1.2.3"'
+}
+
+@test "rtk-manager: stats work when PATH contains spaces" {
+  local spaced_bin="$TEST_TEMP_DIR/bin with space"
+  mkdir -p "$spaced_bin"
+  cat > "$spaced_bin/rtk" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "rtk 1.2.3" ;;
+  gain)
+    if [ "${2:-}" = "--json" ]; then
+      echo '{"average_savings_pct":88}'
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$spaced_bin/rtk"
+  export PATH="$spaced_bin:$PATH"
+  run rtk_manager status --json --stats
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg path "$spaced_bin/rtk" '.rtk_path == $path'
+  echo "$output" | jq -e '.stats.average_savings_pct == 88'
 }
 
 @test "rtk-manager: detects current RTK settings hook and updatedInput risk with VBW hook" {
@@ -496,6 +519,35 @@ JSON
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.global_hook_present == true'
   echo "$output" | jq -e '.global_hook_command | test("rtk-rewrite")'
+}
+
+@test "rtk-manager: quoted absolute hook command in settings JSON is active" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0" "$TEST_TEMP_DIR/managed bin with space")"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<JSON
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"\"$binary\" hook claude"}]}]}}
+JSON
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.settings_json_valid == true'
+  echo "$output" | jq -e '.global_hook_present == true'
+  echo "$output" | jq -e '.settings_hook_state == "active"'
+  echo "$output" | jq -e --arg command "\"$binary\" hook claude" '.global_hook_command == $command'
+  echo "$output" | jq -e '.global_hook_matcher == "Bash"'
+  echo "$output" | jq -e '.compatibility != "binary_only"'
+}
+
+@test "rtk-manager: quoted absolute hook blocks managed uninstall without deactivate" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0" "$TEST_TEMP_DIR/managed bin with space")"
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<JSON
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"\"$binary\" hook claude"}]}]}}
+JSON
+  run rtk_manager uninstall --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"pass --deactivate-hook"* ]]
+  [ -e "$binary" ]
+  [ -f "$VBW_RTK_DIR/rtk-install.json" ]
 }
 
 @test "rtk-manager: managed update dry-run does not cache latest release" {

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -157,16 +157,16 @@ create_rewritten_tar() {
   case "$mode" in
     gnu)
       if [[ "$target_name" = /* ]]; then
-        tar -P -czf "$archive" -C "$payload_dir" rtk --transform "s|^${source_name}$|${target_name}|" "$source_name"
+        tar -P -czf "$archive" -C "$payload_dir" --transform "s|^${source_name}$|${target_name}|" rtk "$source_name"
       else
-        tar -czf "$archive" -C "$payload_dir" rtk --transform "s|^${source_name}$|${target_name}|" "$source_name"
+        tar -czf "$archive" -C "$payload_dir" --transform "s|^${source_name}$|${target_name}|" rtk "$source_name"
       fi
       ;;
     bsd)
       if [[ "$target_name" = /* ]]; then
-        tar -P -czf "$archive" -C "$payload_dir" rtk -s "|^${source_name}$|${target_name}|" "$source_name"
+        tar -P -czf "$archive" -C "$payload_dir" -s "|^${source_name}$|${target_name}|" rtk "$source_name"
       else
-        tar -czf "$archive" -C "$payload_dir" rtk -s "|^${source_name}$|${target_name}|" "$source_name"
+        tar -czf "$archive" -C "$payload_dir" -s "|^${source_name}$|${target_name}|" rtk "$source_name"
       fi
       ;;
     *)

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -7,7 +7,21 @@ setup() {
   export CLAUDE_CONFIG_DIR="$TEST_TEMP_DIR/claude"
   export VBW_RTK_DIR="$CLAUDE_CONFIG_DIR/vbw"
   mkdir -p "$CLAUDE_CONFIG_DIR" "$TEST_TEMP_DIR/bin"
-  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  if command -v jq >/dev/null 2>&1; then
+    ln -sf "$(command -v jq)" "$TEST_TEMP_DIR/bin/jq"
+  fi
+  local clean_path="" path_dir
+  IFS=: read -r -a _rtk_path_parts <<< "$PATH"
+  for path_dir in "${_rtk_path_parts[@]}"; do
+    [ -n "$path_dir" ] || continue
+    [ -x "$path_dir/rtk" ] && continue
+    if [ -z "$clean_path" ]; then
+      clean_path="$path_dir"
+    else
+      clean_path="$clean_path:$path_dir"
+    fi
+  done
+  export PATH="$TEST_TEMP_DIR/bin:$clean_path"
 }
 
 teardown() {
@@ -505,6 +519,28 @@ JSON
   [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
 }
 
+@test "rtk-manager: stale proof does not verify missing quoted hook binary using unrelated PATH RTK" {
+  write_failing_curl
+  write_fake_rtk "0.1.0"
+  local missing_binary="$TEST_TEMP_DIR/missing bin/rtk"
+  local quoted_command="\"$missing_binary\" hook claude"
+  jq -n --arg command "$quoted_command" '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:$command}]}]}}' > "$CLAUDE_CONFIG_DIR/settings.json"
+  mkdir -p "$VBW_RTK_DIR"
+  jq -n --arg command "$quoted_command" '{proof_type:"runtime_smoke",status:"pass",timestamp:"2026-04-27T00:00:00Z",rtk_version:"0.1.0",hook_command:$command,updated_input_verified:true,rtk_rewrite_observed:true,vbw_bash_guard_verified:true,commands:["git status"]}' > "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == true'
+  echo "$output" | jq -e '.global_hook_present == true'
+  echo "$output" | jq -e --arg command "$quoted_command" '.global_hook_command == $command'
+  echo "$output" | jq -e '.active_hook_rtk_path == ""'
+  echo "$output" | jq -e '.proof_source == ""'
+  echo "$output" | jq -e '.compatibility != "verified"'
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.doctor_status == "WARN"'
+  [ ! -f "$TEST_TEMP_DIR/curl-called.log" ]
+}
+
 @test "rtk-manager: proof version must match current RTK version" {
   write_fake_rtk "0.1.0"
   cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
@@ -543,6 +579,21 @@ JSON
   run rtk_manager doctor-json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.rtk_present == true'
+  echo "$output" | jq -e '.compatibility == "verified"'
+  echo "$output" | jq -e '.doctor_status == "PASS"'
+}
+
+@test "rtk-manager: validated quoted absolute hook proof can produce doctor PASS" {
+  local binary
+  binary="$(create_managed_rtk "0.1.0" "$TEST_TEMP_DIR/managed bin with space")"
+  local quoted_command="\"$binary\" hook claude"
+  jq -n --arg command "$quoted_command" '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:$command}]}]}}' > "$CLAUDE_CONFIG_DIR/settings.json"
+  mkdir -p "$VBW_RTK_DIR"
+  jq -n --arg command "$quoted_command" '{proof_type:"runtime_smoke",status:"pass",timestamp:"2026-04-27T00:00:00Z",rtk_version:"0.1.0",hook_command:$command,updated_input_verified:true,rtk_rewrite_observed:true,vbw_bash_guard_verified:true,commands:["git status"]}' > "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  run rtk_manager doctor-json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg path "$binary" '.active_hook_rtk_path == $path'
+  echo "$output" | jq -e '.active_hook_rtk_version == "0.1.0"'
   echo "$output" | jq -e '.compatibility == "verified"'
   echo "$output" | jq -e '.doctor_status == "PASS"'
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -184,12 +184,16 @@ JSON
 write_release_curl() {
   cat > "$TEST_TEMP_DIR/bin/curl" <<EOF
 #!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TEST_TEMP_DIR/curl-calls.log"
 out=""
 url=""
 while [ "\$#" -gt 0 ]; do
   case "\$1" in
     -o)
       out="\${2:-}"
+      shift 2
+      ;;
+    --max-time|--retry|--retry-delay)
       shift 2
       ;;
     -*)
@@ -312,11 +316,13 @@ JSON
   write_fake_rtk "0.1.0"
   prepare_release_fixture "9.9.9"
   write_release_curl
+  export RTK_CURL_MAX_TIME=7
   run rtk_manager status --json --check-updates
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.latest_version == "9.9.9"'
   echo "$output" | jq -e '.update_available == true'
   [ -f "$VBW_RTK_DIR/rtk-latest-release.json" ]
+  grep -Fq -- '--max-time 7' "$TEST_TEMP_DIR/curl-calls.log"
 }
 
 @test "rtk-manager: install dry-run shows preflight and does not mutate" {
@@ -345,6 +351,7 @@ JSON
 @test "rtk-manager: managed install verifies checksum and writes receipt" {
   prepare_release_fixture "9.9.9"
   write_release_curl
+  export RTK_CURL_MAX_TIME=7
   export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
   run rtk_manager install --yes
   [ "$status" -eq 0 ]
@@ -353,6 +360,7 @@ JSON
   jq -e '.manager == "vbw"' "$VBW_RTK_DIR/rtk-install.json"
   jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
   jq -e '.verified_checksum != ""' "$VBW_RTK_DIR/rtk-install.json"
+  [ "$(grep -c -- '--max-time 7' "$TEST_TEMP_DIR/curl-calls.log")" -ge 3 ]
 }
 
 @test "rtk-manager: managed install records version when install dir has spaces" {
@@ -707,12 +715,14 @@ JSON
   binary="$(create_managed_rtk "0.1.0")"
   prepare_release_fixture "9.9.9"
   write_release_curl
+  export RTK_CURL_MAX_TIME=7
   run rtk_manager update --yes
   [ "$status" -eq 0 ]
   [ -x "$binary" ]
   "$binary" --version | grep -Fq "9.9.9"
   jq -e '.previous_version == "0.1.0"' "$VBW_RTK_DIR/rtk-install.json"
   jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
+  [ "$(grep -c -- '--max-time 7' "$TEST_TEMP_DIR/curl-calls.log")" -ge 3 ]
 }
 
 @test "rtk-manager: missing checksum aborts unless explicitly allowed" {

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -291,6 +291,8 @@ JSON
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.global_hook_present == true'
   echo "$output" | jq -e '.global_hook_command == "rtk hook claude"'
+  echo "$output" | jq -e '.multiple_bash_pretooluse_hooks_detected == true'
+  echo "$output" | jq -e --arg typo_key "multiple_bash_pre""tookuse_hooks_detected" 'has($typo_key) | not'
   echo "$output" | jq -e '.updated_input_risk == true'
   echo "$output" | jq -e '.compatibility == "risk"'
 }

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -38,6 +38,11 @@ case "\${1:-}" in
     if [ "\${2:-}" = "-g" ] && [ "\${3:-}" = "--uninstall" ]; then
       if [ -e "\$0" ]; then echo "uninstall_binary_exists=yes" >> "$TEST_TEMP_DIR/rtk-calls.log"; fi
       if [ "\${FAKE_RTK_UNINSTALL_FAIL:-false}" = "true" ]; then exit 44; fi
+      if [ "\${FAKE_RTK_MUTATE_CONFIG_ON_UNINSTALL:-false}" = "true" ]; then
+        echo mutated > "$CLAUDE_CONFIG_DIR/settings.json"
+        echo mutated > "$CLAUDE_CONFIG_DIR/CLAUDE.md"
+        echo mutated > "$CLAUDE_CONFIG_DIR/RTK.md"
+      fi
       rm -f "$CLAUDE_CONFIG_DIR/settings.json"
       exit 0
     fi
@@ -129,6 +134,11 @@ case "\${1:-}" in
     if [ "\${2:-}" = "-g" ] && [ "\${3:-}" = "--uninstall" ]; then
       if [ -e "\$0" ]; then echo "uninstall_binary_exists=yes" >> "$TEST_TEMP_DIR/rtk-calls.log"; fi
       if [ "\${FAKE_RTK_UNINSTALL_FAIL:-false}" = "true" ]; then exit 44; fi
+      if [ "\${FAKE_RTK_MUTATE_CONFIG_ON_UNINSTALL:-false}" = "true" ]; then
+        echo mutated > "$CLAUDE_CONFIG_DIR/settings.json"
+        echo mutated > "$CLAUDE_CONFIG_DIR/CLAUDE.md"
+        echo mutated > "$CLAUDE_CONFIG_DIR/RTK.md"
+      fi
       exit 0
     fi
     ;;
@@ -216,6 +226,25 @@ EOF
   ! grep -Fq 'gain --json' "$TEST_TEMP_DIR/rtk-calls.log"
 }
 
+@test "rtk-manager: status detects RTK version when PATH contains spaces" {
+  local spaced_bin="$TEST_TEMP_DIR/bin with space"
+  mkdir -p "$spaced_bin"
+  cat > "$spaced_bin/rtk" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "rtk 1.2.3" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$spaced_bin/rtk"
+  export PATH="$spaced_bin:$PATH"
+  run rtk_manager status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.rtk_present == true'
+  echo "$output" | jq -e --arg path "$spaced_bin/rtk" '.rtk_path == $path'
+  echo "$output" | jq -e '.rtk_version == "1.2.3"'
+}
+
 @test "rtk-manager: detects current RTK settings hook and updatedInput risk with VBW hook" {
   write_fake_rtk "0.1.0"
   cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'JSON'
@@ -285,6 +314,16 @@ JSON
   jq -e '.manager == "vbw"' "$VBW_RTK_DIR/rtk-install.json"
   jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
   jq -e '.verified_checksum != ""' "$VBW_RTK_DIR/rtk-install.json"
+}
+
+@test "rtk-manager: managed install records version when install dir has spaces" {
+  prepare_release_fixture "9.9.9"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install bin with space"
+  run rtk_manager install --yes
+  [ "$status" -eq 0 ]
+  [ -x "$RTK_INSTALL_DIR/rtk" ]
+  jq -e '.installed_version == "9.9.9"' "$VBW_RTK_DIR/rtk-install.json"
 }
 
 @test "rtk-manager: managed install aborts on checksum mismatch" {
@@ -533,6 +572,25 @@ JSON
   grep -Fq 'uninstall_binary_exists=yes' "$TEST_TEMP_DIR/rtk-calls.log"
   [ ! -e "$binary" ]
   [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+}
+
+@test "rtk-manager: uninstall deactivation backs up Claude config before mutation" {
+  create_managed_rtk "0.1.0" >/dev/null
+  cat > "$CLAUDE_CONFIG_DIR/settings.json" <<'EOF'
+original settings
+EOF
+  cat > "$CLAUDE_CONFIG_DIR/CLAUDE.md" <<'EOF'
+original claude
+EOF
+  cat > "$CLAUDE_CONFIG_DIR/RTK.md" <<'EOF'
+original rtk
+EOF
+  export FAKE_RTK_MUTATE_CONFIG_ON_UNINSTALL=true
+  run rtk_manager uninstall --yes --deactivate-hook
+  [ "$status" -eq 0 ]
+  grep -R "original settings" "$VBW_RTK_DIR/backups"
+  grep -R "original claude" "$VBW_RTK_DIR/backups"
+  grep -R "original rtk" "$VBW_RTK_DIR/backups"
 }
 
 @test "rtk-manager: failed hook deactivation preserves managed binary" {

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -135,6 +135,102 @@ EOF
 EOF
 }
 
+tar_supports_rewrite() {
+  local probe_dir
+  if tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+    echo "gnu"
+  else
+    probe_dir="$(mktemp -d)"
+    echo x > "$probe_dir/x"
+    if tar -czf "$probe_dir/out.tar.gz" -C "$probe_dir" -s '|^x$|y|' x >/dev/null 2>&1; then
+      rm -rf "$probe_dir"
+      echo "bsd"
+      return 0
+    fi
+    rm -rf "$probe_dir"
+    echo ""
+  fi
+}
+
+create_rewritten_tar() {
+  local archive="$1" payload_dir="$2" source_name="$3" target_name="$4" mode="$5"
+  case "$mode" in
+    gnu)
+      if [[ "$target_name" = /* ]]; then
+        tar -P -czf "$archive" -C "$payload_dir" rtk --transform "s|^${source_name}$|${target_name}|" "$source_name"
+      else
+        tar -czf "$archive" -C "$payload_dir" rtk --transform "s|^${source_name}$|${target_name}|" "$source_name"
+      fi
+      ;;
+    bsd)
+      if [[ "$target_name" = /* ]]; then
+        tar -P -czf "$archive" -C "$payload_dir" rtk -s "|^${source_name}$|${target_name}|" "$source_name"
+      else
+        tar -czf "$archive" -C "$payload_dir" rtk -s "|^${source_name}$|${target_name}|" "$source_name"
+      fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+prepare_malicious_release_fixture() {
+  local unsafe_member="$1" version="${2:-9.9.9}" mode asset checksum
+  mode="$(tar_supports_rewrite)"
+  [ -n "$mode" ] || return 1
+  asset="$(release_target_asset)"
+  mkdir -p "$TEST_TEMP_DIR/release/payload"
+  cat > "$TEST_TEMP_DIR/release/payload/rtk" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  --version) echo "rtk $version" ;;
+  *) echo "installed fake rtk $version" ;;
+esac
+EOF
+  chmod +x "$TEST_TEMP_DIR/release/payload/rtk"
+  echo "evil" > "$TEST_TEMP_DIR/release/payload/evil"
+  create_rewritten_tar "$TEST_TEMP_DIR/release/$asset" "$TEST_TEMP_DIR/release/payload" evil "$unsafe_member" "$mode" || return 1
+  checksum="$(sha256_value "$TEST_TEMP_DIR/release/$asset")"
+  printf '%s  %s\n' "$checksum" "$asset" > "$TEST_TEMP_DIR/release/checksums.txt"
+  cat > "$TEST_TEMP_DIR/release/release.json" <<EOF
+{
+  "tag_name": "v$version",
+  "assets": [
+    {"name": "$asset", "browser_download_url": "https://example.invalid/$asset"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"}
+  ]
+}
+EOF
+}
+
+prepare_ambiguous_rtk_release_fixture() {
+  local version="${1:-9.9.9}" asset checksum
+  asset="$(release_target_asset)"
+  mkdir -p "$TEST_TEMP_DIR/release/payload/nested"
+  cat > "$TEST_TEMP_DIR/release/payload/rtk" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  --version) echo "rtk $version" ;;
+  *) echo "installed fake rtk $version" ;;
+esac
+EOF
+  cp "$TEST_TEMP_DIR/release/payload/rtk" "$TEST_TEMP_DIR/release/payload/nested/rtk"
+  chmod +x "$TEST_TEMP_DIR/release/payload/rtk" "$TEST_TEMP_DIR/release/payload/nested/rtk"
+  (cd "$TEST_TEMP_DIR/release/payload" && tar -czf "$TEST_TEMP_DIR/release/$asset" rtk nested/rtk)
+  checksum="$(sha256_value "$TEST_TEMP_DIR/release/$asset")"
+  printf '%s  %s\n' "$checksum" "$asset" > "$TEST_TEMP_DIR/release/checksums.txt"
+  cat > "$TEST_TEMP_DIR/release/release.json" <<EOF
+{
+  "tag_name": "v$version",
+  "assets": [
+    {"name": "$asset", "browser_download_url": "https://example.invalid/$asset"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/checksums.txt"}
+  ]
+}
+EOF
+}
+
 create_managed_rtk() {
   local version="${1:-0.1.0}" dir="${2:-$TEST_TEMP_DIR/managed-bin}" binary
   mkdir -p "$dir" "$VBW_RTK_DIR"
@@ -381,6 +477,41 @@ JSON
   [ "$status" -eq 1 ]
   [[ "$output" == *"checksum mismatch"* ]]
   [ ! -e "$TEST_TEMP_DIR/install-bin/rtk" ]
+}
+
+@test "rtk-manager: managed install rejects archive traversal member" {
+  prepare_malicious_release_fixture "../outside-marker" || skip "tar rewrite support unavailable"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsafe RTK archive member path"* ]]
+  [ ! -e "$TEST_TEMP_DIR/install-bin/rtk" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  [ ! -e "$TEST_TEMP_DIR/outside-marker" ]
+}
+
+@test "rtk-manager: managed install rejects archive absolute member" {
+  prepare_malicious_release_fixture "$TEST_TEMP_DIR/outside-marker" || skip "tar rewrite support unavailable"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsafe RTK archive member path"* ]]
+  [ ! -e "$TEST_TEMP_DIR/install-bin/rtk" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
+  [ ! -e "$TEST_TEMP_DIR/outside-marker" ]
+}
+
+@test "rtk-manager: managed install rejects ambiguous rtk members" {
+  prepare_ambiguous_rtk_release_fixture "9.9.9"
+  write_release_curl
+  export RTK_INSTALL_DIR="$TEST_TEMP_DIR/install-bin"
+  run rtk_manager install --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"multiple rtk binaries"* ]]
+  [ ! -e "$TEST_TEMP_DIR/install-bin/rtk" ]
+  [ ! -f "$VBW_RTK_DIR/rtk-install.json" ]
 }
 
 @test "rtk-manager: init dry-run warns about hook mutation and compatibility" {


### PR DESCRIPTION
## Linked Issue

Fixes #216

Supersedes the approach in #217 with a maintainer-owned implementation rather than merging that PR as-is.

## What

Adds explicit, opt-in RTK management through `/vbw:rtk` and a deterministic `scripts/rtk-manager.sh` helper. The implementation keeps RTK install/update, hook activation, verification, and uninstall as user-invoked actions, adds RTK doctor/status surfacing without recurring SessionStart context, and adds BATS/contract coverage for consent, checksum, ownership, compatibility-proof, no-network, no-implicit-setup, bounded network calls, and safe archive extraction invariants.

## Why

The root issue was a missing ownership/consent boundary for RTK integration. RTK can reduce tool-output tokens, but installing binaries and mutating Claude Code global hook settings are user-global operations. The chosen architecture makes VBW capable of managing RTK only through an explicit `/vbw:rtk` command, with deterministic shell-owned facts and safety gates, rather than embedding installer behavior in normal VBW startup/status/doctor paths.

## How

- `commands/rtk.md`: adds the explicit `/vbw:rtk` command with state-driven status/install/init/verify/update/uninstall flows and separate confirmations for binary install/update vs hook activation.
- `scripts/rtk-manager.sh`: adds offline default status, latest-release install/update with checksum verification, bounded `curl`, safe tar extraction, settings.json-first hook detection, proof-gated compatibility, ownership-aware update/uninstall, receipt/backup handling, and explicit stats only.
- `commands/doctor.md`: adds check 18 using plugin-root-resolved `rtk-manager.sh doctor-json`, with SKIP/WARN/PASS driven by helper JSON.
- `commands/status.md`: documents RTK metrics as explicit `--metrics` external-only output, not default status noise.
- `README.md`: documents `/vbw:rtk`, separate binary vs hook activation, checksum verification, global config caveats, `updatedInput` risk, and external RTK metrics.
- `AGENTS.md` and `docs/vbw-vs-paul-analysis.md`: remove brittle command-count prose made stale by adding `/vbw:rtk`.
- `scripts/verify-vibe.sh`: updates tracked command count from 25 to 26.
- `testing/list-contract-tests.sh`, `testing/verify-plugin-root-resolution.sh`, `testing/verify-rtk-integration-contract.sh`: register and enforce RTK integration contracts, including plugin-root resolution for `rtk.md` and `doctor.md`.
- `tests/rtk-manager.bats`: adds behavior coverage for RTK states, checksum handling, proof validation, ownership-aware update/uninstall, no-network defaults, quoted paths, config backups, bounded network calls, safe archive extraction, and test PATH isolation.

## Acceptance criteria verification

1. `commands/rtk.md` exists with valid VBW command frontmatter (`name: vbw:rtk`) and supports explicit `status`, `install`, `init`, `verify`, `update`, and `uninstall` flows through deterministic helper output.  
   Satisfied by `commands/rtk.md`; contract-tested by `testing/verify-commands-contract.sh` and `testing/verify-rtk-integration-contract.sh`.
2. No RTK install, update, hook activation, network latest-release check, or recurring RTK prompt is invoked from plugin load, SessionStart, `/vbw:init`, `/vbw:vibe`, default `/vbw:status`, or `/vbw:doctor`.  
   Satisfied by keeping mutating flows inside `/vbw:rtk`; enforced by `testing/verify-rtk-integration-contract.sh` and no RTK references in `scripts/session-start.sh`.
3. `scripts/rtk-manager.sh status --json` is read-only and does not call RTK gain/stat commands or the network by default; `status --json --check-updates`, install, and update are the only flows allowed to query GitHub latest-release metadata.  
   Satisfied in `scripts/rtk-manager.sh`; covered by `tests/rtk-manager.bats` no-network/no-gain tests.
4. RTK hook detection treats `${CLAUDE_DIR}/settings.json` as the source of truth and also reports current/legacy RTK artifacts such as `rtk hook claude`, `rtk-rewrite.sh`, `${CLAUDE_DIR}/RTK.md`, and `@RTK.md` references.  
   Satisfied by settings JSON hook parsing plus artifact fields; covered by BATS and RTK contract tests, including quoted absolute hook command cases.
5. VBW-managed install/update defaults to latest `rtk-ai/rtk` GitHub release assets, verifies `checksums.txt` when available, never uses `sudo`, never edits shell profiles, never silently changes `PATH`, and never uses `curl | sh` in managed code.  
   Satisfied by release metadata/download/checksum flow, preflight text, bounded `curl`, and safe tar extraction; enforced by contract tests.
6. Binary install/update and `rtk init -g` hook activation are separate mutating actions, each with preflight output and explicit confirmation/dry-run behavior; non-interactive mutation aborts unless a deliberate automation flag is provided.  
   Satisfied by separate install/update/init helper paths and `ensure_confirmation`; covered by BATS dry-run/confirmation tests.
7. VBW writes RTK install receipts and relevant local backups under the resolved Claude config root and uses those receipts for ownership-aware update/uninstall behavior.  
   Satisfied by receipt/backup helpers; covered by update/uninstall/backup BATS tests.
8. `/vbw:doctor` reports RTK as check 18 using helper JSON only: `SKIP` when absent, `WARN` when binary-only/hook-active-unverified/risky/outdated, and `PASS` only when compatibility has a concrete proof source.  
   Satisfied by `commands/doctor.md` check 18 and `doctor_json`; covered by BATS proof/artifact/no-network cases.
9. Default `/vbw:status` does not advertise or nag about RTK when absent; any RTK savings shown in explicit metrics/detail mode are labeled external to RTK, not VBW savings.  
   Satisfied by `commands/status.md` explicit `--metrics` guidance.
10. README and command/help surfaces document `/vbw:rtk` concisely, including separate binary install vs hook activation, checksum verification, no silent global config mutation, and the PreToolUse `updatedInput` compatibility caveat.  
   Satisfied by `README.md`, `commands/rtk.md`, and dynamic help frontmatter.
11. BATS tests cover the RTK manager's absent/binary-only/hook-active states, malformed settings JSON, dry-run no-mutation behavior, checksum pass/fail/missing behavior, update/version logic, ownership-aware uninstall/update behavior, and no-network default status/doctor-json paths.  
   Satisfied by `tests/rtk-manager.bats` (48 RTK tests at latest run).
12. Contract tests verify no implicit RTK setup paths, no `curl | sh`, helper JSON consumption by doctor/status, no default `/vbw:status` RTK noise, doctor count update to 18, plugin-root resolution for `rtk.md`, and no RTK SessionStart context.  
   Satisfied by `testing/verify-rtk-integration-contract.sh`, `testing/verify-plugin-root-resolution.sh`, and the full suite.

## Testing

- Latest local full suite from `/Users/dpearson/repos/vibe-better-with-claude-code-vbw-worktrees/feat-216-rtk-managed-install`:
  - `bash testing/run-all.sh`
  - Result: lint `1/1`, contracts `48/48`, BATS `3172/3172`.
- Latest remote CI on head `28186dd73b319d91dc9466efcf90d87a3a5216c1`:
  - `CI_GREEN` — all 18 checks passed.
- Targeted checks repeatedly run during remediation:
  - `bats tests/rtk-manager.bats`
  - `bash testing/verify-rtk-integration-contract.sh`
  - `bash testing/verify-plugin-root-resolution.sh`
  - `bash testing/verify-commands-contract.sh`
  - `bash testing/verify-bash-scripts-contract.sh`
  - `bash testing/verify-pipefail-safety.sh`
  - `bash testing/run-lint.sh`

## QA summary

- Primary QA rounds completed: 9
  - Rounds 1–8 found legitimate contract/regression issues and were fixed in separate commits.
  - Round 9 returned CLEAN.
  - Total primary QA findings fixed: 22 (5 high, 15 medium, 2 low).
- Cross-model QA: skipped — GPT-class Copilot session; workflow gate says GPT-class sessions skip Phase 3.5 because no different, more capable cross-model target is available.
- Copilot PR review rounds completed: 6
  - Round 1: fixed misspelled `multiple_bash_pretooluse_hooks_detected` JSON field.
  - Round 2: bounded RTK-managed `curl` calls with `--max-time`.
  - Round 3: added tar member validation and safe single-member extraction.
  - Round 4: fixed tar fixture portability and contract failure newline formatting.
  - Round 5: removed empty PATH segment from RTK BATS setup.
  - Round 6: clean `COMMENTED` review with zero inline comments.
  - Total Copilot findings fixed: 6.
- False positives: none recorded.

## Commit evidence

- `931313c8` — initial RTK integration
- `517a058b` — QA round 1 fixes
- `e72aca98` — QA round 2 fixes
- `e2ad2284` — QA round 3 fixes
- `8be4e4d2` — QA round 4 fixes
- `1d626e49` — QA round 5 fixes
- `a4f100d3` — QA round 6 fixes
- `5f30ffd1` — QA round 7 fixes
- `a966f554` — QA round 8 fixes
- `4b526ec3` — clean QA round 9 evidence commit
- `bda33aaa` — Copilot review round 1 fix
- `2307739f` — Copilot review round 2 fix
- `8dbb5207` — Copilot review round 3 fix
- `5fb4186a` — Copilot review round 4 fix
- `28186dd7` — Copilot review round 5 fix

## Notes

- No version files were changed.
- No new Node/Python/Ruby tooling or package dependencies were introduced.
- RTK compatibility remains unverified/WARN unless a concrete runtime smoke proof validates the exact active hook runtime.
