### PR TITLE
fix(rtk): tolerate smoke history tail mismatch during smoke proof

### DIFF
--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -500,13 +500,17 @@ rtk_history_total() {
   '
 }
 
-rtk_history_evidence_tail() {
+rtk_history_evidence() {
   awk '
     /(Total|total)[^0-9]{0,40}[0-9]+/ { next }
     /(commands|Commands|entries|Entries)[^0-9]{0,40}[0-9]+/ && $0 !~ /rtk[[:space:]]/ { next }
     /^[[:space:]]*[0-9]+[[:space:]]+(commands|command|entries|entry)([[:space:]]|$)/ { next }
     { print }
-  ' | tail -n 40 2>/dev/null || true
+  '
+}
+
+rtk_history_evidence_tail() {
+  rtk_history_evidence | tail -n 40 2>/dev/null || true
 }
 
 rtk_history_command_pattern() {
@@ -638,7 +642,7 @@ smoke_status_preconditions() {
 }
 
 smoke_start() {
-  local status_payload hook_path hook_command hook_version history history_total history_tail history_hash history_command_counts tmp
+  local status_payload hook_path hook_command hook_version history history_total history_evidence history_tail history_hash history_command_counts tmp
   status_payload="$(status_json false false)"
   smoke_status_preconditions "$status_payload"
   if printf '%s' "$status_payload" | jq -e '.compatibility == "verified" and ((.proof_source // "") != "")' >/dev/null 2>&1; then
@@ -649,9 +653,10 @@ smoke_start() {
   hook_version="$(printf '%s' "$status_payload" | jq -r '.active_hook_rtk_version')"
   history="$(rtk_history_snapshot "$hook_path")"
   history_total="$(printf '%s\n' "$history" | rtk_history_total || true)"
-  history_tail="$(printf '%s\n' "$history" | rtk_history_evidence_tail)"
+  history_evidence="$(printf '%s\n' "$history" | rtk_history_evidence)"
+  history_tail="$(printf '%s\n' "$history_evidence" | tail -n 40 2>/dev/null || true)"
   history_hash="$(printf '%s' "$history_tail" | sha256_text || true)"
-  history_command_counts="$(rtk_history_command_counts_json "$history_tail")"
+  history_command_counts="$(rtk_history_command_counts_json "$history_evidence")"
   mkdir -p "$VBW_RTK_DIR"
   tmp="$(mktemp "$VBW_RTK_DIR/rtk-smoke-pending.XXXXXX")"
   jq -n \
@@ -748,7 +753,7 @@ write_runtime_smoke_proof() {
 
 smoke_finish() {
   local pending_payload status_payload hook_path hook_command hook_version pending_hook_command pending_hook_version
-  local history history_after_total history_before_total history_before_tail history_after_tail history_before_sha256 history_after_sha256 history_evidence count_evidence isolation_evidence
+  local history history_after_total history_before_total history_before_tail history_after_evidence history_after_tail history_before_sha256 history_after_sha256 history_evidence count_evidence isolation_evidence
   local before_ls before_status before_log after_ls after_status after_log command_evidence_json
   [ -f "$RTK_PENDING_SMOKE_FILE" ] || smoke_fail 1 "pending smoke file missing" "$RTK_PENDING_SMOKE_FILE"
   jq empty "$RTK_PENDING_SMOKE_FILE" >/dev/null 2>&1 || smoke_fail 1 "pending smoke file is malformed" "$RTK_PENDING_SMOKE_FILE"
@@ -765,7 +770,8 @@ smoke_finish() {
   [ "$hook_version" = "$pending_hook_version" ] || smoke_fail 1 "RTK hook version changed during smoke" "$pending_hook_version -> $hook_version"
 
   history="$(rtk_history_snapshot "$hook_path")"
-  history_after_tail="$(printf '%s\n' "$history" | rtk_history_evidence_tail)"
+  history_after_evidence="$(printf '%s\n' "$history" | rtk_history_evidence)"
+  history_after_tail="$(printf '%s\n' "$history_after_evidence" | tail -n 40 2>/dev/null || true)"
   history_before_sha256="$(printf '%s' "$pending_payload" | jq -r '.history_before_sha256 // ""')"
   history_after_sha256="$(printf '%s' "$history_after_tail" | sha256_text || true)"
   history_after_total="$(printf '%s\n' "$history" | rtk_history_total || true)"
@@ -774,13 +780,13 @@ smoke_finish() {
   before_ls="$(rtk_pending_history_command_count "$pending_payload" ls)"
   before_status="$(rtk_pending_history_command_count "$pending_payload" status)"
   before_log="$(rtk_pending_history_command_count "$pending_payload" log)"
-  after_ls="$(rtk_history_command_count "$history_after_tail" ls)"
-  after_status="$(rtk_history_command_count "$history_after_tail" status)"
-  after_log="$(rtk_history_command_count "$history_after_tail" log)"
+  after_ls="$(rtk_history_command_count "$history_after_evidence" ls)"
+  after_status="$(rtk_history_command_count "$history_after_evidence" status)"
+  after_log="$(rtk_history_command_count "$history_after_evidence" log)"
   if [ -n "$history_before_sha256" ] && [ -n "$history_after_sha256" ] && [ "$history_before_sha256" = "$history_after_sha256" ]; then
     smoke_fail 1 "RTK history did not advance after smoke-start" "history tail hash unchanged"
   fi
-  history_evidence="$(rtk_history_after_pending_tail "$history_before_tail" "$history")"
+  history_evidence="$(rtk_history_after_pending_tail "$history_before_tail" "$history_after_evidence")"
   isolation_evidence="exact_tail"
   count_evidence="unavailable"
   if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
@@ -796,7 +802,7 @@ smoke_finish() {
       smoke_fail 1 "fresh smoke evidence requires a new /vbw:rtk verify attempt" "pending smoke file lacks history_before_command_counts"
     fi
     rtk_history_require_fresh_command_counts "$before_ls" "$before_status" "$before_log" "$after_ls" "$after_status" "$after_log"
-    history_evidence="$history_after_tail"
+    history_evidence="$history_after_evidence"
     if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
       isolation_evidence="command_counts_with_total_delta"
     else

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -509,22 +509,81 @@ rtk_history_evidence_tail() {
   ' | tail -n 40 2>/dev/null || true
 }
 
-rtk_history_has_command() {
-  local history="$1" command_key="$2"
+rtk_history_command_pattern() {
+  local command_key="$1"
   case "$command_key" in
     ls)
-      printf '%s\n' "$history" | grep -Eq '(^|[^[:alnum:]_/.-])rtk[[:space:]]+ls[[:space:]]+-la[[:space:]]+[.]([^[:alnum:]_/.-]|$)'
+      printf '%s\n' '(^|[^[:alnum:]_/.-])rtk[[:space:]]+ls[[:space:]]+-la[[:space:]]+[.]([^[:alnum:]_/.-]|$)'
       ;;
     status)
-      printf '%s\n' "$history" | grep -Eq '(^|[^[:alnum:]_/.-])rtk[[:space:]]+git[[:space:]]+status[[:space:]]+--short([^[:alnum:]_-]|$)'
+      printf '%s\n' '(^|[^[:alnum:]_/.-])rtk[[:space:]]+git[[:space:]]+status[[:space:]]+--short([^[:alnum:]_-]|$)'
       ;;
     log)
-      printf '%s\n' "$history" | grep -Eq '(^|[^[:alnum:]_/.-])rtk[[:space:]]+git[[:space:]]+log[[:space:]]+(-n[[:space:]]+2|-[0-9A-Za-z]*n[[:space:]]*2)[[:space:]]+--oneline([^[:alnum:]_-]|$)'
+      printf '%s\n' '(^|[^[:alnum:]_/.-])rtk[[:space:]]+git[[:space:]]+log[[:space:]]+(-n[[:space:]]+2|-[0-9A-Za-z]*n[[:space:]]*2)[[:space:]]+--oneline([^[:alnum:]_-]|$)'
       ;;
     *)
       return 1
       ;;
   esac
+}
+
+rtk_history_command_count() {
+  local history="$1" command_key="$2" pattern count
+  pattern="$(rtk_history_command_pattern "$command_key")" || return 1
+  count="$(printf '%s\n' "$history" | grep -Ec "$pattern" || true)"
+  printf '%s\n' "${count:-0}"
+}
+
+rtk_history_has_command() {
+  local history="$1" command_key="$2" count
+  count="$(rtk_history_command_count "$history" "$command_key")" || return 1
+  [ "${count:-0}" -gt 0 ]
+}
+
+rtk_history_command_counts_json() {
+  local history="$1" ls_count status_count log_count
+  ls_count="$(rtk_history_command_count "$history" ls)"
+  status_count="$(rtk_history_command_count "$history" status)"
+  log_count="$(rtk_history_command_count "$history" log)"
+  jq -n \
+    --argjson ls_count "$ls_count" \
+    --argjson status_count "$status_count" \
+    --argjson log_count "$log_count" \
+    '{ls:$ls_count,status:$status_count,log:$log_count}'
+}
+
+rtk_pending_history_command_count() {
+  local pending_payload="$1" command_key="$2"
+  printf '%s' "$pending_payload" | jq -r --arg key "$command_key" '
+    if ((.history_before_command_counts[$key] // null) | type) == "number" then
+      (.history_before_command_counts[$key] | tostring)
+    else
+      ""
+    end
+  ' 2>/dev/null || true
+}
+
+rtk_history_command_evidence_json() {
+  local before_ls="${1:-0}" before_status="${2:-0}" before_log="${3:-0}" after_ls="${4:-0}" after_status="${5:-0}" after_log="${6:-0}"
+  jq -n \
+    --argjson before_ls "$before_ls" \
+    --argjson before_status "$before_status" \
+    --argjson before_log "$before_log" \
+    --argjson after_ls "$after_ls" \
+    --argjson after_status "$after_status" \
+    --argjson after_log "$after_log" \
+    '{
+      ls:{before:$before_ls,after:$after_ls},
+      status:{before:$before_status,after:$after_status},
+      log:{before:$before_log,after:$after_log}
+    }'
+}
+
+rtk_history_require_fresh_command_counts() {
+  local before_ls="$1" before_status="$2" before_log="$3" after_ls="$4" after_status="$5" after_log="$6"
+  [ "$after_ls" -gt "$before_ls" ] || smoke_fail 1 "missing fresh RTK history evidence after smoke-start" "rtk ls -la . before_count=$before_ls after_count=$after_ls"
+  [ "$after_status" -gt "$before_status" ] || smoke_fail 1 "missing fresh RTK history evidence after smoke-start" "rtk git status --short before_count=$before_status after_count=$after_status"
+  [ "$after_log" -gt "$before_log" ] || smoke_fail 1 "missing fresh RTK history evidence after smoke-start" "rtk git log -n 2 --oneline before_count=$before_log after_count=$after_log"
 }
 
 rtk_history_after_pending_tail() {
@@ -579,7 +638,7 @@ smoke_status_preconditions() {
 }
 
 smoke_start() {
-  local status_payload hook_path hook_command hook_version history history_total history_tail history_hash tmp
+  local status_payload hook_path hook_command hook_version history history_total history_tail history_hash history_command_counts tmp
   status_payload="$(status_json false false)"
   smoke_status_preconditions "$status_payload"
   if printf '%s' "$status_payload" | jq -e '.compatibility == "verified" and ((.proof_source // "") != "")' >/dev/null 2>&1; then
@@ -592,6 +651,7 @@ smoke_start() {
   history_total="$(printf '%s\n' "$history" | rtk_history_total || true)"
   history_tail="$(printf '%s\n' "$history" | rtk_history_evidence_tail)"
   history_hash="$(printf '%s' "$history_tail" | sha256_text || true)"
+  history_command_counts="$(rtk_history_command_counts_json "$history_tail")"
   mkdir -p "$VBW_RTK_DIR"
   tmp="$(mktemp "$VBW_RTK_DIR/rtk-smoke-pending.XXXXXX")"
   jq -n \
@@ -605,6 +665,7 @@ smoke_start() {
     --arg history_before_total "$history_total" \
     --arg history_before_tail "$history_tail" \
     --arg history_before_sha256 "$history_hash" \
+    --argjson history_before_command_counts "$history_command_counts" \
     '{
       proof_type:$proof_type,
       status:$status,
@@ -617,6 +678,7 @@ smoke_start() {
       history_before_total_available: ($history_before_total != ""),
       history_before_tail:$history_before_tail,
       history_before_sha256:$history_before_sha256,
+      history_before_command_counts:$history_before_command_counts,
       expected_unprefixed_commands:["ls -la .","git status --short","git log -n 2 --oneline"]
     }' > "$tmp"
   chmod 600 "$tmp" 2>/dev/null || true
@@ -634,7 +696,7 @@ verify_bash_guard_smoke() {
 }
 
 write_runtime_smoke_proof() {
-  local status_payload="$1" pending_payload="$2" history_after_total="$3" history_after_sha256="$4" count_evidence="$5" tmp
+  local status_payload="$1" pending_payload="$2" history_after_total="$3" history_after_sha256="$4" count_evidence="$5" isolation_evidence="$6" command_evidence_json="$7" tmp
   local hook_command hook_version
   hook_command="$(printf '%s' "$status_payload" | jq -r '.global_hook_command')"
   hook_version="$(printf '%s' "$status_payload" | jq -r '.active_hook_rtk_version')"
@@ -653,6 +715,8 @@ write_runtime_smoke_proof() {
     --arg history_after_total "$history_after_total" \
     --arg history_after_sha256 "$history_after_sha256" \
     --arg count_evidence "$count_evidence" \
+    --arg isolation_evidence "$isolation_evidence" \
+    --argjson history_command_evidence "$command_evidence_json" \
     '{
       proof_type:$proof_type,
       status:$status,
@@ -673,6 +737,8 @@ write_runtime_smoke_proof() {
       history_after_total:(if $history_after_total == "" then null else ($history_after_total | tonumber) end),
       history_after_sha256:$history_after_sha256,
       history_count_evidence:$count_evidence,
+      history_isolation_evidence:$isolation_evidence,
+      history_command_evidence:$history_command_evidence,
       compatibility_basis:$compatibility_basis,
       upstream_caveat:$upstream_caveat
     }' > "$tmp"
@@ -682,7 +748,8 @@ write_runtime_smoke_proof() {
 
 smoke_finish() {
   local pending_payload status_payload hook_path hook_command hook_version pending_hook_command pending_hook_version
-  local history history_after_total history_before_total history_before_tail history_after_tail history_before_sha256 history_after_sha256 history_evidence count_evidence
+  local history history_after_total history_before_total history_before_tail history_after_tail history_before_sha256 history_after_sha256 history_evidence count_evidence isolation_evidence
+  local before_ls before_status before_log after_ls after_status after_log command_evidence_json
   [ -f "$RTK_PENDING_SMOKE_FILE" ] || smoke_fail 1 "pending smoke file missing" "$RTK_PENDING_SMOKE_FILE"
   jq empty "$RTK_PENDING_SMOKE_FILE" >/dev/null 2>&1 || smoke_fail 1 "pending smoke file is malformed" "$RTK_PENDING_SMOKE_FILE"
   pending_payload="$(cat "$RTK_PENDING_SMOKE_FILE")"
@@ -704,13 +771,17 @@ smoke_finish() {
   history_after_total="$(printf '%s\n' "$history" | rtk_history_total || true)"
   history_before_total="$(printf '%s' "$pending_payload" | jq -r '.history_before_total // empty')"
   history_before_tail="$(printf '%s' "$pending_payload" | jq -r '.history_before_tail // ""')"
+  before_ls="$(rtk_pending_history_command_count "$pending_payload" ls)"
+  before_status="$(rtk_pending_history_command_count "$pending_payload" status)"
+  before_log="$(rtk_pending_history_command_count "$pending_payload" log)"
+  after_ls="$(rtk_history_command_count "$history_after_tail" ls)"
+  after_status="$(rtk_history_command_count "$history_after_tail" status)"
+  after_log="$(rtk_history_command_count "$history_after_tail" log)"
   if [ -n "$history_before_sha256" ] && [ -n "$history_after_sha256" ] && [ "$history_before_sha256" = "$history_after_sha256" ]; then
     smoke_fail 1 "RTK history did not advance after smoke-start" "history tail hash unchanged"
   fi
   history_evidence="$(rtk_history_after_pending_tail "$history_before_tail" "$history")"
-  if [ -n "$history_before_tail" ] && [ -z "$history_evidence" ]; then
-    smoke_fail 1 "could not isolate RTK history entries after smoke-start" "pending history tail was not found in the after-history snapshot"
-  fi
+  isolation_evidence="exact_tail"
   count_evidence="unavailable"
   if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
     if [ $((history_after_total - history_before_total)) -lt 3 ]; then
@@ -720,13 +791,26 @@ smoke_finish() {
   else
     count_evidence="history_tail_changed_after_smoke_start"
   fi
+  if [ -n "$history_before_tail" ] && [ -z "$history_evidence" ]; then
+    if [ -z "$before_ls" ] || [ -z "$before_status" ] || [ -z "$before_log" ]; then
+      smoke_fail 1 "fresh smoke evidence requires a new /vbw:rtk verify attempt" "pending smoke file lacks history_before_command_counts"
+    fi
+    rtk_history_require_fresh_command_counts "$before_ls" "$before_status" "$before_log" "$after_ls" "$after_status" "$after_log"
+    history_evidence="$history_after_tail"
+    if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
+      isolation_evidence="command_counts_with_total_delta"
+    else
+      isolation_evidence="command_counts_with_tail_change"
+    fi
+  fi
   rtk_history_has_command "$history_evidence" ls || smoke_fail 1 "missing RTK history evidence" "rtk ls -la ."
   rtk_history_has_command "$history_evidence" status || smoke_fail 1 "missing RTK history evidence" "rtk git status --short"
   rtk_history_has_command "$history_evidence" log || smoke_fail 1 "missing RTK history evidence" "rtk git log -n 2 --oneline"
   verify_bash_guard_smoke || smoke_fail 1 "VBW Bash guard smoke verification failed" "expected scripts/bash-guard.sh to block synthetic destructive command with exit 2"
-  write_runtime_smoke_proof "$status_payload" "$pending_payload" "$history_after_total" "$history_after_sha256" "$count_evidence"
+  command_evidence_json="$(rtk_history_command_evidence_json "${before_ls:-0}" "${before_status:-0}" "${before_log:-0}" "$after_ls" "$after_status" "$after_log")"
+  write_runtime_smoke_proof "$status_payload" "$pending_payload" "$history_after_total" "$history_after_sha256" "$count_evidence" "$isolation_evidence" "$command_evidence_json"
   rm -f "$RTK_PENDING_SMOKE_FILE"
-  jq -n --arg status "pass" --arg proof_source "$RTK_PROOF_FILE" --arg history_count_evidence "$count_evidence" '{status:$status,proof_source:$proof_source,history_count_evidence:$history_count_evidence}'
+  jq -n --arg status "pass" --arg proof_source "$RTK_PROOF_FILE" --arg history_count_evidence "$count_evidence" --arg history_isolation_evidence "$isolation_evidence" '{status:$status,proof_source:$proof_source,history_count_evidence:$history_count_evidence,history_isolation_evidence:$history_isolation_evidence}'
 }
 
 status_json() {
@@ -1662,7 +1746,7 @@ verify_rtk() {
     "Config: " + (.config_state // "unknown") + " at " + (.config_path // "unknown") + "\n" +
     "Runtime: " + (if .compatibility == "verified" then "verified by runtime smoke proof " + .proof_source else "manual Claude Code smoke required before PASS" end) +
     (if (.compatibility == "verified" and (.updated_input_risk == true)) then "\nCaveat: " + (.diagnostic_caveat // "anthropics/claude-code#15897 remains an upstream diagnostic caveat") else "" end) +
-    (if .compatibility == "verified" then "" else "\nManual smoke: restart Claude Code, run the scoped /vbw:rtk verify Bash-tool sequence, confirm RTK rewrites and VBW bash-guard behavior, then record proof." end)
+    (if .compatibility == "verified" then "" else "\nManual smoke: run the scoped /vbw:rtk verify Bash-tool sequence; if it fails, inspect the RTK smoke failure diagnostic and rerun /vbw:rtk verify after addressing the local evidence gap." end)
   '
 }
 

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -510,7 +510,8 @@ rtk_history_evidence() {
 }
 
 rtk_history_evidence_tail() {
-  rtk_history_evidence | tail -n 40 2>/dev/null || true
+  # Callers keep full filtered evidence separately for command-count proof.
+  tail -n 40 2>/dev/null || true
 }
 
 rtk_history_command_pattern() {
@@ -654,7 +655,7 @@ smoke_start() {
   history="$(rtk_history_snapshot "$hook_path")"
   history_total="$(printf '%s\n' "$history" | rtk_history_total || true)"
   history_evidence="$(printf '%s\n' "$history" | rtk_history_evidence)"
-  history_tail="$(printf '%s\n' "$history_evidence" | tail -n 40 2>/dev/null || true)"
+  history_tail="$(printf '%s\n' "$history_evidence" | rtk_history_evidence_tail)"
   history_hash="$(printf '%s' "$history_tail" | sha256_text || true)"
   history_command_counts="$(rtk_history_command_counts_json "$history_evidence")"
   mkdir -p "$VBW_RTK_DIR"
@@ -772,7 +773,7 @@ smoke_finish() {
 
   history="$(rtk_history_snapshot "$hook_path")"
   history_after_evidence="$(printf '%s\n' "$history" | rtk_history_evidence)"
-  history_after_tail="$(printf '%s\n' "$history_after_evidence" | tail -n 40 2>/dev/null || true)"
+  history_after_tail="$(printf '%s\n' "$history_after_evidence" | rtk_history_evidence_tail)"
   history_before_sha256="$(printf '%s' "$pending_payload" | jq -r '.history_before_sha256 // ""')"
   history_after_sha256="$(printf '%s' "$history_after_tail" | sha256_text || true)"
   history_after_total="$(printf '%s\n' "$history" | rtk_history_total || true)"

--- a/scripts/rtk-manager.sh
+++ b/scripts/rtk-manager.sh
@@ -754,6 +754,7 @@ write_runtime_smoke_proof() {
 smoke_finish() {
   local pending_payload status_payload hook_path hook_command hook_version pending_hook_command pending_hook_version
   local history history_after_total history_before_total history_before_tail history_after_evidence history_after_tail history_before_sha256 history_after_sha256 history_evidence count_evidence isolation_evidence
+  local history_tail_hash_unchanged=false history_totals_available=false history_total_delta=0
   local before_ls before_status before_log after_ls after_status after_log command_evidence_json
   [ -f "$RTK_PENDING_SMOKE_FILE" ] || smoke_fail 1 "pending smoke file missing" "$RTK_PENDING_SMOKE_FILE"
   jq empty "$RTK_PENDING_SMOKE_FILE" >/dev/null 2>&1 || smoke_fail 1 "pending smoke file is malformed" "$RTK_PENDING_SMOKE_FILE"
@@ -784,17 +785,22 @@ smoke_finish() {
   after_status="$(rtk_history_command_count "$history_after_evidence" status)"
   after_log="$(rtk_history_command_count "$history_after_evidence" log)"
   if [ -n "$history_before_sha256" ] && [ -n "$history_after_sha256" ] && [ "$history_before_sha256" = "$history_after_sha256" ]; then
-    smoke_fail 1 "RTK history did not advance after smoke-start" "history tail hash unchanged"
+    history_tail_hash_unchanged=true
   fi
   history_evidence="$(rtk_history_after_pending_tail "$history_before_tail" "$history_after_evidence")"
   isolation_evidence="exact_tail"
   count_evidence="unavailable"
   if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
-    if [ $((history_after_total - history_before_total)) -lt 3 ]; then
+    history_totals_available=true
+    history_total_delta=$((history_after_total - history_before_total))
+    if [ "$history_total_delta" -lt 3 ]; then
       smoke_fail 1 "RTK history count did not increase by at least 3" "before=$history_before_total after=$history_after_total"
     fi
-    count_evidence="before=$history_before_total after=$history_after_total delta=$((history_after_total - history_before_total))"
+    count_evidence="before=$history_before_total after=$history_after_total delta=$history_total_delta"
   else
+    if [ "$history_tail_hash_unchanged" = "true" ]; then
+      smoke_fail 1 "RTK history did not advance after smoke-start" "history totals unavailable and evidence tail hash unchanged"
+    fi
     count_evidence="history_tail_changed_after_smoke_start"
   fi
   if [ -n "$history_before_tail" ] && [ -z "$history_evidence" ]; then
@@ -803,7 +809,7 @@ smoke_finish() {
     fi
     rtk_history_require_fresh_command_counts "$before_ls" "$before_status" "$before_log" "$after_ls" "$after_status" "$after_log"
     history_evidence="$history_after_evidence"
-    if [ -n "$history_before_total" ] && [ -n "$history_after_total" ]; then
+    if [ "$history_totals_available" = "true" ]; then
       isolation_evidence="command_counts_with_total_delta"
     else
       isolation_evidence="command_counts_with_tail_change"

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -381,7 +381,12 @@ else
   fail "rtk-manager can still pass full RTK history through argv during smoke verification"
 fi
 
+rtk_tail_policy_count="$(grep -Fc 'tail -n 40' "$RTK_MANAGER" || true)"
 if contains "$RTK_MANAGER" 'rtk_history_evidence()' \
+  && contains "$RTK_MANAGER" 'rtk_history_evidence_tail()' \
+  && contains_re "$RTK_MANAGER" 'history_tail=.*rtk_history_evidence_tail' \
+  && contains_re "$RTK_MANAGER" 'history_after_tail=.*rtk_history_evidence_tail' \
+  && [ "$rtk_tail_policy_count" -eq 1 ] \
   && contains "$RTK_MANAGER" 'rtk_history_command_count()' \
   && contains "$RTK_MANAGER" 'history_tail_hash_unchanged' \
   && contains "$RTK_MANAGER" 'history_totals_available' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -381,6 +381,22 @@ else
   fail "rtk-manager can still pass full RTK history through argv during smoke verification"
 fi
 
+if contains "$RTK_MANAGER" 'rtk_history_command_count()' \
+  && contains "$RTK_MANAGER" 'history_before_command_counts' \
+  && contains "$RTK_MANAGER" 'rtk_history_require_fresh_command_counts' \
+  && contains "$RTK_MANAGER" 'history_isolation_evidence' \
+  && contains "$RTK_MANAGER" 'history_command_evidence' \
+  && contains "$RTK_MANAGER" 'missing fresh RTK history evidence after smoke-start' \
+  && contains "$RTK_MANAGER" 'fresh smoke evidence requires a new /vbw:rtk verify attempt' \
+  && ! contains "$RTK_MANAGER" 'pending history tail was not found in the after-history snapshot' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish accepts parseable total tail mismatch with fresh command counts' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total tail mismatch with stale command counts' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish asks for fresh verify when tail mismatch pending lacks command counts'; then
+  pass "rtk-manager proves fresh smoke history with command counts when exact tail isolation is unavailable"
+else
+  fail "rtk-manager missing robust tail-mismatch smoke history proof contract"
+fi
+
 if contains "$RTK_MANAGER" 'compatibility_basis="runtime_smoke_passed"' \
   && contains "$RTK_MANAGER" 'proof_state="valid"' \
   && contains "$RTK_MANAGER" 'upstream_issue="anthropics/claude-code#15897"' \

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -383,6 +383,9 @@ fi
 
 if contains "$RTK_MANAGER" 'rtk_history_evidence()' \
   && contains "$RTK_MANAGER" 'rtk_history_command_count()' \
+  && contains "$RTK_MANAGER" 'history_tail_hash_unchanged' \
+  && contains "$RTK_MANAGER" 'history_totals_available' \
+  && contains "$RTK_MANAGER" 'history_total_delta' \
   && contains "$RTK_MANAGER" 'history_before_command_counts' \
   && contains "$RTK_MANAGER" 'history_command_counts="$(rtk_history_command_counts_json "$history_evidence")"' \
   && contains "$RTK_MANAGER" 'after_ls="$(rtk_history_command_count "$history_after_evidence" ls)"' \
@@ -390,12 +393,16 @@ if contains "$RTK_MANAGER" 'rtk_history_evidence()' \
   && contains "$RTK_MANAGER" 'history_isolation_evidence' \
   && contains "$RTK_MANAGER" 'history_command_evidence' \
   && contains "$RTK_MANAGER" 'missing fresh RTK history evidence after smoke-start' \
+  && contains "$RTK_MANAGER" 'history totals unavailable and evidence tail hash unchanged' \
   && contains "$RTK_MANAGER" 'fresh smoke evidence requires a new /vbw:rtk verify attempt' \
   && ! contains "$RTK_MANAGER" 'pending history tail was not found in the after-history snapshot' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish accepts parseable total tail mismatch with fresh command counts' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total tail mismatch with stale command counts' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total tail mismatch with stale commands outside stored tail' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish accepts parseable total unchanged tail with fresh prepended command counts' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total unchanged tail with stale prepended unrelated commands' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects count-unavailable tail mismatch with stale commands outside stored tail' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects count-unavailable unchanged tail with scoped-looking prepended commands' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish asks for fresh verify when tail mismatch pending lacks command counts'; then
   pass "rtk-manager proves fresh smoke history with command counts when exact tail isolation is unavailable"
 else

--- a/testing/verify-rtk-integration-contract.sh
+++ b/testing/verify-rtk-integration-contract.sh
@@ -381,8 +381,11 @@ else
   fail "rtk-manager can still pass full RTK history through argv during smoke verification"
 fi
 
-if contains "$RTK_MANAGER" 'rtk_history_command_count()' \
+if contains "$RTK_MANAGER" 'rtk_history_evidence()' \
+  && contains "$RTK_MANAGER" 'rtk_history_command_count()' \
   && contains "$RTK_MANAGER" 'history_before_command_counts' \
+  && contains "$RTK_MANAGER" 'history_command_counts="$(rtk_history_command_counts_json "$history_evidence")"' \
+  && contains "$RTK_MANAGER" 'after_ls="$(rtk_history_command_count "$history_after_evidence" ls)"' \
   && contains "$RTK_MANAGER" 'rtk_history_require_fresh_command_counts' \
   && contains "$RTK_MANAGER" 'history_isolation_evidence' \
   && contains "$RTK_MANAGER" 'history_command_evidence' \
@@ -391,6 +394,8 @@ if contains "$RTK_MANAGER" 'rtk_history_command_count()' \
   && ! contains "$RTK_MANAGER" 'pending history tail was not found in the after-history snapshot' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish accepts parseable total tail mismatch with fresh command counts' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total tail mismatch with stale command counts' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects parseable total tail mismatch with stale commands outside stored tail' \
+  && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish rejects count-unavailable tail mismatch with stale commands outside stored tail' \
   && contains "$ROOT/tests/rtk-manager.bats" 'smoke-finish asks for fresh verify when tail mismatch pending lacks command counts'; then
   pass "rtk-manager proves fresh smoke history with command counts when exact tail isolation is unavailable"
 else

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -1338,6 +1338,65 @@ JSON
   [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
 }
 
+@test "rtk-manager: smoke-finish rejects parseable total tail mismatch with stale commands outside stored tail" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 100' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 41); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 103' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk unrelated-after-1' \
+    'rtk unrelated-after-2' \
+    'rtk unrelated-after-3'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
+  [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
+@test "rtk-manager: smoke-finish accepts parseable total tail mismatch with fresh counts after old outside-tail baseline" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 100' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 41); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 103' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 0 ]
+  jq -e '.history_isolation_evidence == "command_counts_with_total_delta"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.ls.before == 1 and .history_command_evidence.ls.after == 2' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.status.before == 1 and .history_command_evidence.status.after == 2' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.log.before == 1 and .history_command_evidence.log.after == 2' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+}
+
 @test "rtk-manager: smoke-finish accepts count-unavailable proof only from post-start history entries" {
   write_fake_rtk "0.1.0"
   write_present_rtk_config
@@ -1386,6 +1445,31 @@ JSON
     'rtk git status --short' \
     'rtk git log -n 2 --oneline' \
     'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk unrelated-after-smoke'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
+  [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
+@test "rtk-manager: smoke-finish rejects count-unavailable tail mismatch with stale commands outside stored tail" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 41); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
   run rtk_manager smoke-start
   [ "$status" -eq 0 ]
   write_rtk_history \

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -1287,6 +1287,57 @@ JSON
   [[ "$output" != *"Manual smoke:"* ]]
 }
 
+@test "rtk-manager: smoke-finish accepts parseable total tail mismatch with fresh command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 10' \
+    'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 13' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 0 ]
+  [ -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+  jq -e '.history_count_evidence == "before=10 after=13 delta=3"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_isolation_evidence == "command_counts_with_total_delta"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.ls.before == 0 and .history_command_evidence.ls.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.status.before == 0 and .history_command_evidence.status.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.log.before == 0 and .history_command_evidence.log.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+}
+
+@test "rtk-manager: smoke-finish rejects parseable total tail mismatch with stale command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 10' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 13' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk unrelated-1' \
+    'rtk unrelated-2' \
+    'rtk unrelated-3'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
+  [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
 @test "rtk-manager: smoke-finish accepts count-unavailable proof only from post-start history entries" {
   write_fake_rtk "0.1.0"
   write_present_rtk_config
@@ -1305,6 +1356,72 @@ JSON
   jq -e '.history_after_total == null' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
   jq -e '.history_count_evidence == "history_tail_changed_after_smoke_start"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
   jq -e '.history_before_sha256 != "" and .history_after_sha256 != "" and .history_before_sha256 != .history_after_sha256' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+}
+
+@test "rtk-manager: smoke-finish accepts count-unavailable tail mismatch with fresh command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history 'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 0 ]
+  [ -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+  jq -e '.history_count_evidence == "history_tail_changed_after_smoke_start"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_isolation_evidence == "command_counts_with_tail_change"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.ls.before == 0 and .history_command_evidence.ls.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+}
+
+@test "rtk-manager: smoke-finish rejects count-unavailable tail mismatch with stale command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline' \
+    'rtk unrelated-after-smoke'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
+  [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
+@test "rtk-manager: smoke-finish asks for fresh verify when tail mismatch pending lacks command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 10' \
+    'rtk old-before-smoke'
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  jq 'del(.history_before_command_counts)' "$VBW_RTK_DIR/rtk-compatibility-smoke-pending.json" > "$TEST_TEMP_DIR/pending-old.json"
+  mv "$TEST_TEMP_DIR/pending-old.json" "$VBW_RTK_DIR/rtk-compatibility-smoke-pending.json"
+  write_rtk_history \
+    'Total commands: 13' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fresh smoke evidence requires a new /vbw:rtk verify attempt"* ]]
+  [[ "$output" == *"pending smoke file lacks history_before_command_counts"* ]]
+  [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
 }
 
 @test "rtk-manager: smoke-finish rejects count-unavailable unchanged history" {
@@ -1452,6 +1569,17 @@ JSON
   [ "$status" -eq 1 ]
   [[ "$output" == *"pending smoke file is malformed"* ]]
   [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
+@test "rtk-manager: verify output does not recommend restart for runtime smoke" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  run rtk_manager verify
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Manual smoke:"* ]]
+  [[ "$output" != *"restart Claude Code"* ]]
+  [[ "$output" == *"run the scoped /vbw:rtk verify Bash-tool sequence"* ]]
 }
 
 @test "rtk-manager: bash-guard smoke failure prevents proof creation" {

--- a/tests/rtk-manager.bats
+++ b/tests/rtk-manager.bats
@@ -1397,6 +1397,66 @@ JSON
   jq -e '.history_command_evidence.log.before == 1 and .history_command_evidence.log.after == 2' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
 }
 
+@test "rtk-manager: smoke-finish accepts parseable total unchanged tail with fresh prepended command counts" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history 'Total commands: 100'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 103' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-finish
+  [ "$status" -eq 0 ]
+  jq -e '.history_count_evidence == "before=100 after=103 delta=3"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_isolation_evidence == "command_counts_with_total_delta"' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_before_sha256 != "" and .history_after_sha256 != "" and .history_before_sha256 == .history_after_sha256' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.ls.before == 0 and .history_command_evidence.ls.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.status.before == 0 and .history_command_evidence.status.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+  jq -e '.history_command_evidence.log.before == 0 and .history_command_evidence.log.after == 1' "$VBW_RTK_DIR/rtk-compatibility-proof.json"
+}
+
+@test "rtk-manager: smoke-finish rejects parseable total unchanged tail with stale prepended unrelated commands" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history \
+    'Total commands: 100' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'Total commands: 103' \
+    'rtk unrelated-after-1' \
+    'rtk unrelated-after-2' \
+    'rtk unrelated-after-3' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
+  [[ "$output" != *"history tail hash unchanged"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
 @test "rtk-manager: smoke-finish accepts count-unavailable proof only from post-start history entries" {
   write_fake_rtk "0.1.0"
   write_present_rtk_config
@@ -1481,6 +1541,31 @@ JSON
   [ "$status" -eq 1 ]
   [[ "$output" == *"missing fresh RTK history evidence after smoke-start"* ]]
   [[ "$output" != *"pending history tail was not found"* ]]
+  [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
+}
+
+@test "rtk-manager: smoke-finish rejects count-unavailable unchanged tail with scoped-looking prepended commands" {
+  write_fake_rtk "0.1.0"
+  write_present_rtk_config
+  write_rtk_settings_hook
+  write_rtk_history 'rtk previous command'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-start
+  [ "$status" -eq 0 ]
+  write_rtk_history \
+    'rtk previous command' \
+    'rtk ls -la .' \
+    'rtk git status --short' \
+    'rtk git log -n 2 --oneline'
+  for i in $(seq 1 45); do
+    printf 'rtk old-filler-%02d\n' "$i" >> "$FAKE_RTK_HISTORY_FILE"
+  done
+  run rtk_manager smoke-finish
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"RTK history did not advance after smoke-start"* ]]
+  [[ "$output" == *"history totals unavailable and evidence tail hash unchanged"* ]]
   [ ! -f "$VBW_RTK_DIR/rtk-compatibility-proof.json" ]
 }
 


### PR DESCRIPTION
## Linked Issue

Fixes #548

## What

This changes the RTK runtime smoke proof logic so `/vbw:rtk --verify` can pass when RTK’s after-history snapshot no longer contains the exact saved pre-smoke tail, as long as stronger evidence proves freshness: parseable total history count delta plus increased full-history counts for each required scoped RTK command. The patch updates `scripts/rtk-manager.sh`, adds BATS regression coverage in `tests/rtk-manager.bats`, and strengthens the structural contract in `testing/verify-rtk-integration-contract.sh`.

## Why

The root bug was treating a compact 40-line history tail as an ordering-invariant proof boundary. RTK history can be truncated, reformatted, prepended, or reordered between snapshots, so byte-for-byte tail replay is too brittle. The durable invariant is: exact-tail isolation is preferred when available, but when it is unavailable, freshness must be proven by independent full-history command-count increases and, when totals are parseable, a total delta of at least three. Count-unavailable unchanged-tail cases remain conservative and fail safely.

## How

- `scripts/rtk-manager.sh`: records pre-smoke command counts from full filtered RTK history evidence, computes post-smoke counts from full filtered evidence, defers unchanged-tail failure until total/count signals are evaluated, accepts fallback proof only after every required command count increases, and uses `rtk_history_evidence_tail()` as the single compact-tail derivation helper.
- `tests/rtk-manager.bats`: adds regression coverage for tail mismatch, stale outside-tail evidence, unchanged-tail parseable-total acceptance, unchanged-tail stale rejection, count-unavailable unchanged-tail rejection, and unchanged diagnostic behavior.
- `testing/verify-rtk-integration-contract.sh`: adds grep-level guards that the robust command-count history proof invariant remains present, covered by BATS tests, and keeps the 40-line tail policy centralized in the helper.

## Acceptance criteria verification

1. `smoke-finish` tolerates exact-tail mismatch with parseable delta >= 3 and scoped RTK evidence: satisfied by the command-count fallback in `scripts/rtk-manager.sh` and covered by `smoke-finish accepts parseable total tail mismatch with fresh command counts` plus `smoke-finish accepts parseable total unchanged tail with fresh prepended command counts`.
2. Stale command evidence remains rejected for parseable-total and count-unavailable cases: satisfied by `rtk_history_require_fresh_command_counts` and covered by stale tail/outside-tail/unchanged-tail BATS tests.
3. RTK-prefixed evidence for `ls -la .`, `git status --short`, and `git log -n 2 --oneline` remains required: satisfied by `rtk_history_command_pattern`, final `rtk_history_has_command` checks, and missing evidence / missing `--oneline` BATS tests.
4. Missing `--oneline`, missing evidence, hook command/version changes, malformed pending smoke, insufficient count delta, and Bash-guard failure still reject proof creation: covered by existing and retained `smoke-finish` BATS cases.
5. Diagnostics remain actionable and do not tell users to restart Claude Code for locally explainable smoke evidence gaps: `verify` output now points to local smoke diagnostics and rerun guidance; covered by `verify output does not recommend restart for runtime smoke`.
6. BATS cover the real-world pre-tail mismatch path: covered by parseable tail-mismatch acceptance and unchanged-tail/prepended-history acceptance regressions.
7. `testing/verify-rtk-integration-contract.sh` asserts the scoped smoke helper and new history-isolation invariant: the RTK contract check now requires the new state variables, diagnostics, helper call sites, and BATS test names.
8. `bash testing/run-all.sh` passes from the feature worktree: verified locally from `/Users/dpearson/repos/vibe-better-with-claude-code-vbw-worktrees/fix-548-rtk-history-tail-mismatch` with lint 1/1, contracts 48/48, BATS 3214 passed / 0 failed.

## Testing

- `bash testing/verify-rtk-integration-contract.sh` — 69 PASS, 0 FAIL
- `bats --filter 'unchanged tail|tail mismatch|smoke-finish' tests/rtk-manager.bats` — 21 tests, 0 failures
- `bats tests/rtk-manager.bats` — 90 tests, 0 failures
- `bash testing/run-all.sh` — lint 1/1, contracts 48/48, BATS 3214 passed / 0 failed
- GitHub Actions on `31d1d4e096dfa817121fda2c9d4e68aea990d347` — CI_GREEN, all 18 checks passed

## QA summary

- Primary QA: 3 rounds completed.
  - Round 1: 1 high contract finding fixed in `d440e3d6` (stale required commands outside saved 40-line tail).
  - Round 2: 1 high contract finding fixed in `b1e89445` (unchanged tail hash short-circuited parseable total/count proof).
  - Round 3: clean; evidence commit `6eb693ee`.
- Cross-model QA: skipped because this is a GPT-class Copilot session; workflow gate only runs GPT-5.4 cross-model review from Opus-class sessions.
- Copilot PR review: 2 rounds completed.
  - Round 1: 1 low observation fixed in `31d1d4e0` (`rtk_history_evidence_tail()` helper was unused and tail policy duplicated).
  - Round 2: clean (`COMMENTED` with no comments) on `31d1d4e096dfa817121fda2c9d4e68aea990d347`.
- CI/CD: all required checks green on the latest commit.
- Post-review main sync: `origin/main` had 0 new commits; no merge or conflict-resolution QA re-run needed.
- False positives: none.
