### PR TITLE
feat(research): support numbered todo pickup

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ These are the commands you'll use every day. This is the job now.
 | `/vbw:fix` | Quick task in Turbo mode. One commit, no ceremony. For when the fix is obvious and you don't need seven agents to add a missing comma. |
 | `/vbw:debug` | Systematic bug investigation via the Debugger agent. Persists findings to a debug session file so investigations survive across sessions — resume with `--resume` or target a specific session with `--session <id>`. At Thorough effort with ambiguous bugs, spawns 3 parallel debugger teammates for report-only competing-hypothesis investigation, waits for all reports, tears that cohort down, and only then (if needed) spawns one fresh debugger as the sole implementation owner. Investigations that create a new fix commit auto-chain QA and UAT verification inline; investigations that confirm the fix was already present can complete immediately without re-running QA/UAT. |
 | `/vbw:todo` | Add an item to a persistent backlog that survives across sessions. For all those "we should really..." thoughts that usually die in a terminal tab. |
-| `/vbw:list-todos` | Browse pending todos, filter by priority, and pick one to act on. Computes ages, formats a numbered list, persists the last displayed view for deterministic follow-up actions, offers `/vbw:fix`, `/vbw:debug`, and `/vbw:vibe` routing only from unfiltered views, and keeps `remove N` / `delete N` working against the exact displayed snapshot. |
+| `/vbw:list-todos` | Browse pending todos, filter by priority, and pick one to act on. Computes ages, formats a numbered list, persists the last displayed view for deterministic follow-up actions, offers `/vbw:fix`, `/vbw:debug`, `/vbw:research`, and `/vbw:vibe` routing only from unfiltered views, and keeps `remove N` / `delete N` working against the exact displayed snapshot. |
 | `/vbw:pause` | Save session notes for next time. State auto-persists in `.vbw-planning/` -- pause just lets you leave a sticky note for future you. |
 | `/vbw:resume` | Restore project context from `.vbw-planning/` ground truth. Reads state, roadmap, plans, and summaries directly -- no prior `/vbw:pause` needed. |
 | `/vbw:skills` | Browse and install community skills from skills.sh based on your project's tech stack. Detects your stack, suggests relevant skills, and installs them with one command. |
@@ -441,7 +441,7 @@ VBW treats RTK binary installation/update and Claude Code hook activation as sep
 | Command | Description |
 | :--- | :--- |
 | `/vbw:map` | Analyze a codebase with 4 parallel Scout teammates (Tech, Architecture, Quality, Concerns). Produces synthesis documents (INDEX.md, PATTERNS.md). Supports monorepo per-package mapping. Security-enforced via hooks: never reads `.env` or credentials. |
-| `/vbw:research` | Standalone research task, decoupled from planning. For when you need answers but aren't ready to commit to a plan. |
+| `/vbw:research` | Standalone research task, decoupled from planning. Accepts `/vbw:research N` from an unfiltered `/vbw:list-todos` snapshot for context-only Scout research without removing the todo. |
 | `/vbw:whats-new` | View changelog entries since your installed version. |
 | `/vbw:update` | Update VBW to the latest version with automatic cache refresh. |
 | `/vbw:uninstall` | Clean removal of VBW -- statusline, settings, and project data. For when you want to go back to prompting manually like it's 2024. |

--- a/commands/list-todos.md
+++ b/commands/list-todos.md
@@ -52,6 +52,7 @@ allowed-tools: Read, Edit, Bash
              /vbw:vibe N      — full lifecycle (plan → execute → verify)
              /vbw:fix N       — quick fix, one commit
              /vbw:debug N     — investigate with scientific method
+             /vbw:research N  — research context with Scout
              remove N         — delete from todo list
        ```
     - **Filtered view (`filter` is non-null):**
@@ -59,7 +60,7 @@ allowed-tools: Read, Edit, Bash
        ➜ Filtered view:
              remove N         — delete from this displayed list
              delete N         — same as remove N
-          /vbw:list-todos  — rerun unfiltered /vbw:list-todos before using /vbw:vibe N, /vbw:fix N, or /vbw:debug N
+          /vbw:list-todos  — rerun unfiltered /vbw:list-todos before using /vbw:vibe N, /vbw:fix N, /vbw:debug N, or /vbw:research N
        ```
 
     If the user says **`remove N`** or **`delete N`** as a follow-up message (not via a slash command):

--- a/commands/research.md
+++ b/commands/research.md
@@ -54,13 +54,13 @@ Current project:
     bash "{plugin-root}/scripts/todo-details.sh" get <hash>
     ```
     Command shape: `bash "{plugin-root}/scripts/todo-details.sh" get <hash>`.
-    Parse the JSON output. If `status` is `"ok"`, store `detail.context` and `detail.files` for Step 3. If `status` is `"not_found"` or `"error"`, run:
+    Parse the JSON output. If `status` is `"ok"`, store `DETAIL_STATUS=ok`, `detail.context`, and `detail.files` for Step 3. If `status` is `"not_found"` or `"error"`, record the matching `DETAIL_STATUS` value and run:
     ```bash
     bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning <hash>
     ```
     Ignore missing-root-state cases — the helper already degrades gracefully. In all cases, continue without detail.
-    If no ref suffix, $ARGUMENTS minus flags = topic.
-    **Post-parse validation:** If the topic is empty or whitespace-only after stripping flags and ref, check whether a ref was found (including a numbered selection's resolved ref) AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the research context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:research <topic> [--parallel]"`.
+    If no ref suffix, set `DETAIL_STATUS=none`, then $ARGUMENTS minus flags = topic.
+    **Post-parse validation:** If the topic is empty or whitespace-only after stripping flags and ref, check whether a ref was found (including a numbered selection's resolved ref) AND `DETAIL_STATUS=ok`. If yes, proceed — the detail provides the research context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:research <topic> [--parallel]"`.
     `--parallel` controls Scout fan-out (Step 2) and must not be included in the topic text passed to Scout.
 2. **Scope:** Single question = 1 Scout. Multi-faceted or --parallel = 2-4 sub-topics.
 3. **Spawn Scout:**

--- a/commands/research.md
+++ b/commands/research.md
@@ -33,7 +33,23 @@ Current project:
 
 ## Steps
 
-1. **Parse:** Strip any `--parallel` flag from $ARGUMENTS and store it separately for Step 2 routing. If the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the topic. If a ref was found, load extended detail:
+1. **Parse:** Strip any `--parallel` flag from $ARGUMENTS and store it separately for Step 2 routing. After stripping flags, if the remaining topic is a bare integer (matches `^[0-9]+$`), resolve the todo item against the persisted unfiltered `/vbw:list-todos` snapshot and validate that the live backlog still matches the snapshotted identity:
+    ```bash
+    bash "{plugin-root}/scripts/resolve-todo-item.sh" <N> --session-snapshot --require-unfiltered --validate-live
+    ```
+    Parse the JSON output. If `status` is `"ok"`, store `TODO_SELECTED=true`, store the full payload as `TODO_SELECTED_JSON`, replace the topic with the item's `command_text` value, and reuse the item's `ref` metadata for detail loading. If the resolved `state_path` points under `.vbw-planning/milestones/`, STOP with: `This todo came from archived milestone state. Restore the writable root STATE.md first by restarting so session-start.sh can run migration, or run 'bash scripts/migrate-orphaned-state.sh .vbw-planning'.` Do not continue using the archived description as live research input. If `status` is `"error"`, STOP with the resolver's `message` value.
+
+    If the selected item has a non-null `ref`, load detail immediately:
+    ```bash
+    bash "{plugin-root}/scripts/todo-details.sh" get {hash}
+    ```
+    If `status` is `"ok"`, store `DETAIL_STATUS=ok`, `detail.context`, and `detail.files` for Step 3. If `status` is `"not_found"` or `"error"`, record the matching `DETAIL_STATUS` value and run:
+    ```bash
+    bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
+    ```
+    Continue without detail. If the selected item has no ref, use `DETAIL_STATUS=none`.
+
+    If no numbered todo selection was used, preserve the current manual ref behavior: if the remaining $ARGUMENTS contains a `(ref:HASH)` suffix (8 hex characters), extract the hash and strip the ref tag. Store remaining text (minus flags and ref) as the topic. If a ref was found, load extended detail:
     ```bash
     bash "{plugin-root}/scripts/todo-details.sh" get <hash>
     ```
@@ -44,7 +60,7 @@ Current project:
     ```
     Ignore missing-root-state cases — the helper already degrades gracefully. In all cases, continue without detail.
     If no ref suffix, $ARGUMENTS minus flags = topic.
-    **Post-parse validation:** If the topic is empty or whitespace-only after stripping flags and ref, check whether a ref was found AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the research context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:research <topic> [--parallel]"`.
+    **Post-parse validation:** If the topic is empty or whitespace-only after stripping flags and ref, check whether a ref was found (including a numbered selection's resolved ref) AND its detail loaded successfully (status `"ok"`). If yes, proceed — the detail provides the research context. If no ref was found, or the ref detail failed to load, STOP: `"Usage: /vbw:research <topic> [--parallel]"`.
     `--parallel` controls Scout fan-out (Step 2) and must not be included in the topic text passed to Scout.
 2. **Scope:** Single question = 1 Scout. Multi-faceted or --parallel = 2-4 sub-topics.
 3. **Spawn Scout:**
@@ -77,6 +93,7 @@ After calling `Skill(...)`, if the loaded skill's instructions reference additio
 Research: {topic or sub-topic}.
 Project context: {tech stack, constraints from PROJECT.md if relevant}.
 Extended context from todo detail (include only if detail was loaded in Step 1): {detail.context}. Related files: {detail.files, comma-separated}.
+Todo selection note (include only if TODO_SELECTED=true): Numbered /vbw:list-todos research selections are context-only; leave the todo visible because research may not complete the underlying work item.
 </task_context>
 
 <output_path>{resolved save path}</output_path>
@@ -94,7 +111,9 @@ After calling `Skill(...)`, if the loaded skill's instructions reference additio
 
 <task_context>
 Research: {topic or sub-topic}.
-...
+Project context: {tech stack, constraints from PROJECT.md if relevant}.
+Extended context from todo detail (include only if detail was loaded in Step 1): {detail.context}. Related files: {detail.files, comma-separated}.
+Todo selection note (include only if TODO_SELECTED=true): Numbered /vbw:list-todos research selections are context-only; leave the todo visible because research may not complete the underlying work item.
 </task_context>
 ```
     - If save path is unknown yet (user hasn't confirmed), omit `<output_path>` — Scout returns findings in response, and the orchestrator writes them after user confirms a path.

--- a/commands/research.md
+++ b/commands/research.md
@@ -41,11 +41,11 @@ Current project:
 
     If the selected item has a non-null `ref`, load detail immediately:
     ```bash
-    bash "{plugin-root}/scripts/todo-details.sh" get {hash}
+    bash "{plugin-root}/scripts/todo-details.sh" get <hash>
     ```
     If `status` is `"ok"`, store `DETAIL_STATUS=ok`, `detail.context`, and `detail.files` for Step 3. If `status` is `"not_found"` or `"error"`, record the matching `DETAIL_STATUS` value and run:
     ```bash
-    bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
+    bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning <hash>
     ```
     Continue without detail. If the selected item has no ref, use `DETAIL_STATUS=none`.
 
@@ -56,7 +56,7 @@ Current project:
     Command shape: `bash "{plugin-root}/scripts/todo-details.sh" get <hash>`.
     Parse the JSON output. If `status` is `"ok"`, store `detail.context` and `detail.files` for Step 3. If `status` is `"not_found"` or `"error"`, run:
     ```bash
-    bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning {hash}
+    bash "{plugin-root}/scripts/todo-lifecycle.sh" detail-warning <hash>
     ```
     Ignore missing-root-state cases — the helper already degrades gracefully. In all cases, continue without detail.
     If no ref suffix, $ARGUMENTS minus flags = topic.

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -477,10 +477,11 @@ require_text_literal "list-todos: step 5 does not prompt the user for input" "Do
 require_text_literal "list-todos: unfiltered hints preserve /vbw:vibe N" "/vbw:vibe N" "$LIST_TODOS_UNFILTERED_HINTS"
 require_text_literal "list-todos: unfiltered hints preserve /vbw:fix N" "/vbw:fix N" "$LIST_TODOS_UNFILTERED_HINTS"
 require_text_literal "list-todos: unfiltered hints preserve /vbw:debug N" "/vbw:debug N" "$LIST_TODOS_UNFILTERED_HINTS"
+require_text_literal "list-todos: unfiltered hints preserve /vbw:research N" "/vbw:research N" "$LIST_TODOS_UNFILTERED_HINTS"
 require_text_regex "list-todos: unfiltered hints preserve remove N" '(^|[[:space:]])remove N([[:space:]]|$)' "$LIST_TODOS_UNFILTERED_HINTS"
 require_text_regex "list-todos: filtered hints preserve remove N" '(^|[[:space:]])remove N([[:space:]]|$)' "$LIST_TODOS_FILTERED_HINTS"
 require_text_regex "list-todos: filtered hints preserve delete N" '(^|[[:space:]])delete N([[:space:]]|$)' "$LIST_TODOS_FILTERED_HINTS"
-require_text_literal "list-todos: filtered hints preserve rerun-unfiltered guard" "rerun unfiltered /vbw:list-todos before using /vbw:vibe N, /vbw:fix N, or /vbw:debug N" "$LIST_TODOS_FILTERED_HINTS"
+require_text_literal "list-todos: filtered hints preserve rerun-unfiltered guard" "rerun unfiltered /vbw:list-todos before using /vbw:vibe N, /vbw:fix N, /vbw:debug N, or /vbw:research N" "$LIST_TODOS_FILTERED_HINTS"
 
 # --------------------------------------------------------------------------
 # Check 6: /vbw:config bounded structured flow

--- a/testing/verify-todo-pickup-contract.sh
+++ b/testing/verify-todo-pickup-contract.sh
@@ -107,8 +107,8 @@ require_grep "research stores selected todo payload" 'TODO_SELECTED_JSON' "$RESE
 require_grep "research marks numbered todo selection" 'TODO_SELECTED=true' "$RESEARCH_CMD"
 require_grep "research uses selected command text as topic" 'command_text' "$RESEARCH_CMD"
 require_grep "research rejects archived milestone selected todos" 'archived milestone state' "$RESEARCH_CMD"
-require_grep "research loads selected todo detail through helper" 'todo-details\.sh" get \{hash\}' "$RESEARCH_CMD"
-require_grep "research writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning' "$RESEARCH_CMD"
+require_grep "research loads selected todo detail through helper" 'todo-details\.sh" get <hash>' "$RESEARCH_CMD"
+require_grep "research writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning <hash>' "$RESEARCH_CMD"
 require_absent "research does not claim todos automatically" 'todo-lifecycle\.sh" pickup /vbw:research' "$RESEARCH_CMD"
 
 echo

--- a/testing/verify-todo-pickup-contract.sh
+++ b/testing/verify-todo-pickup-contract.sh
@@ -109,7 +109,11 @@ require_grep "research uses selected command text as topic" 'command_text' "$RES
 require_grep "research rejects archived milestone selected todos" 'archived milestone state' "$RESEARCH_CMD"
 require_grep "research loads selected todo detail through helper" 'todo-details\.sh" get <hash>' "$RESEARCH_CMD"
 require_grep "research writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning <hash>' "$RESEARCH_CMD"
+require_grep "research manual detail records ok status" 'Parse the JSON output\. If `status` is `"ok"`, store `DETAIL_STATUS=ok`' "$RESEARCH_CMD"
+require_grep "research no-ref path records none detail status" 'If no ref suffix, set `DETAIL_STATUS=none`' "$RESEARCH_CMD"
+require_grep "research empty-topic validation uses detail status" 'AND `DETAIL_STATUS=ok`' "$RESEARCH_CMD"
 require_absent "research does not claim todos automatically" 'todo-lifecycle\.sh" pickup /vbw:research' "$RESEARCH_CMD"
+require_absent "research does not remove todos automatically" 'todo-lifecycle\.sh" remove' "$RESEARCH_CMD"
 
 echo
  echo "==============================="

--- a/testing/verify-todo-pickup-contract.sh
+++ b/testing/verify-todo-pickup-contract.sh
@@ -68,7 +68,8 @@ require_absent "list-todos no longer asks markdown to pipe JSON into snapshot-sa
 require_grep "list-todos remove uses snapshot resolver" 'resolve-todo-item\.sh" <N> --session-snapshot' "$LIST_CMD"
 require_grep "list-todos remove delegates to lifecycle helper" 'todo-lifecycle\.sh" remove' "$LIST_CMD"
 require_grep "list-todos filtered view rerun-unfiltered hint exists" 'rerun unfiltered /vbw:list-todos' "$LIST_CMD"
-require_absent "list-todos no longer advertises /vbw:research N" '/vbw:research N' "$LIST_CMD"
+require_grep "list-todos advertises /vbw:research N" '/vbw:research N' "$LIST_CMD"
+require_grep "list-todos filtered guard includes /vbw:research N" 'rerun unfiltered /vbw:list-todos before using /vbw:vibe N, /vbw:fix N, /vbw:debug N, or /vbw:research N' "$LIST_CMD"
 
 # debug command surface
 require_grep "debug uses snapshot-backed todo resolver" 'resolve-todo-item\.sh" <N> --session-snapshot --require-unfiltered --validate-live' "$DEBUG_CMD"
@@ -100,8 +101,15 @@ require_grep "vibe eagerly loads detail during Input Parsing for selected todos"
 require_grep "vibe pickup uses lifecycle helper" 'todo-lifecycle\.sh" pickup /vbw:vibe' "$VIBE_CMD"
 require_grep "vibe writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning' "$VIBE_CMD"
 
-# research warning path
+# research command surface
+require_grep "research uses snapshot-backed todo resolver" 'resolve-todo-item\.sh" <N> --session-snapshot --require-unfiltered --validate-live' "$RESEARCH_CMD"
+require_grep "research stores selected todo payload" 'TODO_SELECTED_JSON' "$RESEARCH_CMD"
+require_grep "research marks numbered todo selection" 'TODO_SELECTED=true' "$RESEARCH_CMD"
+require_grep "research uses selected command text as topic" 'command_text' "$RESEARCH_CMD"
+require_grep "research rejects archived milestone selected todos" 'archived milestone state' "$RESEARCH_CMD"
+require_grep "research loads selected todo detail through helper" 'todo-details\.sh" get \{hash\}' "$RESEARCH_CMD"
 require_grep "research writes detail warning through lifecycle helper" 'todo-lifecycle\.sh" detail-warning' "$RESEARCH_CMD"
+require_absent "research does not claim todos automatically" 'todo-lifecycle\.sh" pickup /vbw:research' "$RESEARCH_CMD"
 
 echo
  echo "==============================="


### PR DESCRIPTION
## Linked Issue

Fixes #542

## What

Adds `/vbw:research N` as a snapshot-safe numbered todo pickup path. `commands/research.md` now resolves bare numeric input from the latest unfiltered `/vbw:list-todos` snapshot, reuses todo detail context when available, and keeps research context-only so the todo remains visible. `commands/list-todos.md` now advertises `/vbw:research N`, and the contract tests enforce the new research pickup behavior plus the deterministic detail-status invariants found during Copilot review.

## Why

The root cause was an incomplete numbered-pickup invariant: action-oriented commands (`vibe`, `fix`, `debug`) had snapshot-backed todo resolution, but `research` did not. The durable fix is to reuse the existing ownership boundaries (`resolve-todo-item.sh` for identity validation, `todo-details.sh` for detail lookup, `todo-lifecycle.sh detail-warning` for degraded detail state) rather than adding a parallel resolver or prompt-only workaround.

## How

- `commands/research.md`: strips `--parallel` before parsing, resolves bare integer topics through the snapshot resolver, rejects archived milestone state, loads selected todo detail, records `DETAIL_STATUS` deterministically for numbered/manual/no-ref paths, and adds a Scout context note that numbered research selections do not claim/remove todos.
- `commands/list-todos.md`: adds `/vbw:research N` to unfiltered action hints and filtered-view rerun-unfiltered guidance.
- `testing/verify-todo-pickup-contract.sh`: flips research coverage from absence to positive assertions for resolver usage, selected payload storage, detail loading/warning, detail-status invariants, no pickup/remove calls, and list-todos advertising.
- `testing/verify-askuserquestion-contract.sh`: preserves the display-and-stop list-todos boundary while adding the new research hint to the asserted plain-text hints.
- `README.md`: updates the command reference so user-facing docs match the new numbered research path.

## Acceptance criteria verification

1. `commands/research.md` strips `--parallel` first and recognizes a remaining bare integer via `^[0-9]+$` — implemented in Step 1 parse flow; covered by `testing/verify-todo-pickup-contract.sh`.
2. `commands/research.md` resolves numbered research input with `resolve-todo-item.sh <N> --session-snapshot --require-unfiltered --validate-live` and stops with resolver `message` on error — implemented in Step 1; contract-tested.
3. `commands/research.md` rejects `.vbw-planning/milestones/` selected state paths — implemented with the same archived-state guard wording used by existing pickup commands; contract-tested.
4. Successful numbered resolution stores `TODO_SELECTED_JSON`, uses `command_text`, reuses `ref`, and loads detail through `todo-details.sh get <hash>` — implemented in `commands/research.md`; contract-tested.
5. Missing/error detail lookup calls `todo-lifecycle.sh detail-warning <hash>` and continues without detail — implemented in both numbered and manual ref paths; contract-tested.
6. Manual non-number research topics and manual `(ref:HASH)` behavior are preserved — existing manual path remains after numbered selection handling, now with deterministic `DETAIL_STATUS` recording.
7. `commands/research.md` does not call `todo-lifecycle.sh pickup /vbw:research` — explicitly contract-tested as absent; `remove` is also asserted absent for research.
8. `commands/list-todos.md` advertises `/vbw:research N` in unfiltered action hints — implemented and contract-tested.
9. `commands/list-todos.md` includes `/vbw:research N` in the filtered rerun-unfiltered guard — implemented and contract-tested.
10. `testing/verify-todo-pickup-contract.sh` positively asserts the research pickup contract — added and expanded in this PR; passed locally.
11. Full local verification passed from the worktree root — `bash testing/run-all.sh`: lint `1/1`, contracts `48/48`, BATS `3172 passed, 0 failed`.

## Testing

- `bash testing/verify-todo-pickup-contract.sh` — 53 passed, 0 failed after final Copilot remediation
- `bash testing/verify-askuserquestion-contract.sh` — 107 passed, 0 failed
- `bash scripts/verify-init-todo.sh` — passed in targeted batch
- `bash testing/verify-commands-contract.sh` — 463 passed, 0 failed
- `bash testing/verify-no-inline-exec-spans.sh` — passed
- `bash testing/verify-plugin-root-resolution.sh` — passed
- `bash testing/run-lint.sh` — passed
- `bash testing/run-all.sh` — lint `1/1`, contracts `48/48`, BATS `3172 passed, 0 failed`
- Remote CI on `23c65af37332e7e56b9bf12ab8863bfa5f984166` — `CI_GREEN`, all 18 checks passed

## QA summary

- Primary QA: 1 round, `qa-investigator`, CLEAN with 0 findings. Evidence commit: `5dbd92a2` (`fix(research): address QA round 1`).
- Cross-model QA: skipped — GPT-class/GitHub Copilot session model; no eligible different-family cross-model reviewer per workflow gate.
- Copilot PR review: 3 rounds total.
  - Round 1: 1 low-severity clarity finding; fixed placeholder consistency in `a63f625e` (`fix(research): address Copilot review round 1`).
  - Round 2: 1 low-severity deterministic parse invariant finding; fixed manual `DETAIL_STATUS` recording in `23c65af3` (`fix(research): address Copilot review round 2`).
  - Round 3: fresh review on `23c65af3`, `COMMENTED` with no new comments; zero unresolved Copilot threads.

## Commits

- `20d155b9` — `feat(research): add numbered todo pickup`
- `5dbd92a2` — `fix(research): address QA round 1`
- `a63f625e` — `fix(research): address Copilot review round 1`
- `23c65af3` — `fix(research): address Copilot review round 2`
