### PR TITLE
Align init and discussion prompts with shared interaction contract

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -12,6 +12,14 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Agent, LSP
 <!-- Full init flow: Steps 0-4 handle environment/scaffold/hooks/mapping/summary -->
 <!-- Steps 5-8 handle auto-bootstrap: detect scenario, run inference (brownfield/GSD), confirm with user, generate project files -->
 
+## Shared interaction contract
+
+@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md
+
+## Init interaction boundary
+
+Use structured AskUserQuestion for bounded bootstrap/config/setup choices. Use intentional freeform/no-options input for project names, requirements, phases, field corrections, and other high-cardinality user-authored content. If `Other` or `Let me explain...` signals freeform intent, follow the shared contract: ask plain text, wait for the response, process it, then resume structured prompts only if another bounded decision remains.
+
 ## Context
 
 Working directory:
@@ -57,7 +65,7 @@ Skills:
 
 ### Step 0: Environment setup (settings.json)
 
-**CRITICAL: Complete ENTIRE step (including writing settings.json) BEFORE Step 1. Use AskUserQuestion for prompts. Wait for answers. Write settings.json. Only then proceed.**
+**Required order:** Complete Step 0, including writing `settings.json`, before Step 1. Ask any bounded environment/setup questions, wait for answers, write `settings.json`, then proceed so configuration is stable before scaffold files are created.
 
 **Resolve config directory:** Try in order: env var `CLAUDE_CONFIG_DIR` (if set, even if directory does not yet exist), `~/.config/claude-code` (if exists), otherwise `~/.claude`. Store result as `CLAUDE_DIR`. Use it for all config paths in this command.
 
@@ -265,7 +273,7 @@ If greenfield: write `{"conventions": []}`. Display: `○ Conventions — none y
 
 **3c. Parallel registry search** (if find-skills available): run `npx skills find "<stack-item>"` for ALL detected_stack items **in parallel** (multiple concurrent Bash calls). Deduplicate against installed skills. If detected_stack empty, search by project type. Display results with `(registry)` tag.
 
-**3d. Unified skill prompt:** Combine curated (from 2b) + registry (from 3c) results into single AskUserQuestion multiSelect. Tag `(curated)` or `(registry)`. Max 4 options + "Skip". Install selected: `npx skills add <skill> -g -y`.
+**3d. Unified skill prompt:** Combine curated (from 2b) + registry (from 3c) results into single AskUserQuestion multiSelect. Tag `(curated)` or `(registry)`. Use max 4 visible choices total, including `Skip`; if more than 3 skills are candidates, show the top 3 plus `Skip` and point broader discovery to `/vbw:skills`. Install selected: `npx skills add <skill> -g -y`.
 
 ### Step 3.5: Generate bootstrap CLAUDE.md
 
@@ -379,7 +387,7 @@ Options:
 
 **6e. Correction flow** (when user picks "Close, but needs adjustments"):
 
-Display all fields as a numbered list. Use AskUserQuestion: "Which fields would you like to correct? (enter numbers, comma-separated)"
+Display all fields as a numbered list. Ask as intentional freeform/no-options input: "Which fields would you like to correct?" Enter comma-separated field numbers (for example, 1,3,5). This is freeform input — do not format the field list as a structured options array.
 
 For each selected field, use AskUserQuestion to ask the user for the corrected value. Update the inference JSON with corrected values.
 
@@ -404,7 +412,7 @@ Display: `◆ Generating project files...`
 **7a. Gather project data:**
 
 If SKIP_INFERENCE=true (greenfield or user chose "Define from scratch"):
-- Use AskUserQuestion to ask discovery questions:
+- Ask intentional freeform/no-options discovery questions:
   1. "What is your project name?"
   2. "Describe your project in one sentence."
   3. "What are the key requirements? (one per line)"
@@ -415,7 +423,7 @@ If SKIP_INFERENCE=false (confirmed/corrected inference data):
 - Read `.vbw-planning/inference.json` to get confirmed project context
 - Extract: NAME from `name.value`, DESCRIPTION from `purpose.value`
 - If GSD_MIGRATION: read `.vbw-planning/gsd-inference.json` for milestone/phase context
-- Use AskUserQuestion to ask any remaining questions not covered by inference:
+- Ask intentional freeform/no-options questions for any remaining user-authored content not covered by inference:
   1. "What are the key requirements?" (pre-fill from inferred features if available)
   2. "What phases do you envision?" (pre-fill from GSD recent_phases if available)
 

--- a/references/discussion-engine.md
+++ b/references/discussion-engine.md
@@ -18,7 +18,7 @@ All resolve to this protocol:
 
 ## Interaction Boundary
 
-Use structured AskUserQuestion for bounded discussion decisions with 2–4 visible choices. Use intentional freeform/no-options input for gray-area selections, corrections, or explanations that exceed four visible choices, and do NOT use `options` array for those high-cardinality paths.
+Use structured AskUserQuestion for bounded discussion decisions with 1–4 visible choices. Use intentional freeform/no-options input for gray-area selections, corrections, or explanations that exceed four visible choices, and do NOT use `options` array for those high-cardinality paths.
 
 ## Step 1: Calibrate
 
@@ -226,7 +226,7 @@ Present gray-area selection based on list size and discussion mode:
 
 ## Step 3: Explore
 
-**Early exit:** If Step 2 produced no selected areas because the user chose structured `None — discussion is complete` or entered freeform `none`, skip directly to Step 4.
+**Early exit:** If Step 2 produced no selected areas because the user chose structured `None — discussion is complete` or entered freeform `none` / `None — discussion is complete`, skip directly to Step 4.
 
 For each selected area, have a natural conversation. Not a form. Not a fixed number of questions.
 

--- a/references/discussion-engine.md
+++ b/references/discussion-engine.md
@@ -4,6 +4,10 @@ One engine. Three entry points. Claude thinks, not pattern-matches.
 
 Replaces the three competing discussion subsystems (Bootstrap Discovery, Phase Discovery, Phase Discussion) with a single unified protocol. The user is the visionary. Claude is the builder. The engine's job is to surface decisions that downstream agents (researcher, planner, executor) need to act without asking the user again.
 
+## Shared interaction contract
+
+Generic AskUserQuestion behavior lives in `references/ask-user-question.md`. Use that contract for headers, option counts, built-in `Other`, spacing, and freeform handoffs. This file only defines discussion-specific routing.
+
 ## Entry Points
 
 All resolve to this protocol:
@@ -11,6 +15,10 @@ All resolve to this protocol:
 - `/vbw:vibe` — auto-detects discussion need from state
 - `/vbw:vibe --discuss [N]` — explicit flag, targets phase N
 - `/vbw:discuss [N]` — standalone command
+
+## Interaction Boundary
+
+Use structured AskUserQuestion for bounded discussion decisions with 2–4 visible choices. Use intentional freeform/no-options input for gray-area selections, corrections, or explanations that exceed four visible choices, and do NOT use `options` array for those high-cardinality paths.
 
 ## Step 1: Calibrate
 
@@ -32,15 +40,21 @@ Two modes, silently selected:
 
 Same gray area, two modes:
 
+<examples>
+<example label="Builder mode gray-area prompt">
 **Builder:** "When someone's internet drops while they're writing a post, we'll save their work and try again when they're back online. This is standard — it prevents data loss. Sound good?"
 - "Sounds good (Recommended — prevents data loss)"
 - "I'd prefer it to show an error instead"
 - "Let me explain..."
+</example>
 
+<example label="Architect mode gray-area prompt">
 **Architect:** "For offline write handling, the enterprise-standard approach is optimistic local queueing with sync on reconnect. Pessimistic blocking has a poor UX in mobile-first apps and doesn't reduce conflict risk. Recommendation: queue locally, sync on reconnect."
 - "Queue locally, sync on reconnect (Recommended — standard for mobile-first)"
 - "Block submission, show connectivity state"
 - "Let me explain..."
+</example>
+</examples>
 
 ## Step 1.5: Detect Continuation
 
@@ -129,6 +143,8 @@ Presentation varies by profile:
 
 **Low confidence (genuine questions):** Fall through to standard Step 3 Explore flow with recommendation-led questions.
 
+When the user selects `Let me explain...`, stop using AskUserQuestion, ask a plain-text follow-up for the explanation, wait for the response, then update the assumption from that response before continuing.
+
 ### A4: Process Corrections
 
 For each assumption the user reviews:
@@ -197,9 +213,11 @@ Profile depth controls gray area count:
 | default | 3-5 |
 | production | 4-6 |
 
-Present gray areas as a multi-select using AskUserQuestion.
-- **Fresh discussion:** "Which areas should we discuss?" No "skip all" option — if the user ran discuss, give them real choices.
-- **Continuation:** "These topics weren't covered in the previous discussion. Which would you like to explore?" Include a "None — discussion is complete" option since the user may have only wanted to check.
+Present gray-area selection based on list size:
+- **1–4 gray areas:** Use structured AskUserQuestion multi-select.
+- **5–6 gray areas:** Present a numbered list and ask for intentional freeform/no-options selection; do NOT use `options` array. Fresh discussions still require at least one selected area. Continuation discussions may accept `none` / "None — discussion is complete" because the user may have only wanted to check.
+- **Fresh discussion copy:** "Which areas should we discuss?" No "skip all" option when using structured selection.
+- **Continuation copy:** "These topics weren't covered in the previous discussion. Which would you like to explore?"
 
 > **AskUserQuestion spacing**: output 3–4 blank lines before the tool call (the dialog obscures trailing text).
 
@@ -213,7 +231,7 @@ The rhythm:
 1. Open with your recommendation for the area (for product decisions, present options equally per the Recommendation Principle instead): state the gray area, provide your recommendation with brief reasoning (2-3 sentences), then ask for confirmation via AskUserQuestion. Format the first option as the recommended choice with "(Recommended — [brief reason])" in the label. Include 1-2 alternatives and a "Let me explain..." free-form option.
 2. If user picks recommended: confirm in one line, move on. No follow-ups for standard picks.
 3. If user picks alternative: record the preference. Only ask a follow-up if the alternative changes a downstream requirement or invalidates the recommendation's reasoning — otherwise move on.
-4. If user picks "Let me explain...": read their free-form input, adjust your recommendation based on their reasoning, and confirm the updated decision. Treat their input as a preference, not a request for more options.
+4. If user picks "Let me explain...": stop using AskUserQuestion, ask a plain-text follow-up, wait for the response, adjust your recommendation based on their reasoning, and confirm the updated decision. Treat their input as a preference, not a request for more options.
 5. After covering the area, move to the next one.
 
 **Clear-cut batching:** For decisions where the enterprise answer is standard practice across well-architected projects, batch them instead of asking individually. Present the batch as a list with brief reasoning and confirm via AskUserQuestion with options like "All good", "I'd like to discuss one of these", and "Let me explain...": "For [area], we'll use these standard approaches: [list with brief reasoning]. Any of these need discussion?"

--- a/references/discussion-engine.md
+++ b/references/discussion-engine.md
@@ -213,9 +213,12 @@ Profile depth controls gray area count:
 | default | 3-5 |
 | production | 4-6 |
 
-Present gray-area selection based on list size:
-- **1–4 gray areas:** Use structured AskUserQuestion multi-select.
-- **5–6 gray areas:** Present a numbered list and ask for intentional freeform/no-options selection; do NOT use `options` array. Fresh discussions still require at least one selected area. Continuation discussions may accept `none` / "None — discussion is complete" because the user may have only wanted to check.
+Present gray-area selection based on list size and discussion mode:
+- **Continuation invariant:** Continuation discussions must always offer an explicit `None — discussion is complete` no-op path. Selecting it, or entering `none` in a freeform path, means no gray areas were selected.
+- **Fresh 1–4 gray areas:** Use structured AskUserQuestion multi-select and require at least one selected area.
+- **Fresh 5–6 gray areas:** Present a numbered list and ask for intentional freeform/no-options selection; require at least one selected area and do NOT use `options` array.
+- **Continuation 1–3 uncovered gray areas:** Use structured AskUserQuestion multi-select with `None — discussion is complete` as a visible option. This keeps the total within four visible choices because the no-op option counts.
+- **Continuation 4–6 uncovered gray areas:** Present a numbered list and ask for intentional freeform/no-options selection; accept `none` / `None — discussion is complete` and do NOT use `options` array.
 - **Fresh discussion copy:** "Which areas should we discuss?" No "skip all" option when using structured selection.
 - **Continuation copy:** "These topics weren't covered in the previous discussion. Which would you like to explore?"
 
@@ -223,7 +226,7 @@ Present gray-area selection based on list size:
 
 ## Step 3: Explore
 
-**Early exit:** If no areas were selected (user chose "None — discussion is complete" in Step 2), skip directly to Step 4.
+**Early exit:** If Step 2 produced no selected areas because the user chose structured `None — discussion is complete` or entered freeform `none`, skip directly to Step 4.
 
 For each selected area, have a natural conversation. Not a form. Not a fixed number of questions.
 

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -25,6 +25,7 @@ REFERENCES_DIR="$ROOT/references"
 
 ASK_USER_QUESTION_REF="$REFERENCES_DIR/ask-user-question.md"
 VIBE_COMMAND_FILE="$COMMANDS_DIR/vibe.md"
+INIT_COMMAND_FILE="$COMMANDS_DIR/init.md"
 LIST_TODOS_COMMAND_FILE="$COMMANDS_DIR/list-todos.md"
 CONFIG_COMMAND_FILE="$COMMANDS_DIR/config.md"
 SKILLS_COMMAND_FILE="$COMMANDS_DIR/skills.md"
@@ -586,6 +587,38 @@ require_text_literal "skills: 5+ candidate branch presents numbered list in ques
 require_text_literal "skills: 5+ candidate parser accepts comma-separated digits" "Accept comma-separated digits" "$SKILLS_HIGH_CARDINALITY_BRANCH"
 require_text_literal "skills: 5+ candidate parser accepts skip" 'Accept the word `skip`' "$SKILLS_HIGH_CARDINALITY_BRANCH"
 require_text_literal "skills: 5+ candidate parser rejects invalid numeric/freeform input" "Reject out-of-range numbers" "$SKILLS_HIGH_CARDINALITY_BRANCH"
+
+# --------------------------------------------------------------------------
+# Check 8: /vbw:init shared interaction contract boundary
+# --------------------------------------------------------------------------
+
+echo ""
+echo "--- Check 8: /vbw:init shared interaction boundary ---"
+
+INIT_SHARED_BLOCK="$(extract_heading_block "$INIT_COMMAND_FILE" "## Shared interaction contract" '^## ' || true)"
+INIT_BODY="$(extract_body "$INIT_COMMAND_FILE")"
+INIT_STEP_0="$(extract_regex_block "$INIT_COMMAND_FILE" '^### Step 0: Environment setup' '^### ' || true)"
+INIT_SKILL_PROMPT="$(extract_regex_block "$INIT_COMMAND_FILE" '^### Step 3: Convergence' '^### Step 3\.5:' || true)"
+INIT_CORRECTION_FLOW="$(extract_regex_block "$INIT_COMMAND_FILE" '^\*\*6e\. Correction flow' '^### Step 7:' || true)"
+
+require_file_literal "init: loads shared AskUserQuestion reference" '@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md' "$INIT_COMMAND_FILE"
+require_text_occurrence_count "init: shared AskUserQuestion reference appears once" "$INIT_BODY" '@${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md' 1
+
+if [ -n "$INIT_SHARED_BLOCK" ]; then
+  pass "init: shared interaction contract block extracted"
+else
+  fail "init: shared interaction contract block extracted"
+fi
+
+require_text_literal "init: shared block points to AskUserQuestion reference" 'references/ask-user-question.md' "$INIT_SHARED_BLOCK"
+require_text_regex "init: documents bounded choices as structured AskUserQuestion" 'bounded (bootstrap|config|setup|choices).*structured AskUserQuestion|structured AskUserQuestion.*bounded (bootstrap|config|setup|choices)' "$INIT_BODY"
+require_text_regex "init: documents project data as intentional freeform" 'project names?.*requirements?.*phases?.*field corrections?.*(freeform|no-options)|freeform.*project names?.*requirements?.*phases?.*field corrections?' "$INIT_BODY"
+require_text_regex "init: documents Other/freeform handoff uses shared contract" '(Other|Let me explain).*shared contract|shared contract.*(Other|Let me explain)' "$INIT_BODY"
+require_text_regex "init: skill prompt counts Skip within four visible choices" 'max 4 visible choices total, including `?Skip`?' "$INIT_SKILL_PROMPT"
+forbid_text_regex "init: skill prompt does not allow four options plus Skip" 'Max 4 options[[:space:]]*\+[[:space:]]*"?Skip"?' "$INIT_SKILL_PROMPT"
+require_text_literal "init: field correction selection is marked freeform" 'This is freeform input' "$INIT_CORRECTION_FLOW"
+require_text_regex "init: field correction guard forbids structured options array" 'do not format.*structured options array|do NOT use.*options.*array' "$INIT_CORRECTION_FLOW"
+forbid_text_regex "init: Step 0 ordering avoids unnecessary all-caps intensity" '\*\*CRITICAL: Complete ENTIRE step' "$INIT_STEP_0"
 
 echo ""
 echo "==============================="

--- a/testing/verify-discussion-engine-contract.sh
+++ b/testing/verify-discussion-engine-contract.sh
@@ -141,6 +141,8 @@ fi
 # --- Shared AskUserQuestion contract and local structured/freeform boundary ---
 
 SHARED_BLOCK="$(extract_heading_block "$ENGINE" "## Shared interaction contract" '^## ' || true)"
+STEP_2_BLOCK="$(extract_heading_block "$ENGINE" "## Step 2: Orient" '^## ' || true)"
+STEP_3_BLOCK="$(extract_heading_block "$ENGINE" "## Step 3: Explore" '^## ' || true)"
 
 if [ -n "$SHARED_BLOCK" ]; then
   pass "engine: shared interaction contract block extracted"
@@ -148,11 +150,27 @@ else
   fail "engine: shared interaction contract block extracted"
 fi
 
+if [ -n "$STEP_2_BLOCK" ]; then
+  pass "engine: Step 2 block extracted"
+else
+  fail "engine: Step 2 block extracted"
+fi
+
+if [ -n "$STEP_3_BLOCK" ]; then
+  pass "engine: Step 3 block extracted"
+else
+  fail "engine: Step 3 block extracted"
+fi
+
 require_text_literal "engine: shared block points to ask-user-question reference" "references/ask-user-question.md" "$SHARED_BLOCK"
 require_file_regex "engine: documents bounded choices as structured AskUserQuestion" 'bounded (discussion )?decisions?.*structured AskUserQuestion|structured AskUserQuestion.*bounded (discussion )?decisions?' "$ENGINE"
 require_file_regex "engine: documents larger selections as freeform/no-options" '(5[-–]6|more than four|exceed four).*freeform|freeform.*(5[-–]6|more than four|exceed four)' "$ENGINE"
 require_file_literal "engine: freeform selection forbids options array" 'do NOT use `options` array' "$ENGINE"
 require_file_regex "engine: Step 2 distinguishes 1-4 vs 5-6 gray areas" '1[-–]4 gray areas.*structured|5[-–]6 gray areas.*freeform|1[-–]4.*structured multi-select|5[-–]6.*numbered/freeform' "$ENGINE"
+require_text_literal "engine: continuation selection keeps explicit no-op path" 'Continuation discussions must always offer an explicit `None — discussion is complete` no-op path' "$STEP_2_BLOCK"
+require_text_regex "engine: structured continuation accounts for None option limit" 'Continuation 1[-–]3 uncovered gray areas.*structured AskUserQuestion.*None|1[-–]3.*None.*four visible choices' "$STEP_2_BLOCK"
+require_text_regex "engine: freeform continuation accepts none without options array" 'Continuation 4[-–]6 uncovered gray areas.*freeform|accept `none`|do NOT use `options` array' "$STEP_2_BLOCK"
+require_text_regex "engine: Step 3 early exit covers structured and freeform no-op" 'structured `None — discussion is complete`.*freeform `none`|freeform `none`.*structured `None — discussion is complete`|no selected areas' "$STEP_3_BLOCK"
 require_file_literal "engine: Let me explain stops AskUserQuestion" 'stop using AskUserQuestion' "$ENGINE"
 require_file_regex "engine: Let me explain asks plain-text follow-up and waits" 'plain-text follow-up.*wait|wait.*plain-text follow-up' "$ENGINE"
 require_file_regex "engine: Builder sample is clearly marked as an example" '<example[^>]*Builder|label="Builder"' "$ENGINE"

--- a/testing/verify-discussion-engine-contract.sh
+++ b/testing/verify-discussion-engine-contract.sh
@@ -100,6 +100,31 @@ extract_heading_block() {
   ' "$file"
 }
 
+extract_bullet_block() {
+  local text="$1"
+  local anchor="$2"
+
+  awk -v anchor="$anchor" '
+    {
+      line=$0
+
+      if (index(line, anchor) > 0) {
+        found=1
+        print line
+        next
+      }
+
+      if (found && line ~ /^- \*\*/) {
+        exit
+      }
+
+      if (found) {
+        print line
+      }
+    }
+  ' <<< "$text"
+}
+
 echo "=== Discussion Engine Contract Verification ==="
 
 ENGINE="$ROOT/references/discussion-engine.md"
@@ -141,13 +166,24 @@ fi
 # --- Shared AskUserQuestion contract and local structured/freeform boundary ---
 
 SHARED_BLOCK="$(extract_heading_block "$ENGINE" "## Shared interaction contract" '^## ' || true)"
+INTERACTION_BLOCK="$(extract_heading_block "$ENGINE" "## Interaction Boundary" '^## ' || true)"
 STEP_2_BLOCK="$(extract_heading_block "$ENGINE" "## Step 2: Orient" '^## ' || true)"
 STEP_3_BLOCK="$(extract_heading_block "$ENGINE" "## Step 3: Explore" '^## ' || true)"
+FRESH_STRUCTURED_BLOCK="$(extract_bullet_block "$STEP_2_BLOCK" "Fresh 1–4 gray areas" || true)"
+FRESH_FREEFORM_BLOCK="$(extract_bullet_block "$STEP_2_BLOCK" "Fresh 5–6 gray areas" || true)"
+CONTINUATION_STRUCTURED_BLOCK="$(extract_bullet_block "$STEP_2_BLOCK" "Continuation 1–3 uncovered gray areas" || true)"
+CONTINUATION_FREEFORM_BLOCK="$(extract_bullet_block "$STEP_2_BLOCK" "Continuation 4–6 uncovered gray areas" || true)"
 
 if [ -n "$SHARED_BLOCK" ]; then
   pass "engine: shared interaction contract block extracted"
 else
   fail "engine: shared interaction contract block extracted"
+fi
+
+if [ -n "$INTERACTION_BLOCK" ]; then
+  pass "engine: interaction boundary block extracted"
+else
+  fail "engine: interaction boundary block extracted"
 fi
 
 if [ -n "$STEP_2_BLOCK" ]; then
@@ -162,19 +198,60 @@ else
   fail "engine: Step 3 block extracted"
 fi
 
+if [ -n "$FRESH_STRUCTURED_BLOCK" ]; then
+  pass "engine: fresh structured gray-area branch extracted"
+else
+  fail "engine: fresh structured gray-area branch extracted"
+fi
+
+if [ -n "$FRESH_FREEFORM_BLOCK" ]; then
+  pass "engine: fresh freeform gray-area branch extracted"
+else
+  fail "engine: fresh freeform gray-area branch extracted"
+fi
+
+if [ -n "$CONTINUATION_STRUCTURED_BLOCK" ]; then
+  pass "engine: continuation structured gray-area branch extracted"
+else
+  fail "engine: continuation structured gray-area branch extracted"
+fi
+
+if [ -n "$CONTINUATION_FREEFORM_BLOCK" ]; then
+  pass "engine: continuation freeform gray-area branch extracted"
+else
+  fail "engine: continuation freeform gray-area branch extracted"
+fi
+
 require_text_literal "engine: shared block points to ask-user-question reference" "references/ask-user-question.md" "$SHARED_BLOCK"
-require_file_regex "engine: documents bounded choices as structured AskUserQuestion" 'bounded (discussion )?decisions?.*structured AskUserQuestion|structured AskUserQuestion.*bounded (discussion )?decisions?' "$ENGINE"
-require_file_regex "engine: documents larger selections as freeform/no-options" '(5[-–]6|more than four|exceed four).*freeform|freeform.*(5[-–]6|more than four|exceed four)' "$ENGINE"
-require_file_literal "engine: freeform selection forbids options array" 'do NOT use `options` array' "$ENGINE"
-require_file_regex "engine: Step 2 distinguishes 1-4 vs 5-6 gray areas" '1[-–]4 gray areas.*structured|5[-–]6 gray areas.*freeform|1[-–]4.*structured multi-select|5[-–]6.*numbered/freeform' "$ENGINE"
+require_text_literal "engine: boundary documents structured 1–4 visible choices" "Use structured AskUserQuestion for bounded discussion decisions with 1–4 visible choices" "$INTERACTION_BLOCK"
+require_text_literal "engine: boundary documents larger selections as freeform/no-options" "Use intentional freeform/no-options input" "$INTERACTION_BLOCK"
+require_text_literal "engine: boundary forbids options array for high-cardinality paths" 'do NOT use `options` array' "$INTERACTION_BLOCK"
 require_text_literal "engine: continuation selection keeps explicit no-op path" 'Continuation discussions must always offer an explicit `None — discussion is complete` no-op path' "$STEP_2_BLOCK"
-require_text_regex "engine: structured continuation accounts for None option limit" 'Continuation 1[-–]3 uncovered gray areas.*structured AskUserQuestion.*None|1[-–]3.*None.*four visible choices' "$STEP_2_BLOCK"
-require_text_regex "engine: freeform continuation accepts none without options array" 'Continuation 4[-–]6 uncovered gray areas.*freeform|accept `none`|do NOT use `options` array' "$STEP_2_BLOCK"
-require_text_regex "engine: Step 3 early exit covers structured and freeform no-op" 'structured `None — discussion is complete`.*freeform `none`|freeform `none`.*structured `None — discussion is complete`|no selected areas' "$STEP_3_BLOCK"
+
+require_text_literal "engine: fresh 1–4 branch uses structured multi-select" "Use structured AskUserQuestion multi-select" "$FRESH_STRUCTURED_BLOCK"
+require_text_literal "engine: fresh 1–4 branch requires selected area" "require at least one selected area" "$FRESH_STRUCTURED_BLOCK"
+
+require_text_literal "engine: fresh 5–6 branch uses freeform/no-options" "intentional freeform/no-options selection" "$FRESH_FREEFORM_BLOCK"
+require_text_literal "engine: fresh 5–6 branch requires selected area" "require at least one selected area" "$FRESH_FREEFORM_BLOCK"
+require_text_literal "engine: fresh 5–6 branch forbids options array" 'do NOT use `options` array' "$FRESH_FREEFORM_BLOCK"
+
+require_text_literal "engine: continuation 1–3 branch uses structured multi-select" "Use structured AskUserQuestion multi-select" "$CONTINUATION_STRUCTURED_BLOCK"
+require_text_literal "engine: continuation 1–3 branch includes None option" 'None — discussion is complete' "$CONTINUATION_STRUCTURED_BLOCK"
+require_text_literal "engine: continuation 1–3 branch accounts for four visible choices" "four visible choices" "$CONTINUATION_STRUCTURED_BLOCK"
+
+require_text_literal "engine: continuation 4–6 branch uses freeform/no-options" "intentional freeform/no-options selection" "$CONTINUATION_FREEFORM_BLOCK"
+require_text_literal "engine: continuation 4–6 branch accepts both no-op spellings" 'accept `none` / `None — discussion is complete`' "$CONTINUATION_FREEFORM_BLOCK"
+require_text_literal "engine: continuation 4–6 branch forbids options array" 'do NOT use `options` array' "$CONTINUATION_FREEFORM_BLOCK"
+
+require_text_literal "engine: Step 3 early exit requires no selected areas" "Step 2 produced no selected areas" "$STEP_3_BLOCK"
+require_text_literal "engine: Step 3 early exit covers structured None" 'structured `None — discussion is complete`' "$STEP_3_BLOCK"
+require_text_literal "engine: Step 3 early exit covers freeform none" 'freeform `none`' "$STEP_3_BLOCK"
+require_text_literal "engine: Step 3 early exit covers freeform None phrase" 'freeform `none` / `None — discussion is complete`' "$STEP_3_BLOCK"
+require_text_literal "engine: Step 3 early exit skips to Step 4" "skip directly to Step 4" "$STEP_3_BLOCK"
 require_file_literal "engine: Let me explain stops AskUserQuestion" 'stop using AskUserQuestion' "$ENGINE"
-require_file_regex "engine: Let me explain asks plain-text follow-up and waits" 'plain-text follow-up.*wait|wait.*plain-text follow-up' "$ENGINE"
-require_file_regex "engine: Builder sample is clearly marked as an example" '<example[^>]*Builder|label="Builder"' "$ENGINE"
-require_file_regex "engine: Architect sample is clearly marked as an example" '<example[^>]*Architect|label="Architect"' "$ENGINE"
+require_file_regex "engine: Let me explain asks plain-text follow-up and waits" 'plain-text follow-up, wait for the response' "$ENGINE"
+require_file_literal "engine: Builder sample is clearly marked as an example" '<example label="Builder mode gray-area prompt">' "$ENGINE"
+require_file_literal "engine: Architect sample is clearly marked as an example" '<example label="Architect mode gray-area prompt">' "$ENGINE"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/testing/verify-discussion-engine-contract.sh
+++ b/testing/verify-discussion-engine-contract.sh
@@ -18,6 +18,88 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
+require_file_literal() {
+  local desc="$1"
+  local needle="$2"
+  local file="$3"
+
+  if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+require_file_regex() {
+  local desc="$1"
+  local pattern="$2"
+  local file="$3"
+
+  if [ -f "$file" ] && grep -Eq -- "$pattern" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+require_text_literal() {
+  local desc="$1"
+  local needle="$2"
+  local text="$3"
+
+  if grep -Fq -- "$needle" <<< "$text"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+require_text_regex() {
+  local desc="$1"
+  local pattern="$2"
+  local text="$3"
+
+  if grep -Eq -- "$pattern" <<< "$text"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+extract_heading_block() {
+  local file="$1"
+  local heading="$2"
+  local end_regex="$3"
+
+  awk -v h="$heading" -v end_re="$end_regex" '
+    function trim_line(s) {
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+
+    {
+      line=$0
+      gsub(/\r/, "", line)
+      trimmed=trim_line(line)
+
+      if (trimmed == h) {
+        found=1
+        print line
+        next
+      }
+
+      if (found && trimmed ~ end_re) {
+        exit
+      }
+
+      if (found) {
+        print line
+      }
+    }
+  ' "$file"
+}
+
 echo "=== Discussion Engine Contract Verification ==="
 
 ENGINE="$ROOT/references/discussion-engine.md"
@@ -55,6 +137,26 @@ if grep -q "META.md" "$ENGINE"; then
 else
   fail "engine: codebase map guard missing META.md reference"
 fi
+
+# --- Shared AskUserQuestion contract and local structured/freeform boundary ---
+
+SHARED_BLOCK="$(extract_heading_block "$ENGINE" "## Shared interaction contract" '^## ' || true)"
+
+if [ -n "$SHARED_BLOCK" ]; then
+  pass "engine: shared interaction contract block extracted"
+else
+  fail "engine: shared interaction contract block extracted"
+fi
+
+require_text_literal "engine: shared block points to ask-user-question reference" "references/ask-user-question.md" "$SHARED_BLOCK"
+require_file_regex "engine: documents bounded choices as structured AskUserQuestion" 'bounded (discussion )?decisions?.*structured AskUserQuestion|structured AskUserQuestion.*bounded (discussion )?decisions?' "$ENGINE"
+require_file_regex "engine: documents larger selections as freeform/no-options" '(5[-–]6|more than four|exceed four).*freeform|freeform.*(5[-–]6|more than four|exceed four)' "$ENGINE"
+require_file_literal "engine: freeform selection forbids options array" 'do NOT use `options` array' "$ENGINE"
+require_file_regex "engine: Step 2 distinguishes 1-4 vs 5-6 gray areas" '1[-–]4 gray areas.*structured|5[-–]6 gray areas.*freeform|1[-–]4.*structured multi-select|5[-–]6.*numbered/freeform' "$ENGINE"
+require_file_literal "engine: Let me explain stops AskUserQuestion" 'stop using AskUserQuestion' "$ENGINE"
+require_file_regex "engine: Let me explain asks plain-text follow-up and waits" 'plain-text follow-up.*wait|wait.*plain-text follow-up' "$ENGINE"
+require_file_regex "engine: Builder sample is clearly marked as an example" '<example[^>]*Builder|label="Builder"' "$ENGINE"
+require_file_regex "engine: Architect sample is clearly marked as an example" '<example[^>]*Architect|label="Architect"' "$ENGINE"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Linked Issue

Fixes #483

## What

Aligns `/vbw:init` and `references/discussion-engine.md` with the shared AskUserQuestion interaction contract, then hardens the contract tests so the structured-vs-freeform boundary cannot drift silently. The change keeps the existing bootstrap/discussion behavior functionally equivalent while making the interaction routing explicit and testable.

## Why

Issue #483 identified that the highest-leverage human-in-the-loop flows were defining interaction behavior locally instead of consistently reusing the shared contract. The durable fix is to make the shared contract the source of generic AskUserQuestion behavior, keep only command/reference-specific routing in the local artifacts, and add focused contract checks for the invariants that matter: bounded choices stay structured; high-cardinality/correction/explanation paths stay intentional freeform/no-options; `Let me explain...` becomes a true plain-text handoff.

## How

- `commands/init.md` — Adds a shared interaction contract anchor and an init-specific interaction boundary, clarifies which bootstrap decisions are bounded structured prompts, keeps `Skip` inside the four-visible-choice limit, and marks project data/corrections as intentional freeform/no-options input.
- `references/discussion-engine.md` — Adds the shared interaction contract anchor, clarifies the discussion-specific structured/freeform boundary, delimits Builder/Architect examples, documents `Let me explain...` as a plain-text handoff, and preserves continuation no-op behavior across structured and freeform gray-area selection.
- `testing/verify-askuserquestion-contract.sh` — Adds init-specific regression checks for the shared anchor, option-count boundary, field-correction freeform behavior, and lower-intensity Step 0 wording.
- `testing/verify-discussion-engine-contract.sh` — Adds and later hardens discussion-engine contract checks with heading/bullet-local assertions for the shared anchor, gray-area routing, continuation no-op behavior, `Let me explain...` handoff, and example delimiters.

## Acceptance Criteria Verification

1. `commands/init.md` reuses shared interaction guidance for bounded AskUserQuestion flows.
   - Satisfied by the `## Shared interaction contract` section in `commands/init.md`, which imports `references/ask-user-question.md`, plus contract checks in `testing/verify-askuserquestion-contract.sh`.
2. `references/discussion-engine.md` clearly distinguishes structured option prompts from intentional plain-text/freeform follow-up.
   - Satisfied by `## Shared interaction contract`, `## Interaction Boundary`, Step 2 gray-area routing, and Step 3 `Let me explain...` handoff wording in `references/discussion-engine.md`; verified by `testing/verify-discussion-engine-contract.sh`.
3. `Let me explain...` style flows are documented as real freeform handoffs.
   - Satisfied by discussion-engine instructions to stop using AskUserQuestion, ask a plain-text follow-up, wait for the response, and resume only after processing; verified by discussion-engine contract checks.
4. Examples added or updated are clearly delimited from normative instructions.
   - Satisfied by `<examples>` / `<example label="...">` wrappers around Builder and Architect gray-area prompts; verified by discussion-engine contract checks.
5. Prompt wording avoids unnecessary intensity where guidance is not a hard invariant.
   - Satisfied by replacing the all-caps Step 0 imperative in `commands/init.md` with lower-intensity required-order wording; verified by init contract checks.
6. Bootstrap/discussion behavior remains functionally equivalent except for clearer interaction framing.
   - Satisfied by prompt-only routing/wording changes that preserve existing bootstrap and discussion flows, plus the QA/Copilot review loop and full test suite.
7. Files touched are limited to `commands/init.md`, `references/discussion-engine.md`, and directly affected contract tests.
   - Satisfied: only those four files changed.
8. `bash testing/run-all.sh` passes.
   - Satisfied locally and in CI. Local final run: lint 1/1, contract 48/48, BATS 3172 passed / 0 failed. GitHub Actions: 18/18 checks green on `477f8838f49a424b5fb1ef2b0f8743a748b2ea14`.

## Testing

- `bash testing/verify-discussion-engine-contract.sh` — passed, 41 checks.
- `bash testing/verify-askuserquestion-contract.sh` — passed, 106 checks.
- `bash testing/run-all.sh` — passed locally after implementation and after Copilot remediation: lint 1/1, contract 48/48, BATS 3172 passed / 0 failed.
- GitHub Actions — green on `477f8838f49a424b5fb1ef2b0f8743a748b2ea14` with 18/18 checks passing.

## QA Summary

- Primary QA round 1 (`qa-investigator`) — 1 legitimate medium contract finding fixed in `c15f56417745de06a2c2bb944a20b26a80f64350` by restoring the explicit continuation no-op path in discussion routing and adding regression coverage.
- Primary QA round 2 (`qa-investigator`) — clean; evidence commit `0ce5aa279336631e1a561d0d89212dca06d2c508`.
- Cross-model QA — skipped by workflow gate because this is a GPT-class session and same-family GPT cross-validation does not provide the required diverse model perspective.
- Copilot PR review round 1 — 3 actionable comments fixed in `477f8838f49a424b5fb1ef2b0f8743a748b2ea14`:
  - Align interaction boundary wording with the Step 2 `1–4` structured range.
  - Include both accepted freeform no-op spellings in the Step 3 early-exit wording.
  - Replace permissive contract regexes with block-local and branch-local assertions.
- Copilot PR review round 2 — clean `COMMENTED` review with no new comments on `477f8838f49a424b5fb1ef2b0f8743a748b2ea14`.
- Copilot threads — all addressed threads replied to and resolved; zero unresolved Copilot-authored threads remain.

## Final Status

- PR is ready for review and merge-clean.
- `origin/main` had no new commits during the post-review sync check.
- All local and remote checks are green.
