### PR TITLE
fix(execute): route teams by dependency width

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Think of it as project management for the post-dignity era of software developme
 
 Most Claude Code plugins were built for the subagent era, one main session spawning helper agents that report back and die. Much like the codebases they produce. VBW is designed from the ground up for the platform features that changed the game:
 
-- **Agent Teams for real parallelism.** `/vbw:vibe` creates a team of Dev teammates that execute tasks concurrently, each in their own context window. `/vbw:map` runs 4 Scout teammates in parallel to analyze your codebase. This isn't "spawn a subagent and wait" -- it's coordinated teamwork with a shared task list and direct inter-agent communication. Agent health monitoring tracks lifecycle events, detects orphaned teammates, and recovers stuck agents via circuit breakers.
+- **Agent Teams for real parallelism.** `/vbw:vibe` uses dependency-aware routing: true Dev teams are created when plans have real parallel delegate work, while linear dependency chains use serialized Dev subagents to avoid fake coordination overhead. `/vbw:map` runs 4 Scout teammates in parallel to analyze your codebase. When teams are used, this isn't "spawn a subagent and wait" -- it's coordinated teamwork with a shared task list and direct inter-agent communication. Agent health monitoring tracks lifecycle events, detects orphaned teammates, and recovers stuck agents via circuit breakers.
 
 - **Native hooks for continuous verification.** 24 hooks across 11 event types run automatically -- validating SUMMARY.md structure, checking commit format, validating frontmatter descriptions, gating task completion, blocking sensitive file access, enforcing plan file boundaries, managing session lifecycle, tracking agent health and cost attribution, tracking session metrics, pre-flight prompt validation, and post-compaction context verification. No more spawning a QA agent after every task. The platform enforces it, not the prompt.
 
@@ -115,11 +115,11 @@ Agent Teams are [experimental with known limitations](https://code.claude.com/do
 
 - **Task status lag.** Teammates sometimes forget to mark tasks complete. VBW's `TaskCompleted` hook treats commit matching as an advisory signal for execute-protocol tasks instead of a universal blocking gate, so manual or non-code tasks do not get stranded at `in_progress` when no commit exists or the wording diverges. The `TeammateIdle` hook runs a tiered SUMMARY.md gate — all summaries present passes immediately, conventional commit format only grants a 1-plan grace period, and 2+ missing summaries block regardless.
 
-- **Shutdown coordination.** VBW defines `shutdown_request`/`shutdown_response` schemas in the typed communication protocol. After phase work completes, the orchestrator sends `shutdown_request` to every teammate, waits for acknowledgment, then calls `TeamDelete`. All 6 team-participating agents (Dev, QA, Scout, Lead, Debugger, Docs) have explicit shutdown handlers with mechanical SendMessage tool-call instructions. Architect is planning-only and excluded from the shutdown protocol. If shutdown stalls or agents linger, `/vbw:doctor --cleanup` detects and cleans stale teams, orphan processes, and dangling PIDs.
+- **Shutdown coordination.** VBW defines `shutdown_request`/`shutdown_response` schemas in the typed communication protocol. After a true team run completes, the orchestrator sends `shutdown_request` to every teammate, waits for acknowledgment, then calls `TeamDelete`. Serialized subagent, turbo, and internal direct runs skip team shutdown because no team was created. All 6 team-participating agents (Dev, QA, Scout, Lead, Debugger, Docs) have explicit shutdown handlers with mechanical SendMessage tool-call instructions. Architect is planning-only and excluded from the shutdown protocol. If shutdown stalls or agents linger, `/vbw:doctor --cleanup` detects and cleans stale teams, orphan processes, and dangling PIDs.
 
 - **File conflicts.** Plans decompose work into tasks with explicit file ownership. Dev teammates operate on disjoint file sets by design, enforced at runtime by the `file-guard.sh` hook that blocks writes to files not declared in the active plan.
 
-- **Worktree isolation.** Each Dev agent gets its own git worktree — physical filesystem isolation, not just file-list enforcement. Six scripts handle the full lifecycle: create, merge, cleanup, status, targeting, and agent mapping. Off by default; set `worktree_isolation` to `"on"` in config to enable. See [Execution Model](#execution-model) for how this interacts with parallel plans and lease locks.
+- **Worktree isolation.** Each Dev plan can get its own git worktree — physical filesystem isolation, not just file-list enforcement — whether execution is true-team parallel or serialized by dependencies. Six scripts handle the full lifecycle: create, merge, cleanup, status, targeting, and agent mapping. Off by default; set `worktree_isolation` to `"on"` in config to enable. See [Execution Model](#execution-model) for how this interacts with dependency routing and lease locks.
 
 Agent Teams ship with seven known limitations. VBW addresses all of them. The eighth... that you're using AI to write software doesn't need a fix. It needs an intervention.
 
@@ -298,7 +298,7 @@ Milestone (your project goal)
 
 ### How Agents Execute Work
 
-When you run `/vbw:vibe` and it enters Execute mode, the **Lead** agent orchestrates everything. It never writes code itself — it spawns **Dev** teammates and assigns each one a plan.
+When you run `/vbw:vibe` and it enters Execute mode, the **Lead** agent orchestrates everything. It never writes code itself — it routes runnable plans to **Dev** agents. Dependency-aware routing chooses true Agent Teams only for real parallel delegate work; otherwise it uses serialized Dev subagents.
 
 ```text
  Lead (orchestrator)
@@ -311,7 +311,7 @@ Each Dev agent reads its assigned PLAN.md and works through the tasks in order: 
 
 **Whether plans actually run in parallel depends on their dependencies.** Each plan can declare `depends_on` in its YAML frontmatter — if Plan 02 depends on Plan 01, Dev-02 waits until Dev-01 finishes. Plans with no dependencies start immediately. In practice, the Architect often chains plans sequentially (Plan 01 → 02 → 03), which means they execute one at a time even though the mechanism supports parallelism.
 
-After all Devs finish, the Lead runs QA (if not skipped), then shuts down the team.
+After all Devs finish, the Lead runs QA (if not skipped). It shuts down a team only if the run actually used true team mode; serialized subagent, turbo, and internal direct runs clear delegation state without SendMessage/TeamDelete.
 
 ### Concurrency and File Conflicts
 
@@ -341,7 +341,7 @@ This is the one command. Run it, and VBW figures out what to do next:
 
 - **No project defined?** It asks about your project, gathers requirements, and creates a phased roadmap.
 - **Phases ready but not planned?** The Lead agent researches, decomposes, and produces plans.
-- **Plans ready but not built?** Dev teammates execute in parallel with atomic commits and continuous verification.
+- **Plans ready but not built?** Dev agents execute with atomic commits and continuous verification. True teams are used for real parallel plan fan-out; linear dependency chains run as serialized subagents.
 - **Everything built?** It tells you and suggests wrapping up.
 
 You don't need to know which state your project is in. VBW knows. Just keep running `/vbw:vibe` and it handles the rest — planning, building, verifying — one phase at a time. Or if you're feeling brave, set your autonomy to `pure-vibe` and it'll loop through every remaining phase without stopping.
@@ -770,13 +770,13 @@ Controls when VBW creates an Agent Team (multiple color-coded Dev agents) vs usi
 
 | Value | Behavior |
 | :--- | :--- |
-| `always` | Creates a team for every phase, even with 1 plan. Maximum agent visibility. |
-| `auto` | Creates a team only when 2+ plans exist. Single plan = single agent, lower overhead. Default. Smart routing may further downgrade simple plans to turbo (no team). |
+| `always` | Forces team mode for delegate-eligible work, including linear delegate graphs. Does not override phase-level turbo, smart-routed turbo, or internal direct segments. |
+| `auto` | Creates a true team only when dependency-aware routing finds real parallel delegate work (`max_parallel_width > 1`). Linear graphs and single delegate plans use serialized subagents. Smart routing may further downgrade simple plans to turbo (no team). Default. |
 | `never` | Never creates teams. All agents run as sequential subagents. Disables parallel execution entirely. |
 
 If `prefer_teams` requests team mode but the live tool set cannot express real team semantics, VBW now emits `⚠ Agent Teams not enabled — using non-team mode` and falls back to explicit non-team execution. It does **not** substitute plain background agents without `team_name` and pretend a team was created.
 
-This setting determines whether parallel execution is even possible. With a single agent (1 plan, no team), there's no concurrency by definition. `auto` also creates teams for ambiguous bugs in debug mode. Note: Planning always uses sequential subagents (Scout → Lead), not teams — `prefer_teams` only affects Execute and debug/map modes.
+This setting determines whether true team execution is allowed for delegate-eligible Execute work. With a single delegate plan or a real dependency chain, `auto` chooses serialized subagents because there is no useful parallelism. `auto` also creates teams for ambiguous bugs in debug mode. Note: Planning always uses sequential subagents (Scout → Lead), not teams — `prefer_teams` only affects Execute and debug/map modes.
 
 #### `worktree_isolation` — Filesystem Isolation
 

--- a/agents/vbw-lead.md
+++ b/agents/vbw-lead.md
@@ -43,10 +43,10 @@ Display: `✓ Lead: Research complete -- {N} files read, context loaded`
 ### Stage 2: Decompose
 Display: `◆ Lead: Decomposing phase into plans...`
 Break phase into 3-5 plans, each executable by one Dev session.
-1. **Maximize wave parallelism.** Each plan is assigned to a separate Dev agent. Plans in the same wave run simultaneously. Design plans so the maximum number can run in wave 1 (no deps). Only add `depends_on` when there is a real data/file dependency — not just logical ordering preference.
+1. **Model real dependencies.** Same-wave plans may run in true team mode only when they are genuinely independent; serialized Dev subagents are valid for real linear chains. Independent API/UI changes with disjoint files may share a wave; a migration followed by model updates is a valid linear chain.
 2. **Minimize file overlap between same-wave plans.** Two plans in the same wave must NOT modify the same files — this causes merge conflicts when agents work in parallel. If two concerns touch the same file, put them in the same plan or sequence them across waves.
 3. **Right-size for agents.** 3-5 tasks/plan. Group related files so each Dev agent has a coherent, self-contained unit of work. Each task = one commit, each plan = one SUMMARY.md.
-4. **Wave structure summary.** After decomposing, verify: Wave 1 should contain 2+ plans when possible. Single-plan waves waste parallelism. If wave 1 has only 1 plan, re-examine whether dependencies are real or assumed.
+4. **Wave structure summary.** After decomposing, verify same-wave work is truly independent and linear chains reflect real dependencies. Do not invent independence just to increase wave 1 size.
 5. Reference CONCERNS.md in must_haves. Embed REQ-IDs in task descriptions.
 6. Wire skills: add SKILL.md as `@` ref in `<context>`, list in `skills_used`.
 7. Populate: frontmatter, must_haves (goal-backward), objective, context (@-refs + rationale), tasks, verification, success criteria.
@@ -54,7 +54,7 @@ Display: `  ✓ Plan {NN}: {title} ({N} tasks, wave {W})`
 
 ### Stage 3: Self-Review
 Display: `◆ Lead: Self-reviewing plans...`
-Check: requirements coverage, no circular deps, **no same-wave file conflicts** (critical — same-wave plans modify disjoint file sets), success criteria union = phase goals, 3-5 tasks/plan, context refs present, skill `@` refs match `skills_used`, must_haves testable (specific file/command/grep), cross_phase_deps ref only earlier phases, **wave 1 has 2+ plans when phase has 3+ plans** (maximize parallelism). Fix inline. Standalone review: skip to here.
+Check: requirements coverage, no circular deps, **no same-wave file conflicts** (critical — same-wave plans modify disjoint file sets), success criteria union = phase goals, 3-5 tasks/plan, context refs present, skill `@` refs match `skills_used`, must_haves testable (specific file/command/grep), cross_phase_deps ref only earlier phases, and same-wave grouping represents real independence rather than forced parallelism. Fix inline. Standalone review: skip to here.
 
 **Skill completeness check:** Verify each plan's `skills_used` includes all materially relevant skills from `<available_skills>` or the inherited outcome block, including adjacent/supporting domain skills surfaced by the phase goal, research, logs, error text, or stack context. If a relevant skill is missing from any plan's `skills_used`, add it now.
 Display: `✓ Lead: Self-review complete -- {issues found and fixed | no issues found}`

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1299,7 +1299,7 @@ This mode handles the case where a milestone was archived before UAT issues were
      LEAD_MODEL="$RESOLVED_MODEL"
      LEAD_MAX_TURNS="$RESOLVED_MAX_TURNS"
      ```
-   **No team creation in Plan mode.** Scout (step 3) and Lead are sequential — Scout must complete before Lead starts (Lead reads the RESEARCH.md). Teams are only for parallel Dev agents in Execute mode (`prefer_teams` is evaluated there, not here). Always spawn Lead as a plain subagent.
+  **No team creation in Plan mode.** Scout (step 3) and Lead are sequential — Scout must complete before Lead starts (Lead reads the RESEARCH.md). Execute mode may later choose true team mode or serialized Dev subagents based on dependency-aware routing; `prefer_teams` is evaluated there, not here. Always spawn Lead as a plain subagent.
   - Before composing the Lead task description, evaluate installed skills visible in your system context — read each skill's description and select all materially helpful installed skills for this task, including adjacent/supporting domain skills surfaced by the prompt, logs, error text, related files, or stack context — not just the single most direct skill. The Lead prompt MUST begin with exactly one explicit skill outcome block: use `<skill_activation>{For each selected skill: "Call Skill({skill-name})"}</skill_activation>` when one or more installed skills are preselected at orchestration time, or `<skill_no_activation>Evaluated installed skills for this task. No skills were preselected at orchestration time. Reason: {brief task-specific reason}.</skill_no_activation>` when none are preselected. Silent omission of both blocks is invalid. After evaluating, state the skill outcome in your response (e.g., "Skills: activating {skill-name}" or "Skills: none preselected — {reason}") so the user has visibility before the agent is spawned. Example: if the prompt or error mentions SwiftData, include `swiftdata` alongside relevant test/build/debug skills. After calling `Skill(...)`, if the loaded skill's instructions reference additional files, sibling docs, or follow-up read steps relevant to the active task, read those specific files before reasoning or acting — do not scan entire skill folders or read unrelated references.
   - If one or more skills were preselected, run `bash "{plugin-root}/scripts/extract-skill-follow-up-files.sh" "{all preselected skill names from the activation block}" 2>/dev/null || true` before spawning the phase planning Lead. If the helper prints a `<skill_follow_up_files>` block, paste it immediately after the follow-up-read sentence in the spawned payload. Otherwise omit that block.
   - Use this payload prefix as the FIRST lines of the phase planning Lead prompt:
@@ -1324,7 +1324,7 @@ This mode handles the case where a milestone was archived before UAT issues were
    - Spawn vbw-lead as subagent via Task tool with compiled context (or full file list as fallback).
    - **CRITICAL:** Set `subagent_type: "vbw:vbw-lead"` and `model: "${LEAD_MODEL}"` in the Task tool invocation. If `LEAD_MAX_TURNS` is non-empty, also pass `maxTurns: ${LEAD_MAX_TURNS}`. If `LEAD_MAX_TURNS` is empty, do NOT include maxTurns (omitting it = unlimited).
    - **CRITICAL:** If a RESEARCH.md was found or created in step 3, include in the Lead prompt: `Read {research-path} for full research findings before planning.` where `{research-path}` is the per-plan or legacy path from step 3. The Lead must read the file itself — do NOT substitute an inlined summary.
-   - **CRITICAL:** Include in the Lead prompt: "Plans will be executed by a team of parallel Dev agents — one agent per plan. Maximize wave 1 plans (no deps) so agents start simultaneously. Ensure same-wave plans modify disjoint file sets to avoid merge conflicts."
+  - Required Lead guidance: "Execute may run plans as true team teammates or as serialized Dev subagents. Model real dependencies accurately. Same-wave plans must be genuinely independent and modify disjoint file sets; linear chains are valid when dependencies are real. Do not invent independence to increase wave 1 size — dependency-aware Execute uses teams only for real parallel delegate work, and false same-wave grouping can cause stale inputs or file conflicts."
    - **CRITICAL:** Include in the Lead prompt: `Use resolve-artifact-path.sh to compute plan filenames: bash ${RESOLVE_SCRIPT} plan "{phase-dir}" --plan-number {MM}` where `RESOLVE_SCRIPT` is the path from step 3. The script returns the canonical filename (e.g., `03-01-PLAN.md`). Call it once per plan with the plan number.
    - Display `◆ Spawning Lead agent...` -> `✓ Lead agent complete`.
 8. **Normalize plan filenames:**
@@ -1362,7 +1362,7 @@ This mode handles the case where a milestone was archived before UAT issues were
 
 ### Mode: Execute
 
-**Execute-mode invariant:** Parallel execution is only valid when the live tool set can create real team-scoped teammates. If real team semantics cannot be established, execute mode must warn and fall back to explicit non-team execution. Never simulate a team with background `Agent` spawns that lack `team_name`.
+**Execute-mode invariant:** Parallel execution is only valid when dependency-aware routing finds real parallel delegate work and the live tool set can create real team-scoped teammates. If routing selects serialized subagents, turbo/internal direct, or real team semantics cannot be established, execute mode must fall back to explicit non-team execution. Never simulate a team with background `Agent` spawns that lack `team_name`.
 
 Read `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/references/execute-protocol.md` and follow its instructions.
 
@@ -1666,7 +1666,7 @@ FAIL -> STOP with remediation suggestions. WARN -> proceed with warnings.
 
 After Execute mode completes (autonomy=pure-vibe only): if more unbuilt phases exist, auto-continue to next phase (Plan + Execute). Loop until `next_phase_state=all_done` or error. Other autonomy levels: STOP after phase.
 
-**CRITICAL — Between iterations:** Before starting the next phase's Plan mode, verify ALL agents from the previous phase (Dev, QA) have been shut down via the Execute mode Step 5 HARD GATE. Do NOT enter Plan mode while prior Execute agents are still active. If unsure (e.g., after compaction), send `shutdown_request` to any teammates that may still exist from the prior Execute team and call TeamDelete before continuing.
+**CRITICAL — Between iterations:** Before starting the next phase's Plan mode, inspect the prior Execute delegation marker/state. Send `shutdown_request` and call TeamDelete only when the prior run actually persisted `delegation_mode=team` with a real `TEAM_NAME`. If the prior run used serialized subagents, turbo/internal direct, or fallback non-team mode, rely on completed subagent/direct execution plus the cleared delegation state; do not send team shutdown messages without a real team.
 
 ## Output Format
 

--- a/docs/vbw-vs-gsd-source-validated.md
+++ b/docs/vbw-vs-gsd-source-validated.md
@@ -245,8 +245,8 @@ GSD's Nyquist compliance check (ensuring plans don't exceed ~50% context) is a u
 
 | Feature | VBW | GSD |
 |---------|-----|-----|
-| **Parallelism** | Agent Teams (persistent teammates with shared task lists) | Wave-based parallel execution (dependency graph → wave grouping) |
-| **Isolation** | Worktree isolation (physical filesystem separation) | No filesystem isolation |
+| **Parallelism** | Dependency-aware routing: Agent Teams for real fan-out, serialized Dev subagents for linear graphs | Wave-based parallel execution (dependency graph → wave grouping) |
+| **Isolation** | Worktree isolation per plan when enabled (physical filesystem separation for team or serialized execution) | No filesystem isolation |
 | **File access control** | `file-guard.sh` hook + `lease-lock.sh` locking | Instruction-level per-plan file boundaries |
 | **Deviation handling** | Event logging, SUMMARY.md deviation section | 4 structured deviation rules in executor agent |
 | **Checkpoints** | `autonomous: false` + UAT CHECKPOINTs | 3 formal checkpoint types (human-verify, decision, human-action) |
@@ -258,7 +258,7 @@ GSD's Nyquist compliance check (ensuring plans don't exceed ~50% context) is a u
 
 GSD's checkpoint system is more formally specified than VBW's. Three distinct types with structured XML (`checkpoint:human-verify`, `checkpoint:decision`, `checkpoint:human-action`) each with documented presentation formats, usage frequency (90%/9%/1%), and auto-mode bypass rules. GSD's `checkpoints.md` reference (29KB) includes service CLI references, authentication gate protocols, and environment automation patterns.
 
-VBW's worktree isolation and lease locking provide stronger parallel execution guarantees. GSD relies on instruction-level file boundaries.
+VBW's worktree isolation and lease locking provide stronger execution guarantees when plans can run in parallel, while dependency-aware routing avoids team overhead for linear graphs. GSD relies on instruction-level file boundaries.
 
 GSD's 4 deviation rules are well-defined:
 1. Auto-fix bugs discovered during implementation
@@ -331,7 +331,7 @@ Different approaches to interruptions: VBW renumbers directories, file prefixes,
 |------------|---------------|----------------|
 | **Blocking platform hooks (exit 2)** | `hard-gate.sh`, `qa-gate.sh`, `file-guard.sh`, `bash-guard.sh`, `security-filter.sh`, `archive-uat-guard.sh` | Model cannot bypass these during compaction or context overflow |
 | **Platform-enforced agent permissions** | `disallowedTools` in agent YAML — Scout cannot write files; QA restricted to persistence via `write-verification.sh` | Verified tool restriction at the platform level, not instruction level |
-| **Worktree isolation** | `worktree-create.sh`, `worktree-target.sh`, `worktree-agent-map.sh` | Physical filesystem separation for parallel agents |
+| **Worktree isolation** | `worktree-create.sh`, `worktree-target.sh`, `worktree-agent-map.sh` | Physical filesystem separation per plan when enabled, for both team and serialized execution |
 | **Lease locks** | `lease-lock.sh` | File-level exclusive locking during parallel execution |
 | **Contract system** | `generate-contract.sh`, `validate-contract.sh` with hash integrity | Tasks operate within declared boundaries, hash prevents tampering |
 | **Event-sourced state** | `event-log.jsonl` (13 event types) + `recover-state.sh` | Crash recovery via event replay, not just checkpoint files |
@@ -416,7 +416,7 @@ The blocking hooks (exit 2) are the key differentiator. These run as bash subpro
 | **Primary goal** | Structured AI development via context engineering | Structured AI development via phased workflows |
 | **Optimization target** | Token-to-value efficiency (Nyquist compliance, ~50% context budgets) | Token efficiency (86% overhead reduction vs stock, per-role budgets) |
 | **Loop closure** | Instruction-enforced + CLI verification | Instruction-enforced + hook-enforced (exit 2) |
-| **Parallel execution** | Wave-based (dependency graph → wave grouping) | Agent Teams (persistent teammates + worktree isolation) |
+| **Parallel execution** | Wave-based (dependency graph → wave grouping) | Dependency-aware Agent Teams for fan-out; serialized Dev subagents for linear graphs; worktree isolation when enabled |
 | **Decision flow** | State-detected single path (resume-project.md) | State-detected single path (phase-detect.sh) |
 | **Session continuity** | Explicit pause → `.continue-here.md` with 7 sections | Auto-persistent (`.execution-state.json` + `event-log.jsonl`) |
 | **Quality gates** | Goal-backward verification (verifier + plan checker) | Goal-backward verification (QA agent, tiered) + hook gates |
@@ -442,7 +442,7 @@ The blocking hooks (exit 2) are the key differentiator. These run as bash subpro
 - **You need platform-enforced quality gates** — VBW's blocking hooks prevent the model from bypassing rules
 - **You run long, complex sessions** — VBW's event-sourced state recovery and compaction hooks handle multi-hour sessions and crashes
 - **You want tiered QA** — VBW's Quick/Standard/Deep tiers let you right-size verification effort
-- **You want filesystem isolation** — VBW's worktree isolation provides physical separation for parallel agents
+- **You want filesystem isolation** — VBW's worktree isolation provides physical separation per plan when enabled, not only for parallel/team execution
 - **You want fine-grained control** — 4 effort levels × 4 autonomy levels × bundled work profiles
 - **You want security enforcement** — `bash-guard.sh` (40+ patterns), `security-filter.sh` (.env, .pem, credentials), and `file-guard.sh` (undeclared file access)
 - **You use the Claude Code marketplace** — VBW distributes as a marketplace plugin with migration handling

--- a/docs/vbw-vs-paul-analysis.md
+++ b/docs/vbw-vs-paul-analysis.md
@@ -139,7 +139,7 @@ PAUL enforces loop closure via instructions to the model. VBW enforces it via pl
 
 **PAUL's claim:** GSD wastes tokens on subagent sprawl. PAUL keeps execution in-session. Subagents are reserved for discovery/research only.
 
-**VBW's reality:** VBW takes a more nuanced position — it uses Agent Teams (not subagents) with surgical context management:
+**VBW's reality:** VBW takes a more nuanced position — it uses dependency-aware execution with surgical context management. Real fan-out graphs use Agent Teams; linear graphs use serialized Dev subagents to avoid fake coordination overhead:
 
 | Mechanism | What it does |
 |---|---|
@@ -147,9 +147,9 @@ PAUL enforces loop closure via instructions to the model. VBW enforces it via pl
 | **Token budgets** | Per-role caps (Scout 200 lines, Dev/Debugger 800 lines) with per-task complexity scoring from contract metadata |
 | **86% overhead reduction** | Measured and documented: 12,100 tokens vs stock Agent Teams' 87,100 tokens |
 | **Smart routing** | `assess-plan-risk.sh` downgrades low-risk plans to turbo (single agent, no team) automatically |
-| **`prefer_teams` setting** | `auto` mode creates teams only when 2+ plans exist — single plan = single agent, zero coordination overhead |
+| **`prefer_teams` setting** | `auto` mode creates teams only when dependency analysis finds real parallel delegate work; linear graphs and single delegate plans use serialized subagents |
 
-PAUL's argument that "subagents produce ~70% quality work" is valid criticism of vanilla subagent spawning. But VBW doesn't use vanilla subagents — Agent Teams are persistent teammates with shared task lists, typed communication schemas, and compiled context. The quality delta PAUL describes doesn't apply.
+PAUL's argument that "subagents produce ~70% quality work" is valid criticism of vanilla subagent sprawl. VBW avoids that pattern: true Agent Teams are persistent teammates with shared task lists, typed communication schemas, and compiled context, while serialized Dev subagents are used deliberately for linear dependency chains where parallelism would be fake.
 
 More importantly: VBW's parallel execution with context compilation achieves **both** speed and quality. PAUL forces a false dichotomy — "quality OR speed." VBW's token analysis proves you can have parallel execution at 86% lower overhead than stock implementation.
 
@@ -302,7 +302,7 @@ Beyond addressing every PAUL differentiator, VBW includes substantial capabiliti
 | **Platform hooks (21 handlers, 11 event types)** | Continuous verification, security filtering, lifecycle management, compaction recovery — all running as platform hooks, not instructions | None — CARL adds dynamic rules but no platform-level hooks |
 | **Agent tool permissions (platform-enforced)** | 4 of 7 agents have `disallowedTools` enforced by Claude Code itself | None — PAUL is single-agent |
 | **Database safety guard** | 40+ destructive command patterns blocked across all major frameworks | None |
-| **Parallel execution with isolation** | Agent Teams + worktree isolation + lease locks + file guards | Explicitly rejected — in-session only |
+| **Parallel execution with isolation** | Dependency-aware true teams for real fan-out; serialized Dev subagents for linear graphs; worktree isolation + lease locks + file guards | Explicitly rejected — in-session only |
 | **Three-tier automated QA** | Goal-backward verification at Quick/Standard/Deep tiers with 5-30+ checks | Manual UNIFY reconciliation |
 | **Human acceptance testing (UAT)** | VBW's UAT protocol (verify.md) with per-test CHECKPOINT prompts, severity classification, resume support | `/paul:verify` exists but is guide-based, not structured |
 | **UAT remediation pipeline** | Automatic detection of unresolved UAT → discuss → plan → execute chain, including milestone recovery | None |
@@ -333,7 +333,7 @@ PAUL's PAUL-VS-GSD.md includes a philosophy comparison table. Here it is with VB
 | Primary goal | Ship fast | Ship correctly | Ship correctly AND fast (parallel execution with quality gates) |
 | Optimization target | Speed to done | Token-to-value efficiency | Measured token efficiency (86% reduction vs stock) |
 | Loop closure | Flexible | Mandatory | Mandatory + hook-enforced + archive-guarded |
-| Subagent role | Execution (parallel speed) | Discovery only | Execution (Agent Teams with context compilation) + Discovery (Scout) |
+| Subagent role | Execution (parallel speed) | Discovery only | Execution (Agent Teams for fan-out, serialized Dev subagents for linear graphs) + Discovery (Scout) |
 | Decision flow | Multiple options | Single best path | Single best path (`phase-detect.sh` → one action) |
 | Session handoff | Implicit | Explicit + dated | Automatic (no prior action needed) + event-sourced crash recovery |
 | Quality gates | Completion-based | Acceptance-based | Automated QA + Human UAT + hook-enforced gates |

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -62,19 +62,18 @@ All runtime script invocations below assume `VBW_PLUGIN_ROOT` is set.
 **Orchestrator read-scope boundary:** You may ONLY read planning/state artifacts: `*-PLAN.md`, `*-SUMMARY.md`, `*-RESEARCH.md`, `STATE.md`, `ROADMAP.md`, `REQUIREMENTS.md`, `.execution-state.json`, `.context-*.md`, `config.json`, and `.vbw-planning/` metadata. Do NOT read product source files (application code, tests, configs outside `.vbw-planning/`). If you need to understand product code to make a routing or sequencing decision, that understanding must come from Dev — delegate it via a task.
 
 1. Glob `*-PLAN.md` in phase dir. Read each plan's YAML frontmatter.
-2. Check existing SUMMARY.md files — a plan is complete only if its SUMMARY has `status: complete|partial` (use `is_summary_complete` from `scripts/summary-utils.sh`). A SUMMARY with `status: pending` or no status field is NOT complete.
+2. Check existing SUMMARY.md files — a plan is progression-complete for Execute dependency routing only when its SUMMARY has `status: complete|partial`. Strict phase/build completion still requires `complete|completed`. A SUMMARY with `status: pending` or no status field is NOT progression-complete.
 3. `git log --oneline -20` for committed tasks (crash recovery).
 4. Build remaining plans list. If `--plan=NN`, filter to that plan.
-4b. **Worktree isolation (REQ-WORKTREE):** If `worktree_isolation` is not `"off"` in config:
+4b. **Worktree isolation (REQ-WORKTREE):** If `worktree_isolation` is not `"off"` in config, worktrees remain per-plan but are created/refreshed just in time when a plan becomes runnable. Do **not** create every remaining plan worktree up front; a dependent serialized plan must start from a branch that includes prerequisite output.
    ```bash
    WORKTREE_ISOLATION=$(jq -r '.worktree_isolation // "off"' .vbw-planning/config.json 2>/dev/null || echo "off")
    ```
-   For each uncompleted plan in the remaining plans list:
-   - Create worktree: `WPATH=$(bash "${VBW_PLUGIN_ROOT}/scripts/worktree-create.sh" {phase} {plan} 2>/dev/null || echo "")`. If `WPATH` is empty, log warning and continue without worktree for this plan.
-   - If `WPATH` is non-empty:
-     - Store `worktree_path` in the plan's entry in execution-state.json (added alongside `"status"` in the `plans` array).
-     - Fetch targeting JSON: `WTARGET=$(bash "${VBW_PLUGIN_ROOT}/scripts/worktree-target.sh" "$WPATH" 2>/dev/null || echo "{}")`.
-     - Register agent mapping: `bash "${VBW_PLUGIN_ROOT}/scripts/worktree-agent-map.sh" set "dev-{plan}" "$WPATH" {phase} {plan} 2>/dev/null || true`.
+  For each plan when it becomes runnable in Step 3:
+  - Merge or otherwise make completed prerequisite worktree output visible before creating the dependent plan's worktree.
+  - Create/refresh worktree: `WPATH=$(bash "${VBW_PLUGIN_ROOT}/scripts/worktree-create.sh" {phase} {plan} 2>/dev/null || echo "")`. If `WPATH` is empty, log warning and continue without worktree for this plan.
+  - If `WPATH` is non-empty: update that plan's `worktree_path` in `.execution-state.json`, regenerate `WTARGET=$(bash "${VBW_PLUGIN_ROOT}/scripts/worktree-target.sh" "$WPATH" 2>/dev/null || echo "{}")`, and register `bash "${VBW_PLUGIN_ROOT}/scripts/worktree-agent-map.sh" set "dev-{plan}" "$WPATH" {phase} {plan} 2>/dev/null || true` before spawning Dev.
+  - After merge/cleanup for that plan, clear `bash "${VBW_PLUGIN_ROOT}/scripts/worktree-agent-map.sh" clear "dev-{plan}" 2>/dev/null || true`.
    When `worktree_isolation="off"`: skip this step silently.
 5. Partially-complete plans: note resume-from task number.
 6. **Crash recovery:** If `.vbw-planning/.execution-state.json` exists with `"status": "running"`, update plan statuses to match current SUMMARY.md state.
@@ -93,10 +92,11 @@ All runtime script invocations below assume `VBW_PLUGIN_ROOT` is set.
   "phase": N, "phase_name": "{slug}", "status": "running",
   "started_at": "{ISO 8601}", "wave": 1, "total_waves": N,
   "correlation_id": "{UUID}",
-  "plans": [{"id": "NN-MM", "title": "...", "wave": W, "status": "pending|complete"}]
+  "effort": "{effective effort}", "phase_effort": "{configured phase effort}",
+  "plans": [{"id": "NN-MM", "title": "...", "wave": W, "status": "pending|complete|partial|failed"}]
 }
 ```
-Set completed plans (with SUMMARY.md whose `status` is `complete` or `completed`) to `"complete"`, others to `"pending"`. A SUMMARY.md with a non-terminal status (e.g., `pending`) does NOT count as complete.
+Set plan status from verified SUMMARY.md frontmatter: `complete|completed` → `"complete"`, `partial` → `"partial"`, `failed` → `"failed"`, others → `"pending"`. `phase_effort` preserves the configured phase effort; `effort` may be temporarily changed to `turbo` or internal `direct` for segment-local guard visibility and restored before the next non-direct segment.
 
 **Task list hygiene (crash-resume):** When resuming execution (`.execution-state.json` already existed), plans that are already `"complete"` were finished in a prior session. Immediately mark those plans as completed in your task list — do NOT leave them as not-started or in-progress. Only pending plans should be active in your task list.
 
@@ -125,18 +125,45 @@ Set completed plans (with SUMMARY.md whose `status` is `complete` or `completed`
    - All satisfied: `✓ Cross-phase dependencies verified`
    - No cross_phase_deps: skip silently
 
-### Step 3: Create Agent Team and execute
+### Step 3: Resolve Execute routing and run segments
 
-**Team creation (multi-agent only):**
-Read prefer_teams config to determine team creation:
+**Smart Routing (REQ-15):** If `smart_routing=true` in config, build a transient route map before selecting team/subagent mode:
 ```bash
-PREFER_TEAMS=$(bash "${VBW_PLUGIN_ROOT}/scripts/normalize-prefer-teams.sh" .vbw-planning/config.json 2>/dev/null || echo "auto")
+ROUTE_MAP=.vbw-planning/.cache/execute-route-map.json
+mkdir -p .vbw-planning/.cache
+printf '{"plans":{}}\n' > "$ROUTE_MAP"
 ```
+- For each remaining plan, assess risk before team selection:
+  ```bash
+  RISK=$(bash "${VBW_PLUGIN_ROOT}/scripts/assess-plan-risk.sh" {plan_path} 2>/dev/null || echo "medium")
+  TASK_COUNT=$(grep -c '^### Task [0-9]' {plan_path} 2>/dev/null || echo "0")
+  ```
+- If `RISK=low` AND `TASK_COUNT<=3` AND effort is not `thorough`: write route `turbo` for that plan in `$ROUTE_MAP` and log numeric metrics:
+  `bash "${VBW_PLUGIN_ROOT}/scripts/collect-metrics.sh" smart_route {phase} {plan} risk=$RISK tasks=$TASK_COUNT routed=turbo 2>/dev/null || true`
+- Otherwise: omit the route-map entry or write route `delegate`; log non-turbo delegated metrics as:
+  `bash "${VBW_PLUGIN_ROOT}/scripts/collect-metrics.sh" smart_route {phase} {plan} risk=$RISK tasks=$TASK_COUNT routed=team 2>/dev/null || true`
+- Internal route `direct` is only for explicit route-map entries supplied by existing guard/delegation machinery. Do not add a user-facing `direct` phase effort.
+- On script error: leave the plan unlisted in the route map; missing entries default to delegate.
 
-Team request policy:
-- `prefer_teams='always'`: request team mode for ALL remaining-plan counts (even 1 plan), unless turbo or smart-routed to turbo
-- `prefer_teams='auto'`: request team mode only when 2+ uncompleted plans remain, unless turbo or smart-routed to turbo
-- `prefer_teams='never'`: request explicit non-team mode
+**Dependency-aware routing helper:** After `.execution-state.json` and the optional route map exist, resolve routing before writing `.delegated-workflow.json`:
+```bash
+ROUTE_ARGS=()
+[ -f .vbw-planning/.cache/execute-route-map.json ] && ROUTE_ARGS=(--route-map .vbw-planning/.cache/execute-route-map.json)
+ROUTING=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-execute-delegation-mode.sh" \
+  --phase-dir "{phase_dir}" \
+  --config .vbw-planning/config.json \
+  --execution-state .vbw-planning/.execution-state.json \
+  "${ROUTE_ARGS[@]}" \
+  --segments)
+```
+The helper canonicalizes `prefer_teams` with `normalize-prefer-teams.sh`, computes remaining dependency waves from the execution state and plan frontmatter, and emits compact JSON (`delegation_mode`, `requested_mode`, `reason`, `max_parallel_width`, `delegate_count`, route-specific plan IDs, and ordered `segments`).
+If the helper exits non-zero or returns `reason=invalid_dependency_graph`, stop before spawning agents and surface the diagnostic. Valid serial graphs are not errors: `prefer_teams=auto` with `max_parallel_width <= 1` uses serialized Dev subagents.
+
+Team request policy from helper output:
+- `prefer_teams='always'`: request team mode for delegate-eligible work regardless of dependency width; it does not override phase-level turbo, smart-routed turbo, or explicit internal-direct segments.
+- `prefer_teams='auto'`: request team mode only when dependency analysis finds real parallel delegate work (`max_parallel_width > 1`).
+- `prefer_teams='never'`: request explicit non-team mode.
+- Unknown normalized values preserve the raw value, use `delegation_mode=subagent`, and report `unknown_prefer_teams:<value>`.
 
 Determine whether **real team semantics** are available in the live tool set before spawning anything:
 - Real team semantics are available when either:
@@ -145,53 +172,46 @@ Determine whether **real team semantics** are available in the live tool set bef
 - If the live tool set only supports plain background spawns (for example `Agent` with `run_in_background: true` but no `team_name`), then real team semantics are **NOT** available.
 - **Plain background `Agent` spawns without team semantics are NOT an agent team. Do NOT use them as a substitute for team mode.**
 
-Branch execute mode into exactly one of these runtime paths and persist it **before the first teammate spawn**:
+Process `ROUTING.segments[]` in order. Before each segment, ensure no previous team marker is live. If the previous segment used true team mode, send `shutdown_request`, wait for responses, call `TeamDelete`, run `clean-stale-teams.sh`, then clear or replace the marker before starting the next segment.
+
+Branch each segment into exactly one runtime path and persist that segment's actual mode **before the first spawn or orchestrator product-file write**:
 
 1. **True team mode**
-   - Use this path only when prefer_teams requests team mode **and** real team semantics are available.
+   - Use this path only when the helper segment has `delegation_mode=team` **and** real team semantics are available.
    - **Pre-TeamCreate cleanup** (remove orphaned VBW team directories from prior sessions before creating a new team):
      ```bash
      bash "${VBW_PLUGIN_ROOT}/scripts/clean-stale-teams.sh" 2>/dev/null || true
      ```
-   - Set `TEAM_NAME="vbw-phase-{NN}"`.
+   - Set `TEAM_NAME` from the segment (`team_name`) or default to `"vbw-phase-{NN}"`.
    - If literal `TeamCreate` is available, call it with `team_name="$TEAM_NAME"`, `description="Phase {NN}: {phase-name}"`.
    - If literal `TeamCreate` is unavailable but the live teammate spawn tool accepts `team_name`, create the team implicitly by using the shared `TEAM_NAME` on every teammate spawn.
    - Persist the actual runtime mode:
      ```bash
-     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {effort} team "$TEAM_NAME"
+     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {segment_effort} team "$TEAM_NAME"
      ```
-   - All Dev and QA teammates below MUST carry `team_name: "$TEAM_NAME"` plus `name: "dev-{MM}"` (from plan number) or `name: "qa"` / `name: "qa-wave{W}"` on the live spawn call.
+   - All Dev and QA teammates below MUST carry `team_name: "$TEAM_NAME"` plus `name: "dev-{MM}"` (from plan number) or `name: "qa"` / `name: "qa-wave{W}"` on the live spawn call. No plain task-management `TaskCreate` may happen after the team marker is set unless it carries the selected `TEAM_NAME` and teammate `name`.
 
 2. **Explicit non-team mode**
-   - Use this path when `prefer_teams='never'`, or when `prefer_teams='auto'` and only 1 plan remains, or when turbo / smart routing resolves to non-team execution.
+   - Use this path when `prefer_teams='never'`, `prefer_teams='auto'` with `max_parallel_width <= 1`, unknown `prefer_teams`, no delegate-eligible plans, segment route `turbo`/internal `direct`, or team-tooling-unavailable fallback.
+   - For `turbo` or internal `direct` segments, update `.execution-state.json.effort` to `turbo` or `direct` before orchestrator product-file writes; keep `phase_effort` unchanged and restore `.execution-state.json.effort` to `phase_effort` before the next non-direct segment.
    - Persist the actual runtime mode:
      ```bash
-     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {effort} subagent
+     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {segment_effort} subagent
      ```
    - Skip TeamCreate. Spawn one Dev at a time and wait for completion before spawning the next one.
    - **Do NOT use `run_in_background: true` to simulate parallelism in non-team mode.**
 
 3. **Team-tooling-unavailable fallback**
-   - Use this path when prefer_teams requests team mode but the live tool set cannot express real team semantics.
+   - Use this path when the helper requests `delegation_mode=team` but the live tool set cannot express real team semantics.
    - Display: `⚠ Agent Teams not enabled — using non-team mode`
    - Persist the fallback runtime mode:
      ```bash
-     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {effort} subagent
+     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {segment_effort} subagent
      ```
    - Skip TeamCreate and continue in explicit non-team mode.
    - **Do NOT preserve “parallelism” by launching multiple background `Agent` spawns without `team_name`.**
 
-**Smart Routing (REQ-15):** If `smart_routing=true` in config:
-- Before creating agent teams, assess each plan:
-  ```bash
-  RISK=$(bash "${VBW_PLUGIN_ROOT}/scripts/assess-plan-risk.sh" {plan_path} 2>/dev/null || echo "medium")
-  TASK_COUNT=$(grep -c '^### Task [0-9]' {plan_path} 2>/dev/null || echo "0")
-  ```
-- If `RISK=low` AND `TASK_COUNT<=3` AND effort is not `thorough`: force turbo execution for this plan (no team, direct implementation). Log routing decision:
-  `bash "${VBW_PLUGIN_ROOT}/scripts/collect-metrics.sh" smart_route {phase} {plan} risk=$RISK tasks=$TASK_COUNT routed=turbo 2>/dev/null || true`
-- Otherwise: proceed with normal team delegation. Log:
-  `bash "${VBW_PLUGIN_ROOT}/scripts/collect-metrics.sh" smart_route {phase} {plan} risk=$RISK tasks=$TASK_COUNT routed=team 2>/dev/null || true`
-- On script error: fall back to configured effort level.
+After each segment completes, verify each plan's SUMMARY.md through Step 3c and write the verified status (`complete`, `partial`, or `failed`) into `.execution-state.json`. Only `complete|partial` unlock dependents. Re-run the helper against the updated execution state until no pending plans remain.
 
 **Delegation directive (all except Turbo):**
 You are the team LEAD. NEVER implement tasks yourself.
@@ -303,7 +323,7 @@ if [ $? -ne 0 ]; then echo "$QA_MAX_TURNS" >&2; exit 1; fi
 
 **MCP tool evaluation for Dev tasks:** Also evaluate available MCP tools in your system context. If any MCP servers provide capabilities relevant to the tasks (build tools, documentation servers, domain-specific APIs), note them in the Dev task description so the Dev agent knows which MCP tools to use.
 
-For each uncompleted plan, create the teammate task using the live teammate spawn tool (for example `TaskCreate` or `Agent`):
+For each runnable plan in the current segment, create the teammate task using the live teammate spawn tool (for example `TaskCreate` or `Agent`). In non-team mode, spawn exactly one Dev and wait for its result before spawning the next runnable plan. In true team mode, every spawn/TaskCreate after the marker is set must include the selected `TEAM_NAME` and teammate `name`.
 ```yaml
 subject: "Execute {NN-MM}: {plan-title}"
 description: |
@@ -333,9 +353,9 @@ Display: `◆ Spawning Dev teammate (${DEV_MODEL})...`
 **CRITICAL:** When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "dev-{MM}"` on the live spawn call. If the live spawn tool is `Agent`, those parameters belong on `Agent(...)`. If the live spawn tool is `TaskCreate`, put the same parameters there. Team mode without `team_name` is invalid.
 **CRITICAL:** In explicit non-team mode or team-tooling-unavailable fallback, do NOT use `run_in_background: true` to imitate parallel team execution.
 
-Wire dependencies via TaskUpdate: read `depends_on` from each plan's frontmatter, add `addBlockedBy: [task IDs of dependency plans]`. Plans with empty depends_on start immediately.
+Dependency ordering is enforced by the routing helper's segment plan, not by speculative background spawns. Use TaskUpdate dependency metadata only as a task-list mirror of `depends_on`; do not spawn a dependent plan until the helper recomputes it as runnable from updated execution state. If `--plan=NN`: single task, no dependencies.
 
-Spawn Dev teammates and assign tasks. Platform enforces execution ordering via task deps. If `--plan=NN`: single task, no dependencies.
+Just before spawning a runnable plan with `worktree_isolation` enabled, create or refresh that plan's worktree, update its `worktree_path` in execution state, regenerate `WTARGET`, and register `dev-{plan}` with `worktree-agent-map.sh`. After the plan's worktree is merged or cleaned up, clear the mapping.
 
 **Blocked agent notification (mandatory):** When a Dev teammate completes a plan (task marked completed + SUMMARY.md verified), check if any other tasks have `blockedBy` containing that completed task's ID. For each newly-unblocked task, send its assigned Dev a message: "Blocking task {id} complete. Your task is now unblocked — proceed with execution." This ensures blocked agents resume without manual intervention.
 
@@ -385,7 +405,7 @@ Use targeted `message` not `broadcast`. Reserve broadcast for critical blocking 
 - **On message send** (before sending): agents should construct messages using full V2 envelope (id, type, phase, task, author_role, timestamp, schema_version, payload, confidence). Reference `${VBW_PLUGIN_ROOT}/references/handoff-schemas.md` for schema details.
 
 **Execution state updates:**
-- Task completion: update plan status in .execution-state.json (`"complete"` or `"failed"`)
+- Task completion: update plan status in .execution-state.json (`"complete"`, `"partial"`, or `"failed"` from verified SUMMARY.md status)
 - Wave transition: update `"wave"` when first wave N+1 task starts
 - Use `jq` for atomic updates
 
@@ -457,7 +477,7 @@ All metrics calls should be `2>/dev/null || true` — never block execution.
   - Gate failures trigger auto-repair with same flow as pre-task.
 - **Post-plan gate (after all tasks complete, before marking plan done):**
   1. `artifact_persistence` gate: `bash "${VBW_PLUGIN_ROOT}/scripts/hard-gate.sh" artifact_persistence {phase} {plan} {task} {contract_path}`
-  - This gate fires AFTER SUMMARY.md verification but BEFORE updating execution-state.json to "complete".
+  - This gate fires AFTER SUMMARY.md verification but BEFORE updating execution-state.json to the verified terminal status.
 - **YOLO mode:** Hard gates ALWAYS fire regardless of autonomy level. YOLO only skips confirmation prompts.
 - **Fallback:** If hard-gate.sh or auto-repair.sh errors (not a gate fail, but a script error), log to metrics and continue (fail-open on script errors, hard-stop only on gate verdicts).
 
@@ -487,7 +507,7 @@ RESULT=$(bash "${VBW_PLUGIN_ROOT}/scripts/two-phase-complete.sh" {task_id} {phas
 
 ### Step 3c: SUMMARY.md verification gate (mandatory)
 
-**This is a hard gate. Do NOT proceed to QA or mark a plan as complete in .execution-state.json without verifying its SUMMARY.md.**
+**This is a hard gate. Do NOT proceed to QA or mark a plan terminal in .execution-state.json without verifying its SUMMARY.md.**
 
 When a Dev teammate reports plan completion (task marked completed):
 1. **Check:** Verify `{phase_dir}/{plan_id}-SUMMARY.md` exists and contains commit hashes, task statuses, and files modified.
@@ -497,7 +517,7 @@ When a Dev teammate reports plan completion (task marked completed):
 5. **Schema Validation — SUMMARY.md (REQ-17, graduated, always-on):**
   - Validate SUMMARY.md frontmatter: `VALID=$(bash "${VBW_PLUGIN_ROOT}/scripts/validate-schema.sh" summary {summary_path} 2>/dev/null || echo "valid")`
    - If `invalid`: log warning `⚠ Summary {plan_id} schema: ${VALID}` — advisory only.
-6. **Only after SUMMARY.md is verified with terminal status:** Update plan status to `"complete"` in .execution-state.json and proceed.
+6. **Only after SUMMARY.md is verified with terminal status:** Canonicalize and write the verified status to `.execution-state.json`: `complete|completed` → `"complete"`, `partial` → `"partial"`, `failed` → `"failed"`. Only `complete|partial` satisfy Execute dependencies; `failed` is terminal but does not unlock dependents.
 
 **SUMMARY.md timing rule:** A SUMMARY.md represents completed execution. Never create a SUMMARY.md as a placeholder or stub before execution begins. Do not write SUMMARY.md with `status: pending` or any non-terminal status. **Exception:** Remediation round summaries (`R{RR}-SUMMARY.md`) are built incrementally across multiple Dev agents — the first Dev creates the file with `status: in-progress` and subsequent Devs append task sections. The Lead finalizes the frontmatter after all tasks complete.
 
@@ -915,18 +935,18 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
 
 ### Step 5: Update state and present summary
 
-**HARD GATE — Shutdown before ANY output or state updates:** If team was created (based on prefer_teams decision), you MUST shut down the team BEFORE updating state, presenting results, or asking the user anything. This is blocking and non-negotiable:
-1. Send `shutdown_request` via SendMessage to EVERY active teammate (excluding yourself — the orchestrator controls the sequence, not the lead agent) — do not skip any. The SendMessage JSON body must include at minimum: `{"type": "shutdown_request", "id": "<unique-id>", "reason": "phase_complete", "team_name": "vbw-phase-{NN}"}` (this is a simplified form — the full V2 envelope nests these under `payload` with `id` at envelope level, but agents are instructed to match on `"type":"shutdown_request"` regardless of structure). Agents echo the `id` back as `request_id` in their `shutdown_response`. Teammates respond by calling SendMessage with `type: "shutdown_response"`.
+**HARD GATE — Shutdown before ANY output or state updates:** Run team shutdown only when the persisted/helper-resolved runtime state says `delegation_mode=team` and a real `TEAM_NAME` exists. If the helper selected `subagent`, turbo, internal `direct`, no delegate-eligible plans, or team-tooling-unavailable fallback, skip SendMessage/TeamDelete and clear the marker. For actual team mode, shut down the team BEFORE updating state, presenting results, or asking the user anything. This is blocking and non-negotiable:
+1. Send `shutdown_request` via SendMessage to EVERY active teammate in `TEAM_NAME` (excluding yourself — the orchestrator controls the sequence, not the lead agent) — do not skip any. The SendMessage JSON body must include at minimum: `{"type": "shutdown_request", "id": "<unique-id>", "reason": "phase_complete", "team_name": "<TEAM_NAME>"}` (this is a simplified form — the full V2 envelope nests these under `payload` with `id` at envelope level, but agents are instructed to match on `"type":"shutdown_request"` regardless of structure). Agents echo the `id` back as `request_id` in their `shutdown_response`. Teammates respond by calling SendMessage with `type: "shutdown_response"`.
 2. Log event: `bash "${VBW_PLUGIN_ROOT}/scripts/log-event.sh" shutdown_sent {phase} team={team_name} targets={count} 2>/dev/null || true`
 3. Wait for each `shutdown_response` with `approved: true` (delivered as a SendMessage tool call from the teammate, NOT as plain text). If a teammate responds in plain text instead of calling SendMessage, re-send the `shutdown_request`. If a teammate rejects, re-request immediately (max 3 attempts per teammate — if still rejected after 3 attempts, log a warning and proceed with TeamDelete).
 4. Log event: `bash "${VBW_PLUGIN_ROOT}/scripts/log-event.sh" shutdown_received {phase} team={team_name} approved={count} rejected={count} 2>/dev/null || true`
-5. Call TeamDelete for team "vbw-phase-{NN}"
+5. Call TeamDelete for `TEAM_NAME`
 6. **Post-TeamDelete residual cleanup** (belt-and-suspenders — catches race-condition residuals where agents recreate inbox files after TeamDelete):
    ```bash
    bash "${VBW_PLUGIN_ROOT}/scripts/clean-stale-teams.sh" 2>/dev/null || true
    ```
 7. Only THEN proceed to state updates and user-facing output below
-Failure to shut down leaves agents running in the background, consuming API credits (visible as hanging panes in tmux, invisible but still costly without tmux). If no team was created: skip shutdown sequence. **Recovery:** If shutdown stalls or agents linger after TeamDelete, do NOT manually `rm -rf ~/.claude/teams` — use `/vbw:doctor --cleanup` which runs `doctor-cleanup.sh` and `clean-stale-teams.sh` with safe atomic cleanup. These scripts detect stale teams, orphan processes, and dangling PIDs. `clean-stale-teams.sh` immediately removes VBW team directories missing `config.json` (orphaned residuals) without waiting for the 2-hour stale threshold.
+Failure to shut down an actual team leaves agents running in the background, consuming API credits (visible as hanging panes in tmux, invisible but still costly without tmux). If no actual team was created: skip shutdown sequence. **Recovery:** If shutdown stalls or agents linger after TeamDelete, do NOT manually `rm -rf ~/.claude/teams` — use `/vbw:doctor --cleanup` which runs `doctor-cleanup.sh` and `clean-stale-teams.sh` with safe atomic cleanup. These scripts detect stale teams, orphan processes, and dangling PIDs. `clean-stale-teams.sh` immediately removes VBW team directories missing `config.json` (orphaned residuals) without waiting for the 2-hour stale threshold.
 
 Regardless of whether a real team was created, clear the execute delegation marker before state updates:
 ```bash
@@ -951,12 +971,12 @@ For each plan that has a `worktree_path` entry in execution-state.json (complete
 All worktree operations are fail-open: script errors are suppressed (2>/dev/null || true). Merge failures are surfaced as warnings, not blockers.
 When `worktree_isolation="off"`: skip this block silently.
 
-**Post-shutdown verification:** After TeamDelete, there must be ZERO active teammates. If the Pure-Vibe loop or auto-chain will re-enter Plan mode next, confirm no prior agents linger before spawning new ones. This gate survives compaction — if you lost context about whether shutdown happened, assume it did NOT and send `shutdown_request` to any teammates that may still exist before proceeding.
+**Post-shutdown verification:** After TeamDelete for an actual `delegation_mode=team` run, there must be ZERO active teammates. If the Pure-Vibe loop or auto-chain will re-enter Plan mode next, confirm no prior agents linger before spawning new ones. For serialized subagent, turbo, direct, or fallback runs, rely on completed subagent/direct execution plus the cleared delegation marker; do not send team shutdown messages without a real `TEAM_NAME`.
 
 **Control Plane cleanup:** Lock and token state cleanup already handled by existing Lease Lock and Token Budget cleanup blocks.
 
 **Rolling Summary (REQ-03):** If `rolling_summary=true` in config:
-- After TeamDelete (team fully shut down), before phase_end event log:
+- After TeamDelete when an actual team was fully shut down, before phase_end event log:
   ```bash
   bash "${VBW_PLUGIN_ROOT}/scripts/compile-rolling-summary.sh" \
     .vbw-planning/phases .vbw-planning/ROLLING-CONTEXT.md 2>/dev/null || true

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -172,7 +172,7 @@ Determine whether **real team semantics** are available in the live tool set bef
 - If the live tool set only supports plain background spawns (for example `Agent` with `run_in_background: true` but no `team_name`), then real team semantics are **NOT** available.
 - **Plain background `Agent` spawns without team semantics are NOT an agent team. Do NOT use them as a substitute for team mode.**
 
-Process `ROUTING.segments[]` in order. Before each segment, ensure no previous team marker is live. If the previous segment used true team mode, send `shutdown_request`, wait for responses, call `TeamDelete`, run `clean-stale-teams.sh`, then clear or replace the marker before starting the next segment.
+Process `ROUTING.segments[]` in order. For each segment, extract `route`, `plan_ids`, `effort`, `delegation_mode`, and optional `team_name` from the helper output. Before any direct, turbo, fallback, or serialized subagent segment starts, check the current delegation marker; if a live execute marker has `delegation_mode=team`, complete shutdown (`shutdown_request`, responses, `TeamDelete`, stale cleanup) and clear the marker first. Do not start a non-team segment while `.delegated-workflow.json` still reports a live team marker.
 
 Branch each segment into exactly one runtime path and persist that segment's actual mode **before the first spawn or orchestrator product-file write**:
 
@@ -193,12 +193,14 @@ Branch each segment into exactly one runtime path and persist that segment's act
 
 2. **Explicit non-team mode**
    - Use this path when `prefer_teams='never'`, `prefer_teams='auto'` with `max_parallel_width <= 1`, unknown `prefer_teams`, no delegate-eligible plans, segment route `turbo`/internal `direct`, or team-tooling-unavailable fallback.
-   - For `turbo` or internal `direct` segments, update `.execution-state.json.effort` to `turbo` or `direct` before orchestrator product-file writes; keep `phase_effort` unchanged and restore `.execution-state.json.effort` to `phase_effort` before the next non-direct segment.
-   - Persist the actual runtime mode:
+   - For serialized delegate segments (`route=delegate`, `delegation_mode=subagent`), persist the actual runtime mode as subagent, skip TeamCreate, spawn one Dev subagent, and wait for completion before the next spawn:
      ```bash
      bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {segment_effort} subagent
      ```
-   - Skip TeamCreate. Spawn one Dev at a time and wait for completion before spawning the next one.
+   - For `turbo` or internal `direct` segments (`delegation_mode=direct`), update `.execution-state.json.effort` to `turbo` or `direct` before orchestrator product-file writes; keep `phase_effort` unchanged, persist the actual runtime mode as direct, and restore `.execution-state.json.effort` to `phase_effort` before the next non-direct segment:
+     ```bash
+     bash "${VBW_PLUGIN_ROOT}/scripts/delegated-workflow.sh" set execute {segment_effort} direct
+     ```
    - **Do NOT use `run_in_background: true` to simulate parallelism in non-team mode.**
 
 3. **Team-tooling-unavailable fallback**

--- a/scripts/generate-contract.sh
+++ b/scripts/generate-contract.sh
@@ -54,6 +54,102 @@ PLAN=$(awk '/^---$/{n++; next} n==1 && /^plan:/{gsub(/"/,"",$2); print $2; exit}
 # Extract title (objective) from frontmatter
 TITLE=$(awk '/^---$/{n++; next} n==1 && /^title:/{sub(/^title: */, ""); print; exit}' "$PLAN_PATH" 2>/dev/null) || TITLE=""
 
+trim_value() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+strip_dep_token() {
+  local value
+  value=$(trim_value "$1")
+  value="${value%,}"
+  value=$(trim_value "$value")
+  value="${value#\[}"
+  value="${value%\]}"
+  value=$(trim_value "$value")
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+  esac
+  trim_value "$value"
+}
+
+pad_contract_number() {
+  local raw="$1"
+  case "$raw" in
+    ''|*[!0-9]*) printf '%s' "$raw" ;;
+    *) printf '%02d' "$((10#$raw))" ;;
+  esac
+}
+
+normalize_contract_dep_ref() {
+  local raw="$1"
+  local value ph pl phase_id
+  value=$(strip_dep_token "$raw")
+  [ -z "$value" ] && return 1
+  case "$value" in
+    null|NULL|None|none|[]) return 1 ;;
+  esac
+  phase_id=$(pad_contract_number "$PHASE")
+  case "$value" in
+    *-*)
+      ph="${value%%-*}"
+      pl="${value#*-}"
+      if [ -n "$ph" ] && [ -n "$pl" ] && [[ "$ph" =~ ^[0-9]+$ ]] && [[ "$pl" =~ ^[0-9]+$ ]]; then
+        printf '%s-%s\n' "$(pad_contract_number "$ph")" "$(pad_contract_number "$pl")"
+      else
+        printf '%s\n' "$value"
+      fi
+      ;;
+    *)
+      if [[ "$value" =~ ^[0-9]+$ ]] && [[ "$phase_id" =~ ^[0-9]+$ ]]; then
+        printf '%s-%s\n' "$phase_id" "$(pad_contract_number "$value")"
+      else
+        printf '%s\n' "$value"
+      fi
+      ;;
+  esac
+}
+
+extract_depends_on_refs() {
+  awk '
+    function trim(v) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); return v }
+    function emit(v, n, i, parts) {
+      v = trim(v)
+      sub(/[[:space:]]+#.*$/, "", v)
+      v = trim(v)
+      if (v == "" || v == "[]") return
+      if (v ~ /^\[/) {
+        gsub(/^\[/, "", v); gsub(/\].*$/, "", v)
+        n = split(v, parts, ",")
+        for (i = 1; i <= n; i++) {
+          item = trim(parts[i])
+          if (item != "") print item
+        }
+        return
+      }
+      print v
+    }
+    BEGIN { in_front=0; in_dep=0 }
+    /^---$/ { if (in_front==0) { in_front=1; next } else { exit } }
+    in_front && /^[[:space:]]*depends_on:[[:space:]]*/ {
+      line=$0
+      sub(/^[[:space:]]*depends_on:[[:space:]]*/, "", line)
+      if (trim(line) != "") { emit(line); exit }
+      in_dep=1; next
+    }
+    in_front && in_dep && /^[[:space:]]*-[[:space:]]*/ {
+      line=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      emit(line)
+      next
+    }
+    in_front && in_dep && /^[^[:space:]]/ { exit }
+  ' "$PLAN_PATH" 2>/dev/null || true
+}
+
 # Extract must_haves from frontmatter
 MUST_HAVES=$(awk '
   BEGIN { in_front=0; in_mh=0 }
@@ -68,27 +164,20 @@ MUST_HAVES=$(awk '
   in_front && in_mh && /^[^[:space:]]/ { exit }
 ' "$PLAN_PATH" 2>/dev/null) || true
 
-# Extract depends_on from frontmatter
-DEPENDS_ON=$(awk '
-  BEGIN { in_front=0; in_dep=0 }
-  /^---$/ { if (in_front==0) { in_front=1; next } else { exit } }
-  in_front && /^depends_on:/ {
-    # Check inline array format: depends_on: [1, 2]
-    if (match($0, /\[.*\]/)) {
-      sub(/^depends_on: *\[/, ""); sub(/\].*$/, "")
-      gsub(/ /, ""); gsub(/,/, "\n")
-      print
-      exit
-    }
-    in_dep=1; next
-  }
-  in_front && in_dep && /^[[:space:]]+- / {
-    sub(/^[[:space:]]+- /, "")
-    print
-    next
-  }
-  in_front && in_dep && /^[^[:space:]]/ { exit }
-' "$PLAN_PATH" 2>/dev/null) || true
+# Extract depends_on from frontmatter. Keep this parser aligned with
+# resolve-execute-delegation-mode.sh so routing and contract sidecars retain
+# the same dependency edges.
+DEPENDS_ON=""
+while IFS= read -r dep_ref; do
+  dep_norm=$(normalize_contract_dep_ref "$dep_ref" 2>/dev/null || true)
+  [ -n "$dep_norm" ] || continue
+  if [ -n "$DEPENDS_ON" ]; then
+    DEPENDS_ON="${DEPENDS_ON}
+${dep_norm}"
+  else
+    DEPENDS_ON="$dep_norm"
+  fi
+done < <(extract_depends_on_refs)
 
 # Extract verification_checks from frontmatter (if present)
 VERIFICATION_CHECKS=$(awk '
@@ -165,7 +254,7 @@ CONTRACT_FILE="${CONTRACT_DIR}/${PHASE}-${PLAN}.json"
 
   DEP_JSON="[]"
   if [ -n "$DEPENDS_ON" ]; then
-    DEP_JSON=$(echo "$DEPENDS_ON" | jq -R 'tonumber' | jq -s '.' 2>/dev/null) || DEP_JSON="[]"
+    DEP_JSON=$(jq -Rs 'split("\n") | map(select(length > 0))' <<< "$DEPENDS_ON" 2>/dev/null) || DEP_JSON="[]"
   fi
 
   VC_JSON="[]"

--- a/scripts/resolve-execute-delegation-mode.sh
+++ b/scripts/resolve-execute-delegation-mode.sh
@@ -378,7 +378,9 @@ if [ -z "$effective_effort" ] || [ "$effective_effort" = "null" ]; then
   fi
 fi
 phase_effort=$(jq -r '.phase_effort // empty' "$EXEC_STATE_PATH" 2>/dev/null || true)
-[ -z "$phase_effort" ] || [ "$phase_effort" = "null" ] && phase_effort="$effective_effort"
+if [ -z "$phase_effort" ] || [ "$phase_effort" = "null" ]; then
+  phase_effort="$effective_effort"
+fi
 
 plans_json="{}"
 all_plan_ids="[]"

--- a/scripts/resolve-execute-delegation-mode.sh
+++ b/scripts/resolve-execute-delegation-mode.sh
@@ -1,0 +1,655 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# resolve-execute-delegation-mode.sh — dependency-aware Execute routing helper
+#
+# Usage:
+#   resolve-execute-delegation-mode.sh --phase-dir <dir> [--config <path>] [--execution-state <path>] [--route-map <path>] [--segments]
+#
+# Computes whether the current Execute segment should use true team mode or
+# serialized subagents. Missing route-map entries default to delegate. Route-map
+# entries may explicitly set route=delegate|turbo|direct.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHASE_DIR=""
+CONFIG_PATH=".vbw-planning/config.json"
+EXEC_STATE_PATH=".vbw-planning/.execution-state.json"
+ROUTE_MAP_PATH=""
+SEGMENTS_MODE=false
+
+usage() {
+  echo "usage: resolve-execute-delegation-mode.sh --phase-dir <dir> [--config <path>] [--execution-state <path>] [--route-map <path>] [--segments]" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --phase-dir)
+      PHASE_DIR="${2:-}"
+      shift 2
+      ;;
+    --phase-dir=*)
+      PHASE_DIR="${1#--phase-dir=}"
+      shift
+      ;;
+    --config)
+      CONFIG_PATH="${2:-}"
+      shift 2
+      ;;
+    --config=*)
+      CONFIG_PATH="${1#--config=}"
+      shift
+      ;;
+    --execution-state)
+      EXEC_STATE_PATH="${2:-}"
+      shift 2
+      ;;
+    --execution-state=*)
+      EXEC_STATE_PATH="${1#--execution-state=}"
+      shift
+      ;;
+    --route-map)
+      ROUTE_MAP_PATH="${2:-}"
+      shift 2
+      ;;
+    --route-map=*)
+      ROUTE_MAP_PATH="${1#--route-map=}"
+      shift
+      ;;
+    --segments)
+      SEGMENTS_MODE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+fail_json() {
+  local reason="$1"
+  local diagnostic="${2:-$1}"
+  jq -cn \
+    --arg reason "$reason" \
+    --arg diagnostic "$diagnostic" \
+    '{prefer_teams:null,effective_effort:null,remaining_count:0,delegate_count:0,excluded_plan_ids:[],turbo_plan_ids:[],direct_plan_ids:[],max_parallel_width:0,requested_mode:"subagent",delegation_mode:"subagent",reason:$reason,diagnostic:$diagnostic}'
+}
+
+if [ -z "$PHASE_DIR" ]; then
+  usage
+  fail_json "missing_phase_dir" "--phase-dir is required"
+  exit 2
+fi
+if [ ! -d "$PHASE_DIR" ]; then
+  fail_json "missing_phase_dir" "phase dir does not exist: $PHASE_DIR"
+  exit 2
+fi
+if [ ! -f "$EXEC_STATE_PATH" ]; then
+  fail_json "missing_execution_state" "execution state does not exist: $EXEC_STATE_PATH"
+  exit 2
+fi
+if ! jq empty "$EXEC_STATE_PATH" >/dev/null 2>&1; then
+  fail_json "invalid_execution_state" "execution state is not valid JSON: $EXEC_STATE_PATH"
+  exit 2
+fi
+if [ -n "$ROUTE_MAP_PATH" ]; then
+  if [ ! -f "$ROUTE_MAP_PATH" ]; then
+    fail_json "invalid_route_map" "route map does not exist: $ROUTE_MAP_PATH"
+    exit 2
+  fi
+  if ! jq empty "$ROUTE_MAP_PATH" >/dev/null 2>&1; then
+    fail_json "invalid_route_map" "route map is not valid JSON: $ROUTE_MAP_PATH"
+    exit 2
+  fi
+fi
+
+phase_dir_base=$(basename "${PHASE_DIR%/}")
+phase_prefix=$(printf '%s' "$phase_dir_base" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
+if [ -z "$phase_prefix" ]; then
+  fail_json "invalid_phase_dir" "cannot extract numeric phase prefix from: $phase_dir_base"
+  exit 2
+fi
+phase_num=$((10#$phase_prefix))
+phase_id=$(printf '%02d' "$phase_num")
+
+trim_value() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+strip_quotes() {
+  local value
+  value=$(trim_value "$1")
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+  esac
+  trim_value "$value"
+}
+
+pad_number() {
+  local raw="$1"
+  case "$raw" in
+    ''|*[!0-9]*) printf '%s' "$raw" ;;
+    *) printf '%02d' "$((10#$raw))" ;;
+  esac
+}
+
+normalize_plan_ref() {
+  local raw="$1"
+  local value ph pl
+  value=$(strip_quotes "$raw")
+  value="${value%,}"
+  value=$(strip_quotes "$value")
+  value="${value#\[}"
+  value="${value%\]}"
+  value=$(strip_quotes "$value")
+  [ -z "$value" ] && return 1
+  case "$value" in
+    null|NULL|None|none|[])
+      return 1
+      ;;
+  esac
+  case "$value" in
+    *-*)
+      ph="${value%%-*}"
+      pl="${value#*-}"
+      if [ -n "$ph" ] && [ -n "$pl" ] && [[ "$ph" =~ ^[0-9]+$ ]] && [[ "$pl" =~ ^[0-9]+$ ]]; then
+        printf '%s-%s\n' "$(pad_number "$ph")" "$(pad_number "$pl")"
+      else
+        printf '%s\n' "$value"
+      fi
+      ;;
+    *)
+      if [[ "$value" =~ ^[0-9]+$ ]]; then
+        printf '%s-%s\n' "$phase_id" "$(pad_number "$value")"
+      else
+        printf '%s\n' "$value"
+      fi
+      ;;
+  esac
+}
+
+normalize_status() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    complete|completed) printf 'complete\n' ;;
+    partial) printf 'partial\n' ;;
+    failed) printf 'failed\n' ;;
+    running) printf 'running\n' ;;
+    pending|"") printf 'pending\n' ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+is_execute_satisfied_status() {
+  case "$1" in
+    complete|partial) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+frontmatter_value() {
+  local file="$1"
+  local key="$2"
+  awk -v key="$key" '
+    BEGIN { in_fm=0 }
+    /^---[[:space:]]*$/ { if (in_fm == 0) { in_fm=1; next } else { exit } }
+    in_fm && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+      sub("^[[:space:]]*" key ":[[:space:]]*", "")
+      gsub(/^[\"'"'"']|[\"'"'"']$/, "")
+      print
+      exit
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+extract_dep_lines() {
+  local file="$1"
+  awk '
+    function trim(v) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); return v }
+    function emit(v, n, i, parts) {
+      v = trim(v)
+      sub(/[[:space:]]+#.*$/, "", v)
+      v = trim(v)
+      if (v == "" || v == "[]") return
+      if (v ~ /^\[/) {
+        gsub(/^\[/, "", v); gsub(/\].*$/, "", v)
+        n = split(v, parts, ",")
+        for (i = 1; i <= n; i++) {
+          item = trim(parts[i])
+          if (item != "") print item
+        }
+        return
+      }
+      print v
+    }
+    BEGIN { in_front=0; in_dep=0 }
+    /^---[[:space:]]*$/ { if (in_front == 0) { in_front=1; next } else { exit } }
+    in_front && /^[[:space:]]*depends_on:[[:space:]]*/ {
+      line=$0
+      sub(/^[[:space:]]*depends_on:[[:space:]]*/, "", line)
+      if (trim(line) != "") { emit(line); exit }
+      in_dep=1
+      next
+    }
+    in_front && in_dep && /^[[:space:]]*-[[:space:]]*/ {
+      line=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      emit(line)
+      next
+    }
+    in_front && in_dep && /^[^[:space:]]/ { exit }
+  ' "$file" 2>/dev/null || true
+}
+
+resolve_plan_path() {
+  local id="$1"
+  local plan_part="$id"
+  local candidate=""
+  case "$id" in
+    *-*) plan_part="${id#*-}" ;;
+  esac
+
+  for candidate in \
+    "$PHASE_DIR/${phase_id}-${plan_part}-PLAN.md" \
+    "$PHASE_DIR/${id}-PLAN.md" \
+    "$PHASE_DIR/${plan_part}-PLAN.md"; do
+    [ -f "$candidate" ] || continue
+    local fm_phase fm_plan norm_fm_id
+    fm_phase=$(frontmatter_value "$candidate" phase)
+    fm_plan=$(frontmatter_value "$candidate" plan)
+    if [ -n "$fm_phase" ] || [ -n "$fm_plan" ]; then
+      fm_phase=${fm_phase:-$phase_id}
+      fm_plan=${fm_plan:-$plan_part}
+      norm_fm_id=$(normalize_plan_ref "$(pad_number "$fm_phase")-$(pad_number "$fm_plan")" 2>/dev/null || true)
+      if [ -n "$norm_fm_id" ] && [ "$norm_fm_id" != "$id" ]; then
+        printf 'frontmatter_mismatch:%s:declares:%s\n' "$(basename "$candidate")" "$norm_fm_id" >&2
+        return 3
+      fi
+    fi
+    printf '%s\n' "$candidate"
+    return 0
+  done
+
+  return 1
+}
+
+json_has_key() {
+  local json="$1"
+  local key="$2"
+  jq -e --arg key "$key" 'has($key)' <<< "$json" >/dev/null 2>&1
+}
+
+json_array_contains() {
+  local json="$1"
+  local value="$2"
+  jq -e --arg value "$value" 'index($value) != null' <<< "$json" >/dev/null 2>&1
+}
+
+json_array_add() {
+  local json="$1"
+  local value="$2"
+  jq -c --arg value "$value" '. + [$value]' <<< "$json"
+}
+
+json_object_add_plan() {
+  local json="$1"
+  local id="$2"
+  local status="$3"
+  local route="$4"
+  local reason="$5"
+  local path="$6"
+  jq -c \
+    --arg id "$id" \
+    --arg status "$status" \
+    --arg route "$route" \
+    --arg reason "$reason" \
+    --arg path "$path" \
+    '. + {($id): {status:$status, route:$route, reason:$reason, path:$path, deps:[]}}' <<< "$json"
+}
+
+json_object_set_deps() {
+  local json="$1"
+  local id="$2"
+  local deps_json="$3"
+  jq -c --arg id "$id" --argjson deps "$deps_json" '.[$id].deps = $deps' <<< "$json"
+}
+
+read_prefer_teams_raw() {
+  if [ -f "$CONFIG_PATH" ]; then
+    jq -r '.prefer_teams // "auto"' "$CONFIG_PATH" 2>/dev/null || printf 'auto\n'
+  else
+    printf 'auto\n'
+  fi
+}
+
+prefer_raw=$(read_prefer_teams_raw)
+if [ -x "$SCRIPT_DIR/normalize-prefer-teams.sh" ] || [ -f "$SCRIPT_DIR/normalize-prefer-teams.sh" ]; then
+  prefer_teams=$(bash "$SCRIPT_DIR/normalize-prefer-teams.sh" --value "$prefer_raw" 2>/dev/null || printf '%s\n' "$prefer_raw")
+else
+  case "${prefer_raw:-auto}" in
+    ""|null|false|when_parallel) prefer_teams="auto" ;;
+    true) prefer_teams="always" ;;
+    always|auto|never) prefer_teams="$prefer_raw" ;;
+    *) prefer_teams="$prefer_raw" ;;
+  esac
+fi
+
+effective_effort=$(jq -r '.effort // empty' "$EXEC_STATE_PATH" 2>/dev/null || true)
+if [ -z "$effective_effort" ] || [ "$effective_effort" = "null" ]; then
+  if [ -f "$CONFIG_PATH" ]; then
+    effective_effort=$(jq -r '.effort // "balanced"' "$CONFIG_PATH" 2>/dev/null || printf 'balanced\n')
+  else
+    effective_effort="balanced"
+  fi
+fi
+phase_effort=$(jq -r '.phase_effort // empty' "$EXEC_STATE_PATH" 2>/dev/null || true)
+[ -z "$phase_effort" ] || [ "$phase_effort" = "null" ] && phase_effort="$effective_effort"
+
+plans_json="{}"
+all_plan_ids="[]"
+completed_satisfied_nodes="[]"
+pending_delegate_nodes="[]"
+excluded_turbo_nodes="[]"
+excluded_direct_nodes="[]"
+invalid_reason=""
+invalid_detail=""
+
+while IFS=$'\t' read -r raw_id raw_status; do
+  [ -n "${raw_id:-}" ] || continue
+  plan_id=$(normalize_plan_ref "$raw_id" 2>/dev/null || true)
+  if [ -z "$plan_id" ]; then
+    invalid_reason="invalid_dependency_graph"
+    invalid_detail="invalid plan id in execution state: $raw_id"
+    break
+  fi
+  if json_array_contains "$all_plan_ids" "$plan_id"; then
+    invalid_reason="invalid_dependency_graph"
+    invalid_detail="duplicate plan id in execution state: $plan_id"
+    break
+  fi
+
+  status=$(normalize_status "$raw_status")
+  route="delegate"
+  route_reason="default_delegate"
+  if [ "$effective_effort" = "turbo" ]; then
+    route="turbo"
+    route_reason="phase_effort_turbo"
+  elif [ -n "$ROUTE_MAP_PATH" ]; then
+    route=$(jq -r --arg id "$plan_id" --arg raw "$raw_id" '.plans[$id].route // .plans[$raw].route // "delegate"' "$ROUTE_MAP_PATH" 2>/dev/null || printf 'delegate\n')
+    route_reason=$(jq -r --arg id "$plan_id" --arg raw "$raw_id" '.plans[$id].reason // .plans[$raw].reason // "route_map"' "$ROUTE_MAP_PATH" 2>/dev/null || printf 'route_map\n')
+  fi
+  case "$route" in
+    delegate|turbo|direct) ;;
+    *)
+      invalid_reason="invalid_dependency_graph"
+      invalid_detail="invalid route '$route' for plan $plan_id"
+      break
+      ;;
+  esac
+
+  plan_path=""
+  resolve_err_file=$(mktemp "${TMPDIR:-/tmp}/vbw-resolve-plan.XXXXXX")
+  if ! plan_path=$(resolve_plan_path "$plan_id" 2>"$resolve_err_file"); then
+    _rp_err=$(cat "$resolve_err_file" 2>/dev/null || true)
+    rm -f "$resolve_err_file" 2>/dev/null || true
+    invalid_reason="invalid_dependency_graph"
+    if [ -n "$_rp_err" ]; then
+      invalid_detail="$_rp_err"
+    else
+      invalid_detail="plan file not found for $plan_id"
+    fi
+    break
+  fi
+  rm -f "$resolve_err_file" 2>/dev/null || true
+
+  all_plan_ids=$(json_array_add "$all_plan_ids" "$plan_id")
+  plans_json=$(json_object_add_plan "$plans_json" "$plan_id" "$status" "$route" "$route_reason" "$plan_path")
+
+  if is_execute_satisfied_status "$status"; then
+    completed_satisfied_nodes=$(json_array_add "$completed_satisfied_nodes" "$plan_id")
+  else
+    case "$route" in
+      delegate) pending_delegate_nodes=$(json_array_add "$pending_delegate_nodes" "$plan_id") ;;
+      turbo) excluded_turbo_nodes=$(json_array_add "$excluded_turbo_nodes" "$plan_id") ;;
+      direct) excluded_direct_nodes=$(json_array_add "$excluded_direct_nodes" "$plan_id") ;;
+    esac
+  fi
+done < <(jq -r '.plans[]? | [(.id // ""), (.status // "pending")] | @tsv' "$EXEC_STATE_PATH")
+
+if [ -n "$invalid_reason" ]; then
+  fail_json "$invalid_reason" "$invalid_detail"
+  exit 2
+fi
+
+remaining_nodes=$(jq -cn --argjson a "$pending_delegate_nodes" --argjson b "$excluded_turbo_nodes" --argjson c "$excluded_direct_nodes" '$a + $b + $c')
+remaining_count=$(jq -r 'length' <<< "$remaining_nodes")
+delegate_count=$(jq -r 'length' <<< "$pending_delegate_nodes")
+
+# Extract dependencies for every plan and validate references against satisfied or remaining known nodes.
+for plan_id in $(jq -r 'keys[]' <<< "$plans_json"); do
+  plan_path=$(jq -r --arg id "$plan_id" '.[$id].path' <<< "$plans_json")
+  deps_json="[]"
+  while IFS= read -r dep_raw; do
+    dep_id=$(normalize_plan_ref "$dep_raw" 2>/dev/null || true)
+    [ -n "$dep_id" ] || continue
+    deps_json=$(json_array_add "$deps_json" "$dep_id")
+  done < <(extract_dep_lines "$plan_path")
+  plans_json=$(json_object_set_deps "$plans_json" "$plan_id" "$deps_json")
+
+  for dep_id in $(jq -r '.[]' <<< "$deps_json"); do
+    if json_array_contains "$completed_satisfied_nodes" "$dep_id" || json_array_contains "$remaining_nodes" "$dep_id"; then
+      continue
+    fi
+    fail_json "invalid_dependency_graph" "unresolved dependency: $plan_id depends on $dep_id"
+    exit 2
+  done
+done
+
+# Simulate topological waves over all remaining nodes. Count only delegate nodes in each wave.
+completed_for_sim="$completed_satisfied_nodes"
+unresolved="$remaining_nodes"
+max_parallel_width=0
+waves_json="[]"
+
+while [ "$(jq -r 'length' <<< "$unresolved")" -gt 0 ]; do
+  runnable="[]"
+  blocked="[]"
+  for node in $(jq -r '.[]' <<< "$unresolved"); do
+    deps=$(jq -c --arg id "$node" '.[$id].deps // []' <<< "$plans_json")
+    deps_ok=true
+    for dep in $(jq -r '.[]' <<< "$deps"); do
+      if ! json_array_contains "$completed_for_sim" "$dep"; then
+        deps_ok=false
+        break
+      fi
+    done
+    if [ "$deps_ok" = true ]; then
+      runnable=$(json_array_add "$runnable" "$node")
+    else
+      blocked=$(json_array_add "$blocked" "$node")
+    fi
+  done
+
+  runnable_count=$(jq -r 'length' <<< "$runnable")
+  if [ "$runnable_count" -eq 0 ]; then
+    fail_json "invalid_dependency_graph" "cyclic or blocked dependency graph: $(jq -c '.' <<< "$unresolved")"
+    exit 2
+  fi
+
+  delegate_width=$(jq -r --argjson delegate "$pending_delegate_nodes" '[.[] as $node | select($delegate | index($node))] | length' <<< "$runnable")
+  if [ "$delegate_width" -gt "$max_parallel_width" ]; then
+    max_parallel_width="$delegate_width"
+  fi
+  waves_json=$(jq -c --argjson wave "$runnable" '. + [$wave]' <<< "$waves_json")
+  completed_for_sim=$(jq -cn --argjson a "$completed_for_sim" --argjson b "$runnable" '$a + $b')
+  unresolved="$blocked"
+done
+
+requested_mode="subagent"
+delegation_mode="subagent"
+reason="auto_serial_dependency_graph"
+
+if [ "$remaining_count" -eq 0 ]; then
+  requested_mode="subagent"
+  delegation_mode="subagent"
+  reason="no_remaining_plans"
+elif [ "$delegate_count" -eq 0 ]; then
+  if [ "$(jq -r 'length' <<< "$excluded_turbo_nodes")" -gt 0 ]; then
+    requested_mode="turbo"
+    delegation_mode="direct"
+    reason="no_delegate_eligible_plans"
+  elif [ "$(jq -r 'length' <<< "$excluded_direct_nodes")" -gt 0 ]; then
+    requested_mode="direct"
+    delegation_mode="direct"
+    reason="no_delegate_eligible_plans"
+  fi
+elif [ "$effective_effort" = "turbo" ]; then
+  requested_mode="turbo"
+  delegation_mode="direct"
+  reason="phase_effort_turbo"
+else
+  case "$prefer_teams" in
+    always)
+      requested_mode="team"
+      delegation_mode="team"
+      reason="prefer_teams_always"
+      ;;
+    auto)
+      if [ "$max_parallel_width" -gt 1 ]; then
+        requested_mode="team"
+        delegation_mode="team"
+        reason="parallel_delegate_width:$max_parallel_width"
+      else
+        requested_mode="subagent"
+        delegation_mode="subagent"
+        reason="auto_max_parallel_width:$max_parallel_width"
+      fi
+      ;;
+    never)
+      requested_mode="subagent"
+      delegation_mode="subagent"
+      reason="prefer_teams_never"
+      ;;
+    *)
+      requested_mode="subagent"
+      delegation_mode="subagent"
+      reason="unknown_prefer_teams:$prefer_teams"
+      ;;
+  esac
+fi
+
+base_output=$(jq -cn \
+  --arg prefer_teams "$prefer_teams" \
+  --arg effective_effort "$effective_effort" \
+  --arg phase_effort "$phase_effort" \
+  --argjson remaining_count "$remaining_count" \
+  --argjson delegate_count "$delegate_count" \
+  --argjson completed_satisfied_nodes "$completed_satisfied_nodes" \
+  --argjson pending_delegate_nodes "$pending_delegate_nodes" \
+  --argjson excluded_turbo_nodes "$excluded_turbo_nodes" \
+  --argjson excluded_direct_nodes "$excluded_direct_nodes" \
+  --argjson max_parallel_width "$max_parallel_width" \
+  --arg requested_mode "$requested_mode" \
+  --arg delegation_mode "$delegation_mode" \
+  --arg reason "$reason" \
+  --argjson plans "$plans_json" \
+  --argjson waves "$waves_json" \
+  '{
+    prefer_teams:$prefer_teams,
+    effective_effort:$effective_effort,
+    phase_effort:$phase_effort,
+    remaining_count:$remaining_count,
+    delegate_count:$delegate_count,
+    completed_satisfied_nodes:$completed_satisfied_nodes,
+    pending_delegate_nodes:$pending_delegate_nodes,
+    excluded_turbo_nodes:$excluded_turbo_nodes,
+    excluded_direct_nodes:$excluded_direct_nodes,
+    excluded_plan_ids:([$excluded_turbo_nodes[] | {id: ., route:"turbo", reason:($plans[.].reason // "turbo")}] + [$excluded_direct_nodes[] | {id: ., route:"direct", reason:($plans[.].reason // "direct")}]),
+    turbo_plan_ids:$excluded_turbo_nodes,
+    direct_plan_ids:$excluded_direct_nodes,
+    max_parallel_width:$max_parallel_width,
+    requested_mode:$requested_mode,
+    delegation_mode:$delegation_mode,
+    reason:$reason,
+    plans:$plans,
+    dependency_waves:$waves
+   }')
+
+if [ "$SEGMENTS_MODE" != true ]; then
+  printf '%s\n' "$base_output"
+  exit 0
+fi
+
+segments_json="[]"
+team_segment_index=0
+for wave in $(jq -cr '.[]' <<< "$waves_json"); do
+  # Direct and turbo plans are always serialized one plan at a time.
+  for route in turbo direct; do
+    for node in $(jq -r --arg route "$route" --argjson plans "$plans_json" '.[] | select($plans[.].route == $route)' <<< "$wave"); do
+      seg_effort="$route"
+      seg_delegation="direct"
+      segments_json=$(jq -c \
+        --arg route "$route" \
+        --arg effort "$seg_effort" \
+        --arg delegation_mode "$seg_delegation" \
+        --arg id "$node" \
+        '. + [{route:$route, plan_ids:[$id], effort:$effort, delegation_mode:$delegation_mode, prerequisite_merge_required:false, worktree_refresh_required:true}]' <<< "$segments_json")
+    done
+  done
+
+  delegate_wave=$(jq -c --argjson plans "$plans_json" '[.[] | select($plans[.].route == "delegate")]' <<< "$wave")
+  delegate_wave_count=$(jq -r 'length' <<< "$delegate_wave")
+  if [ "$delegate_wave_count" -gt 0 ]; then
+    seg_mode="subagent"
+    seg_reason="segment_serial_delegate_width:$delegate_wave_count"
+    case "$prefer_teams" in
+      always)
+        seg_mode="team"
+        seg_reason="prefer_teams_always"
+        ;;
+      auto)
+        if [ "$delegate_wave_count" -gt 1 ]; then
+          seg_mode="team"
+          seg_reason="parallel_delegate_width:$delegate_wave_count"
+        else
+          seg_mode="subagent"
+          seg_reason="auto_max_parallel_width:$delegate_wave_count"
+        fi
+        ;;
+      never)
+        seg_mode="subagent"
+        seg_reason="prefer_teams_never"
+        ;;
+      *)
+        seg_mode="subagent"
+        seg_reason="unknown_prefer_teams:$prefer_teams"
+        ;;
+    esac
+    team_name=""
+    if [ "$seg_mode" = "team" ]; then
+      team_segment_index=$((team_segment_index + 1))
+      team_name="vbw-phase-${phase_id}"
+      if [ "$team_segment_index" -gt 1 ]; then
+        team_name="vbw-phase-${phase_id}-segment-${team_segment_index}"
+      fi
+    fi
+    segments_json=$(jq -c \
+      --arg route "delegate" \
+      --arg effort "$phase_effort" \
+      --arg delegation_mode "$seg_mode" \
+      --arg team_name "$team_name" \
+      --arg reason "$seg_reason" \
+      --argjson plan_ids "$delegate_wave" \
+      '. + [{route:$route, plan_ids:$plan_ids, effort:$effort, delegation_mode:$delegation_mode, team_name:(if $team_name == "" then null else $team_name end), reason:$reason, prerequisite_merge_required:false, worktree_refresh_required:true}]' <<< "$segments_json")
+  fi
+done
+
+jq -c --argjson segments "$segments_json" '. + {segments:$segments}' <<< "$base_output"

--- a/scripts/resolve-execute-delegation-mode.sh
+++ b/scripts/resolve-execute-delegation-mode.sh
@@ -97,6 +97,20 @@ if ! jq empty "$EXEC_STATE_PATH" >/dev/null 2>&1; then
   fail_json "invalid_execution_state" "execution state is not valid JSON: $EXEC_STATE_PATH"
   exit 2
 fi
+
+exec_shape_error=$(jq -r '
+  if type != "object" then "execution_state_not_object"
+  elif (.plans | type) != "array" then "plans_not_array"
+  elif any(.plans[]; type != "object") then "plan_entry_not_object"
+  elif any(.plans[]; (has("id") | not) or ((.id | type) as $t | ($t != "string" and $t != "number")) or ((.id | tostring | length) == 0)) then "plan_entry_missing_id"
+  else ""
+  end
+' "$EXEC_STATE_PATH" 2>/dev/null || echo "execution_state_schema_error")
+if [ -n "$exec_shape_error" ]; then
+  fail_json "invalid_dependency_graph" "$exec_shape_error"
+  exit 2
+fi
+
 if [ -n "$ROUTE_MAP_PATH" ]; then
   if [ ! -f "$ROUTE_MAP_PATH" ]; then
     fail_json "invalid_route_map" "route map does not exist: $ROUTE_MAP_PATH"
@@ -104,6 +118,19 @@ if [ -n "$ROUTE_MAP_PATH" ]; then
   fi
   if ! jq empty "$ROUTE_MAP_PATH" >/dev/null 2>&1; then
     fail_json "invalid_route_map" "route map is not valid JSON: $ROUTE_MAP_PATH"
+    exit 2
+  fi
+  route_map_shape_error=$(jq -r '
+    if type != "object" then "route_map_not_object"
+    elif (.plans | type) != "object" then "route_map_plans_not_object"
+    elif any(.plans | to_entries[]; (.value | type) != "object") then "route_map_entry_not_object"
+    elif any(.plans | to_entries[]; (.value.route? != null) and ((.value.route | type) != "string" or ((.value.route == "delegate" or .value.route == "turbo" or .value.route == "direct") | not))) then "route_map_invalid_route"
+    elif any(.plans | to_entries[]; (.value.reason? != null) and ((.value.reason | type) == "object" or (.value.reason | type) == "array")) then "route_map_invalid_reason"
+    else ""
+    end
+  ' "$ROUTE_MAP_PATH" 2>/dev/null || echo "route_map_schema_error")
+  if [ -n "$route_map_shape_error" ]; then
+    fail_json "invalid_dependency_graph" "$route_map_shape_error"
     exit 2
   fi
 fi

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -30,6 +30,7 @@ else
   count_complete_summaries() { echo "0"; }
   count_done_summaries() { echo "0"; }
   is_summary_complete() { return 0; }
+  is_summary_terminal() { return 0; }
 fi
 if [ -f "$SCRIPT_DIR/phase-state-utils.sh" ]; then
   # shellcheck source=phase-state-utils.sh
@@ -375,17 +376,17 @@ if [ -d "$PLANNING_DIR" ] && [ ! -f "$PLANNING_DIR/.skills-section-stripped" ]; 
   fi
 fi
 
-# --- Brownfield: detect SUMMARY.md files without valid completion status ---
+# --- Brownfield: detect SUMMARY.md files without valid terminal status ---
 # Projects bootstrapped before status-aware detection may have SUMMARY files
 # that were created empty (touch) or with non-terminal statuses. Warn so users
-# know these plans won't be counted as complete under the new detection.
+# know these plans won't be counted as done under the new detection.
 _bf_bad_summary_count=0
 if [ -d "$PLANNING_DIR/phases" ]; then
   for _bf_phase_dir in "$PLANNING_DIR"/phases/*/; do
     [ -d "$_bf_phase_dir" ] || continue
     for _bf_sf in "$_bf_phase_dir"*-SUMMARY.md "$_bf_phase_dir"SUMMARY.md; do
       [ -f "$_bf_sf" ] || continue
-      if ! is_summary_complete "$_bf_sf"; then
+      if ! is_summary_terminal "$_bf_sf"; then
         _bf_bad_summary_count=$((_bf_bad_summary_count + 1))
       fi
     done
@@ -731,33 +732,34 @@ if [ "$_auto_recovered" = false ] && [ -f "$EXEC_STATE" ]; then
       done
 
       # Reconcile individual plan statuses against actual SUMMARY.md files.
-      # After a reset/undo, .execution-state.json may have stale "complete"
-      # entries for plans whose SUMMARY.md no longer exists on disk.
-      _json_done=$(jq -r '[.plans[]? | select(.status == "complete" or .status == "partial")] | length' "$EXEC_STATE" 2>/dev/null || echo 0)
-      if [ "${_json_done:-0}" -gt "${SUMMARY_COUNT:-0}" ] 2>/dev/null; then
-        # Build JSON array of plan IDs that actually have completed SUMMARY.md
-        _completed_json="[]"
-        for _sf in "$PHASE_DIR"/*-SUMMARY.md "$PHASE_DIR"/SUMMARY.md; do
-          [ -f "$_sf" ] || continue
-          _sf_st=$(extract_summary_status "$_sf")
-          case "$_sf_st" in
-            complete|completed|partial)
-              _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
-              _completed_json=$(echo "$_completed_json" | jq --arg id "$_sf_id" '. + [$id]')
-              ;;
-          esac
-        done
-        # Reset plans to "pending" if their SUMMARY.md is missing on disk
-        _reconcile_tmp="${EXEC_STATE}.reconcile.$$"
-        jq --argjson completed "$_completed_json" '
-          .plans |= map(
-            if (.status == "complete" or .status == "partial") and (.id as $pid | $completed | any(. == $pid) | not) then
-              .status = "pending"
-            else .
-            end
-          )
-        ' "$EXEC_STATE" > "$_reconcile_tmp" 2>/dev/null && mv "$_reconcile_tmp" "$EXEC_STATE" 2>/dev/null || rm -f "$_reconcile_tmp" 2>/dev/null
-      fi
+      # Verified terminal SUMMARY statuses are authoritative for Execute state:
+      # complete stays complete, partial stays partial, failed stays failed.
+      # After a reset/undo, stale terminal JSON entries without SUMMARY.md are
+      # reset to pending so dependents do not unlock from phantom completion.
+      _summary_status_json="{}"
+      for _sf in "$PHASE_DIR"/*-SUMMARY.md "$PHASE_DIR"/SUMMARY.md; do
+        [ -f "$_sf" ] || continue
+        _sf_st=$(extract_summary_status "$_sf")
+        case "$_sf_st" in
+          complete|completed) _sf_st="complete" ;;
+          partial) _sf_st="partial" ;;
+          failed) _sf_st="failed" ;;
+          *) continue ;;
+        esac
+        _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
+        _summary_status_json=$(jq -cn --argjson current "$_summary_status_json" --arg id "$_sf_id" --arg status "$_sf_st" '$current + {($id): $status}')
+      done
+      _reconcile_tmp="${EXEC_STATE}.reconcile.$$"
+      jq --argjson summary_statuses "$_summary_status_json" '
+        .plans |= map(
+          if ($summary_statuses[.id] // null) != null then
+            .status = $summary_statuses[.id]
+          elif (.status == "complete" or .status == "partial" or .status == "failed") then
+            .status = "pending"
+          else .
+          end
+        )
+      ' "$EXEC_STATE" > "$_reconcile_tmp" 2>/dev/null && mv "$_reconcile_tmp" "$EXEC_STATE" 2>/dev/null || rm -f "$_reconcile_tmp" 2>/dev/null
 
       if [ "${STRICT_COMPLETE:-0}" -ge "${PLAN_COUNT:-1}" ] && [ "${PLAN_COUNT:-0}" -gt 0 ]; then
         # All plans are strictly complete — build finished after crash

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -14,7 +14,7 @@ else
   # Safe default: report zero completions when helpers unavailable
   count_complete_summaries() { echo "0"; }
   count_terminal_summaries() { echo "0"; }
-  extract_summary_status() { return 0; }
+  extract_summary_status() { printf ''; return 1; }
 fi
 if [ -f "$SCRIPT_DIR/phase-state-utils.sh" ]; then
   # shellcheck source=phase-state-utils.sh
@@ -376,7 +376,10 @@ fi
 # partial product write cannot preemptively unlock dependent plans.
 STATUS_RAW="$STATUS"
 if type extract_summary_status >/dev/null 2>&1; then
-  STATUS_RAW=$(extract_summary_status "$FILE_PATH")
+  _summary_status_raw=$(extract_summary_status "$FILE_PATH" 2>/dev/null || true)
+  if [ -n "$_summary_status_raw" ]; then
+    STATUS_RAW="$_summary_status_raw"
+  fi
 fi
 STATUS_RAW=$(printf '%s' "${STATUS_RAW:-}" | tr '[:upper:]' '[:lower:]' | tr -d "\r\"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 STATUS=""

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -14,6 +14,7 @@ else
   # Safe default: report zero completions when helpers unavailable
   count_complete_summaries() { echo "0"; }
   count_terminal_summaries() { echo "0"; }
+  extract_summary_status() { return 0; }
 fi
 if [ -f "$SCRIPT_DIR/phase-state-utils.sh" ]; then
   # shellcheck source=phase-state-utils.sh
@@ -370,17 +371,23 @@ if [ -z "$PLAN" ]; then
   [ "$PLAN" = "$SUMMARY_ID" ] && PLAN="$SUMMARY_ID"
 fi
 
-# Normalize status: map known variants to canonical values
-case "$(echo "${STATUS:-}" | tr '[:upper:]' '[:lower:]')" in
-  complete|completed|done) STATUS="complete" ;;
-  partial|incomplete|in_progress|in-progress) STATUS="partial" ;;
-  failed|error|errored) STATUS="failed" ;;
-  "") STATUS="complete" ;;  # default for missing status
-  *) STATUS="complete" ;;   # unknown status — normalize to complete
+# Normalize status: only verified terminal SUMMARY statuses update execution-state.
+# Missing, unknown, and nonterminal statuses are intentionally ignored so a
+# partial product write cannot preemptively unlock dependent plans.
+STATUS_RAW="$STATUS"
+if type extract_summary_status >/dev/null 2>&1; then
+  STATUS_RAW=$(extract_summary_status "$FILE_PATH")
+fi
+STATUS_RAW=$(printf '%s' "${STATUS_RAW:-}" | tr '[:upper:]' '[:lower:]' | tr -d "\r\"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+STATUS=""
+case "$STATUS_RAW" in
+  complete|completed) STATUS="complete" ;;
+  partial) STATUS="partial" ;;
+  failed) STATUS="failed" ;;
 esac
 
 # Update execution-state as best-effort only (never gates STATE/ROADMAP updates)
-if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ]; then
+if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ] && [ -n "$STATUS" ]; then
   TEMP_FILE="${STATE_FILE}.tmp.$$.${RANDOM:-0}"
   jq --arg phase "$PHASE" --arg plan "$PLAN" --arg status "$STATUS" --arg summary_id "$SUMMARY_ID" '
     def as_num: (try tonumber catch null);

--- a/scripts/summary-utils.sh
+++ b/scripts/summary-utils.sh
@@ -87,6 +87,30 @@ is_summary_terminal() {
   esac
 }
 
+# is_valid_summary_status STATUS
+# Returns 0 only for canonical runtime SUMMARY statuses.
+# Brownfield "completed" is accepted by file-level helpers above, but runtime
+# execution state should canonicalize it to "complete" before validation.
+is_valid_summary_status() {
+  local status
+  status=$(trim_summary_value "${1:-}")
+  case "$status" in
+    complete|partial|failed) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# is_execution_progress_status STATUS
+# Returns 0 for statuses that satisfy Execute dependency progression.
+is_execution_progress_status() {
+  local status
+  status=$(trim_summary_value "${1:-}")
+  case "$status" in
+    complete|partial) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # count_complete_summaries DIR
 # Returns count of SUMMARY.md files with terminal-complete status in DIR.
 count_complete_summaries() {
@@ -103,8 +127,9 @@ count_complete_summaries() {
 }
 
 # count_done_summaries DIR
-# Returns count of SUMMARY.md files considered "done" for reconciliation:
-# complete, completed, or partial (matching recover-state.sh's promotion of partial→complete).
+# Returns count of SUMMARY.md files considered "done" for Execute/statusline
+# reconciliation: complete, completed, or partial. Runtime execution state
+# preserves partial as partial; it is progression-satisfied but not strict-complete.
 count_done_summaries() {
   local dir="$1"
   local count=0

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -23,11 +23,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/vbw-config-root.sh
 . "$SCRIPT_DIR/lib/vbw-config-root.sh"
 
-if [ -f "$SCRIPT_DIR/lib/summary-status.sh" ]; then
-  # shellcheck source=lib/summary-status.sh
-  . "$SCRIPT_DIR/lib/summary-status.sh"
-fi
-
 if [ -f "$SCRIPT_DIR/summary-utils.sh" ]; then
   # shellcheck source=summary-utils.sh
   . "$SCRIPT_DIR/summary-utils.sh"

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -27,6 +27,7 @@ printf '%s\t%s\n' \
   permission-mode-contract     testing/verify-permission-mode-contract.sh \
   delegation-guard             testing/verify-delegation-guard.sh \
   agent-spawn-guard            testing/verify-agent-spawn-guard.sh \
+  execute-delegation-routing   testing/verify-execute-delegation-routing.sh \
   summary-status-contract      testing/verify-summary-status-contract.sh \
   summary-utils-contract       testing/verify-summary-utils-contract.sh \
   exec-state-reconciliation    testing/verify-exec-state-reconciliation.sh \

--- a/testing/verify-agent-spawn-guard.sh
+++ b/testing/verify-agent-spawn-guard.sh
@@ -243,6 +243,22 @@ test_non_team_mode_blocks_background_spawn() {
 }
 test_non_team_mode_blocks_background_spawn
 
+test_direct_mode_blocks_background_spawn() {
+  setup_project
+  write_execution_state "corr-123"
+  write_marker execute direct "" "corr-123"
+
+  local output rc
+  output=$(run_guard "$PROJECT" "" true 2>&1) && rc=$? || rc=$?
+  if [ "$rc" -eq 2 ] && echo "$output" | grep -q 'cannot simulate team mode with background Agent spawns'; then
+    pass "Execute direct mode blocks faux-team background spawn"
+  else
+    fail "Execute direct mode should block background spawn (rc=$rc, output=$output)"
+  fi
+  cleanup
+}
+test_direct_mode_blocks_background_spawn
+
 test_non_team_mode_allows_foreground_spawn() {
   setup_project
   write_execution_state "corr-123"

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -1061,14 +1061,15 @@ else
   fail "execute-protocol: missing explicit non-team fallback warning text"
 fi
 
-if ! grep -Fq 'When team was created (2+ plans)' "$ROOT/references/execute-protocol.md" \
-  && grep -Fq 'request team mode for ALL remaining-plan counts (even 1 plan)' "$ROOT/references/execute-protocol.md" \
-  && grep -Fq 'ALL remaining-plan counts (even 1 plan)' "$ROOT/references/execute-protocol.md" \
+if grep -Fq 'resolve-execute-delegation-mode.sh' "$ROOT/references/execute-protocol.md" \
+  && grep -Fq "prefer_teams='auto'" "$ROOT/references/execute-protocol.md" \
+  && grep -Fq 'max_parallel_width > 1' "$ROOT/references/execute-protocol.md" \
+  && ! grep -Fq "prefer_teams='auto': request team mode only when 2+ uncompleted plans remain" "$ROOT/references/execute-protocol.md" \
   && grep -Fq 'When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "dev-{MM}"`' "$ROOT/references/execute-protocol.md" \
   && grep -Fq 'When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "qa"' "$ROOT/references/execute-protocol.md"; then
-  pass "execute-protocol: single-plan team mode uses consistent true-team metadata wording"
+  pass "execute-protocol: dependency-aware routing uses consistent true-team metadata wording"
 else
-  fail "execute-protocol: single-plan team mode wording is inconsistent or still references 2+ plan team creation"
+  fail "execute-protocol: dependency-aware routing wording is inconsistent or still references stale 2+ plan team creation"
 fi
 
 if grep -q 'scripts/delegated-workflow.sh" set execute' "$ROOT/references/execute-protocol.md" \

--- a/testing/verify-delegation-guard.sh
+++ b/testing/verify-delegation-guard.sh
@@ -243,6 +243,30 @@ test_direct_effort_allowed() {
 }
 test_direct_effort_allowed
 
+# --- Test 10b: Execute direct marker is live and allowed through effort exemption ---
+test_execute_direct_marker_allowed() {
+  setup_project
+  jq -n '{phase:1,status:"running",effort:"direct",correlation_id:"corr-direct",plans:[{id:"01-01",status:"pending"}]}' \
+    > "$PROJECT/.vbw-planning/.execution-state.json"
+  (cd "$PROJECT" && bash "$DELEG_SCRIPT" set execute direct direct)
+
+  local status_json
+  status_json=$(cd "$PROJECT" && bash "$DELEG_SCRIPT" status-json)
+  if jq -e '.live == true and .delegation_mode == "direct" and .mode == "execute"' >/dev/null <<< "$status_json"; then
+    pass "execute direct marker: status-json reports live direct mode"
+  else
+    fail "execute direct marker: expected live direct mode, got $status_json"
+  fi
+
+  if run_guard "$PROJECT" "src/app.js" "" >/dev/null 2>&1; then
+    pass "execute direct marker: file-guard allows direct effort product write"
+  else
+    fail "execute direct marker: file-guard unexpectedly blocked direct effort product write"
+  fi
+  cleanup
+}
+test_execute_direct_marker_allowed
+
 # --- Test 11: Execution running with complete status → no block ---
 test_complete_status_no_block() {
   setup_project

--- a/testing/verify-exec-state-reconciliation.sh
+++ b/testing/verify-exec-state-reconciliation.sh
@@ -73,25 +73,25 @@ fi
 echo ""
 echo "--- Session-start plan status reconciliation ---"
 
-# Test 6: session-start compares JSON complete count vs disk SUMMARY count
-if grep -q '_json_done.*plans.*select.*complete.*length' "$ROOT/scripts/session-start.sh"; then
-  pass "session-start extracts JSON complete count for comparison"
+# Test 6: session-start counts complete and partial SUMMARY files for reconciliation
+if grep -q 'SUMMARY_COUNT=0' "$ROOT/scripts/session-start.sh" && grep -q 'partial) SUMMARY_COUNT' "$ROOT/scripts/session-start.sh"; then
+  pass "session-start counts complete and partial SUMMARY files for reconciliation"
 else
-  fail "session-start extracts JSON complete count for comparison"
+  fail "session-start counts complete and partial SUMMARY files for reconciliation"
 fi
 
-# Test 7: session-start triggers reconciliation when JSON > disk
-if grep -q '_json_done.*-gt.*SUMMARY_COUNT' "$ROOT/scripts/session-start.sh"; then
-  pass "session-start triggers reconciliation when JSON exceeds disk count"
+# Test 7: session-start reconciles JSON statuses from disk SUMMARY status map
+if grep -q 'summary_statuses\[\.id\]' "$ROOT/scripts/session-start.sh" && grep -q '\.status = "pending"' "$ROOT/scripts/session-start.sh"; then
+  pass "session-start reconciles JSON statuses from disk SUMMARY status map"
 else
-  fail "session-start triggers reconciliation when JSON exceeds disk count"
+  fail "session-start reconciles JSON statuses from disk SUMMARY status map"
 fi
 
 # Test 8: session-start builds completed IDs from actual SUMMARY.md files
-if grep -q '_completed_json' "$ROOT/scripts/session-start.sh" && grep -q 'SUMMARY' "$ROOT/scripts/session-start.sh"; then
-  pass "session-start builds completed ID list from SUMMARY.md files"
+if grep -q '_summary_status_json' "$ROOT/scripts/session-start.sh" && grep -q 'SUMMARY' "$ROOT/scripts/session-start.sh"; then
+  pass "session-start builds SUMMARY status map from SUMMARY.md files"
 else
-  fail "session-start builds completed ID list from SUMMARY.md files"
+  fail "session-start builds SUMMARY status map from SUMMARY.md files"
 fi
 
 # Test 9: session-start resets stale plan statuses to "pending"
@@ -102,7 +102,7 @@ else
 fi
 
 # Test 10: session-start reconciliation uses jq for atomic JSON update
-if grep -q 'argjson completed' "$ROOT/scripts/session-start.sh" && grep -q 'reconcile_tmp' "$ROOT/scripts/session-start.sh"; then
+if grep -q 'argjson summary_statuses' "$ROOT/scripts/session-start.sh" && grep -q 'reconcile_tmp' "$ROOT/scripts/session-start.sh"; then
   pass "session-start uses jq with argjson for atomic reconciliation"
 else
   fail "session-start uses jq with argjson for atomic reconciliation"
@@ -162,23 +162,27 @@ else
 fi
 
 # Simulate the reconciliation logic from session-start
-_completed_json="[]"
+_summary_status_json="{}"
 for _sf in "$FAKE_PHASE"/*-SUMMARY.md; do
   [ -f "$_sf" ] || continue
   _sf_st=$(sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' "$_sf" 2>/dev/null | head -1 | tr -d '[:space:]')
   case "$_sf_st" in
-    complete|completed)
-      _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
-      _completed_json=$(echo "$_completed_json" | jq --arg id "$_sf_id" '. + [$id]')
-      ;;
+    complete|completed) _sf_st="complete" ;;
+    partial) _sf_st="partial" ;;
+    failed) _sf_st="failed" ;;
+    *) continue ;;
   esac
+      _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
+  _summary_status_json=$(jq -cn --argjson current "$_summary_status_json" --arg id "$_sf_id" --arg status "$_sf_st" '$current + {($id): $status}')
 done
 
 EXEC_STATE="$FAKE_PROJECT/.execution-state.json"
 _reconcile_tmp="${EXEC_STATE}.reconcile.$$"
-jq --argjson completed "$_completed_json" '
+jq --argjson summary_statuses "$_summary_status_json" '
   .plans |= map(
-    if .status == "complete" and (.id as $pid | $completed | any(. == $pid) | not) then
+    if ($summary_statuses[.id] // null) != null then
+      .status = $summary_statuses[.id]
+    elif (.status == "complete" or .status == "partial" or .status == "failed") then
       .status = "pending"
     else .
     end
@@ -214,7 +218,7 @@ else
   fail "reconciliation: plan 06-03 stays pending (got $PLAN3_STATUS)"
 fi
 
-# --- Functional: partial SUMMARY → reconciliation preserves "complete" in JSON ---
+# --- Functional: partial SUMMARY → reconciliation preserves "partial" in JSON ---
 echo ""
 echo "--- Functional: partial SUMMARY accepted by reconciliation ---"
 
@@ -254,42 +258,46 @@ status: partial
 SUMMARY
 
 # Reconciliation should count both complete and partial as "done"
-_completed_json="[]"
+_summary_status_json="{}"
 for _sf in "$PARTIAL_PHASE"/*-SUMMARY.md; do
   [ -f "$_sf" ] || continue
   _sf_st=$(sed -n '/^---$/,/^---$/{ /^status:/{ s/^status:[[:space:]]*//; s/["'"'"']//g; p; }; }' "$_sf" 2>/dev/null | head -1 | tr -d '[:space:]')
   case "$_sf_st" in
-    complete|completed|partial)
-      _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
-      _completed_json=$(echo "$_completed_json" | jq --arg id "$_sf_id" '. + [$id]')
-      ;;
+    complete|completed) _sf_st="complete" ;;
+    partial) _sf_st="partial" ;;
+    failed) _sf_st="failed" ;;
+    *) continue ;;
   esac
+      _sf_id=$(basename "$_sf" | sed 's/-SUMMARY\.md$//')
+  _summary_status_json=$(jq -cn --argjson current "$_summary_status_json" --arg id "$_sf_id" --arg status "$_sf_st" '$current + {($id): $status}')
 done
 
 EXEC_STATE="$PARTIAL_PROJECT/.execution-state.json"
 _reconcile_tmp="${EXEC_STATE}.reconcile.$$"
-jq --argjson completed "$_completed_json" '
+jq --argjson summary_statuses "$_summary_status_json" '
   .plans |= map(
-    if .status == "complete" and (.id as $pid | $completed | any(. == $pid) | not) then
+    if ($summary_statuses[.id] // null) != null then
+      .status = $summary_statuses[.id]
+    elif (.status == "complete" or .status == "partial" or .status == "failed") then
       .status = "pending"
     else .
     end
   )
 ' "$EXEC_STATE" > "$_reconcile_tmp" 2>/dev/null && mv "$_reconcile_tmp" "$EXEC_STATE" 2>/dev/null
 
-# Both plans should stay "complete" because both have SUMMARY.md (one complete, one partial)
-PARTIAL_DONE=$(jq '[.plans[] | select(.status == "complete")] | length' "$EXEC_STATE")
+# One plan should stay complete and the partial SUMMARY should be preserved as partial.
+PARTIAL_DONE=$(jq '[.plans[] | select(.status == "complete" or .status == "partial")] | length' "$EXEC_STATE")
 if [ "$PARTIAL_DONE" -eq 2 ]; then
-  pass "partial: both plans preserved as complete (2 done)"
+  pass "partial: both plans preserved as done (1 complete + 1 partial)"
 else
-  fail "partial: both plans preserved as complete (got $PARTIAL_DONE)"
+  fail "partial: both plans preserved as done (got $PARTIAL_DONE)"
 fi
 
 PARTIAL_P2=$(jq -r '.plans[] | select(.id == "03-02") | .status' "$EXEC_STATE")
-if [ "$PARTIAL_P2" = "complete" ]; then
-  pass "partial: plan 03-02 with partial SUMMARY kept as complete"
+if [ "$PARTIAL_P2" = "partial" ]; then
+  pass "partial: plan 03-02 with partial SUMMARY preserved as partial"
 else
-  fail "partial: plan 03-02 with partial SUMMARY kept as complete (got $PARTIAL_P2)"
+  fail "partial: plan 03-02 with partial SUMMARY preserved as partial (got $PARTIAL_P2)"
 fi
 
 # --- Functional: statusline reconciliation (count_done_summaries) ---
@@ -369,10 +377,10 @@ else
   fail "statusline JQ counts partial plans as done"
 fi
 
-if grep -q 'select(.status == "complete" or .status == "partial")' "$ROOT/scripts/session-start.sh"; then
-  pass "session-start JQ counts partial plans as done"
+if grep -q 'partial) SUMMARY_COUNT' "$ROOT/scripts/session-start.sh" && grep -q 'summary_statuses\[\.id\]' "$ROOT/scripts/session-start.sh"; then
+  pass "session-start reconciliation preserves partial plans as done"
 else
-  fail "session-start JQ counts partial plans as done"
+  fail "session-start reconciliation preserves partial plans as done"
 fi
 
 # recover-state COMPLETE count must use strict-complete only (partial is progress, not done)

--- a/testing/verify-execute-delegation-routing.sh
+++ b/testing/verify-execute-delegation-routing.sh
@@ -123,9 +123,10 @@ assert_json_array_eq() {
 
 expect_helper_failure() {
   local label="$1"
+  shift
   local out status reason
   set +e
-  out=$(run_helper 2>/dev/null)
+  out=$(run_helper "$@" 2>/dev/null)
   status=$?
   set -e
   reason=$(jq -r '.reason // empty' <<< "$out" 2>/dev/null || true)
@@ -291,6 +292,54 @@ write_state '{"plans":[{"id":"01-02","status":"pending"}],"effort":"balanced","p
 write_plan_inline 01-02-PLAN.md 01 03 '[]'
 expect_helper_failure "frontmatter plan mismatch fails closed with invalid_dependency_graph"
 
+# malformed execution-state / route-map schemas fail closed before spawning
+make_fixture valid-empty-plans '"auto"' balanced
+write_state '{"plans":[],"effort":"balanced","phase_effort":"balanced"}'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.reason')" "no_remaining_plans" "valid empty execution-state plans array returns no_remaining_plans"
+
+make_fixture missing-plans '"auto"' balanced
+write_state '{"effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "missing execution-state plans fails closed with invalid_dependency_graph"
+
+make_fixture scalar-plans '"auto"' balanced
+write_state '{"plans":"oops","effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "scalar execution-state plans fails closed with invalid_dependency_graph"
+
+make_fixture object-plans '"auto"' balanced
+write_state '{"plans":{"01-01":{"status":"pending"}},"effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "object execution-state plans fails closed with invalid_dependency_graph"
+
+make_fixture scalar-plan-entry '"auto"' balanced
+write_state '{"plans":["01-01"],"effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "scalar execution-state plan entry fails closed with invalid_dependency_graph"
+
+make_fixture missing-plan-id '"auto"' balanced
+write_state '{"plans":[{"status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "execution-state plan missing id fails closed with invalid_dependency_graph"
+
+make_fixture empty-plan-id '"auto"' balanced
+write_state '{"plans":[{"id":"","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+expect_helper_failure "execution-state plan empty id fails closed with invalid_dependency_graph"
+
+make_fixture route-map-scalar-plans '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+printf '{"plans":"oops"}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+expect_helper_failure "scalar route-map plans fails closed with invalid_dependency_graph" --route-map .vbw-planning/.cache/execute-route-map.json
+
+make_fixture route-map-scalar-entry '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+printf '{"plans":{"01-01":"turbo"}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+expect_helper_failure "scalar route-map entry fails closed with invalid_dependency_graph" --route-map .vbw-planning/.cache/execute-route-map.json
+
+make_fixture route-map-invalid-route '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+printf '{"plans":{"01-01":{"route":"parallel"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+expect_helper_failure "invalid route-map route fails closed with invalid_dependency_graph" --route-map .vbw-planning/.cache/execute-route-map.json
+
 # prefer_teams canonicalization, including legacy aliases only in tests/helper code
 for raw in '"when_parallel"' 'false' 'null' '""'; do
   make_fixture "canon-$raw" "$raw" balanced
@@ -394,6 +443,21 @@ if grep -q 'delegation_mode=team' "$EXECUTE_PROTOCOL" && grep -q 'TEAM_NAME' "$E
   pass "execute-protocol keys team shutdown off actual delegation_mode=team plus TEAM_NAME"
 else
   fail "execute-protocol keys team shutdown off actual delegation_mode=team plus TEAM_NAME"
+fi
+
+if grep -Fq 'set execute {segment_effort} direct' "$EXECUTE_PROTOCOL" \
+  && grep -Fq 'set execute {segment_effort} subagent' "$EXECUTE_PROTOCOL" \
+  && grep -Fq 'For serialized delegate segments (`route=delegate`, `delegation_mode=subagent`)' "$EXECUTE_PROTOCOL" \
+  && grep -Fq 'For `turbo` or internal `direct` segments (`delegation_mode=direct`)' "$EXECUTE_PROTOCOL"; then
+  pass "execute-protocol persists direct/turbo and serialized subagent segments distinctly"
+else
+  fail "execute-protocol persists direct/turbo and serialized subagent segments distinctly"
+fi
+
+if grep -Fq 'Do not start a non-team segment while `.delegated-workflow.json` still reports a live team marker' "$EXECUTE_PROTOCOL"; then
+  pass "execute-protocol forbids non-team segment while live team marker exists"
+else
+  fail "execute-protocol forbids non-team segment while live team marker exists"
 fi
 
 if grep -Fq 'When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "dev-{MM}"`' "$EXECUTE_PROTOCOL" \

--- a/testing/verify-execute-delegation-routing.sh
+++ b/testing/verify-execute-delegation-routing.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-execute-delegation-routing.sh — dependency-aware Execute routing contract
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$ROOT/scripts/resolve-execute-delegation-mode.sh"
+GENERATE_CONTRACT="$ROOT/scripts/generate-contract.sh"
+STATE_UPDATER="$ROOT/scripts/state-updater.sh"
+EXECUTE_PROTOCOL="$ROOT/references/execute-protocol.md"
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=""
+
+pass() {
+  echo "PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
+cleanup() {
+  [ -n "$TMPDIR_BASE" ] && rm -rf "$TMPDIR_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+require_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "ERROR: missing required file: $path" >&2
+    exit 1
+  fi
+}
+
+make_fixture() {
+  local name="$1"
+  local prefer="${2:-auto}"
+  local effort="${3:-balanced}"
+  FIXTURE="$TMPDIR_BASE/$name"
+  PHASE_DIR="$FIXTURE/.vbw-planning/phases/01-test"
+  mkdir -p "$PHASE_DIR" "$FIXTURE/.vbw-planning/.cache"
+  printf '{"prefer_teams":%s,"effort":"%s"}\n' "$prefer" "$effort" > "$FIXTURE/.vbw-planning/config.json"
+}
+
+write_state() {
+  local json="$1"
+  printf '%s\n' "$json" > "$FIXTURE/.vbw-planning/.execution-state.json"
+}
+
+write_plan_inline() {
+  local filename="$1"
+  local phase="$2"
+  local plan="$3"
+  local depends="$4"
+  cat > "$PHASE_DIR/$filename" <<PLAN
+---
+phase: $phase
+plan: $plan
+title: Plan $plan
+depends_on: $depends
+---
+# Plan $plan
+
+### Task 1: Work
+- **Files:** \`src/$plan.txt\`
+PLAN
+}
+
+write_plan_block() {
+  local filename="$1"
+  local phase="$2"
+  local plan="$3"
+  shift 3
+  {
+    printf '%s\n' '---'
+    printf 'phase: %s\n' "$phase"
+    printf 'plan: %s\n' "$plan"
+    printf 'title: Plan %s\n' "$plan"
+    printf '%s\n' 'depends_on:'
+    local dep
+    for dep in "$@"; do
+      printf '  - %s\n' "$dep"
+    done
+    printf '%s\n' '---' '# Plan' '' '### Task 1: Work' '- **Files:** `src/file.txt`'
+  } > "$PHASE_DIR/$filename"
+}
+
+run_helper() {
+  (cd "$FIXTURE" && "$HELPER" --phase-dir .vbw-planning/phases/01-test "${@}")
+}
+
+json_field() {
+  local json="$1"
+  local expr="$2"
+  jq -r "$expr" <<< "$json"
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_json_array_eq() {
+  local actual_json="$1"
+  local expected_json="$2"
+  local label="$3"
+  if jq -ne --argjson actual "$actual_json" --argjson expected "$expected_json" '$actual == $expected' >/dev/null; then
+    pass "$label"
+  else
+    fail "$label (expected $expected_json, got $actual_json)"
+  fi
+}
+
+expect_helper_failure() {
+  local label="$1"
+  local out status reason
+  set +e
+  out=$(run_helper 2>/dev/null)
+  status=$?
+  set -e
+  reason=$(jq -r '.reason // empty' <<< "$out" 2>/dev/null || true)
+  if [ "$status" -ne 0 ] && [ "$reason" = "invalid_dependency_graph" ]; then
+    pass "$label"
+  else
+    fail "$label (status=$status reason='${reason:-}' output='${out:-}')"
+  fi
+}
+
+require_file "$HELPER"
+require_file "$GENERATE_CONTRACT"
+require_file "$STATE_UPDATER"
+require_file "$EXECUTE_PROTOCOL"
+
+TMPDIR_BASE=$(mktemp -d)
+
+echo "=== Execute Delegation Routing Contract Tests ==="
+
+# auto + linear two-plan chain -> subagent
+make_fixture linear '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "subagent" "auto + linear graph -> subagent"
+assert_eq "$(json_field "$out" '.max_parallel_width')" "1" "auto + linear graph has max_parallel_width=1"
+assert_json_array_eq "$(jq -c '.dependency_waves' <<< "$out")" '[["01-01"],["01-02"]]' "auto + linear graph waves are serialized"
+
+# auto + two independent delegate plans -> team
+make_fixture independent '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "auto + two independent delegate plans -> team"
+assert_eq "$(json_field "$out" '.max_parallel_width')" "2" "independent graph has max_parallel_width=2"
+
+# auto + completed prerequisite unlocks two delegate plans -> team
+make_fixture completed-prereq '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"complete"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+write_plan_inline 01-03-PLAN.md 01 03 '["01-01"]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "completed prerequisite unlocks two delegate plans -> team"
+assert_eq "$(json_field "$out" '.max_parallel_width')" "2" "completed prerequisite graph has delegate width 2"
+
+# auto + partial prerequisite unlocks dependent delegate plans
+make_fixture partial-prereq '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"partial"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+write_plan_inline 01-03-PLAN.md 01 03 '["01-01"]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "partial prerequisite unlocks dependent delegate plans for routing"
+assert_json_array_eq "$(jq -c '.completed_satisfied_nodes' <<< "$out")" '["01-01"]' "partial prerequisite is reported as execute-satisfied"
+
+# auto + single pending delegate plan -> subagent
+make_fixture single '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "subagent" "auto + single pending delegate plan -> subagent"
+
+# never + independent delegate plans -> subagent
+make_fixture never '"never"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "subagent" "prefer_teams=never + independent plans -> subagent"
+
+# always + linear delegate chain -> team unless excluded by turbo/direct
+make_fixture always-linear '"always"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "prefer_teams=always overrides delegate width for linear delegate graph"
+
+# execution-state effort turbo overrides balanced config and bypasses team selection
+make_fixture state-turbo '"always"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"turbo","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.effective_effort')" "turbo" "execution-state effort overrides config effort"
+assert_eq "$(json_field "$out" '.delegation_mode')" "direct" "phase-level turbo bypasses team selection"
+assert_eq "$(json_field "$out" '.requested_mode')" "turbo" "phase-level turbo reports requested_mode=turbo"
+
+# single-plan smart-routed turbo bypasses always team override
+make_fixture smart-turbo '"always"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+printf '{"plans":{"01-01":{"route":"turbo","reason":"smart_route"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+out=$(run_helper --route-map .vbw-planning/.cache/execute-route-map.json)
+assert_eq "$(json_field "$out" '.delegation_mode')" "direct" "smart-routed turbo plan bypasses team even with prefer_teams=always"
+assert_json_array_eq "$(jq -c '.turbo_plan_ids' <<< "$out")" '["01-01"]' "smart-routed turbo plan is reported"
+
+# mixed routing: one turbo + one delegate -> no team for single delegate
+make_fixture mixed-single-delegate '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+printf '{"plans":{"01-01":{"route":"turbo","reason":"smart_route"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+out=$(run_helper --route-map .vbw-planning/.cache/execute-route-map.json)
+assert_eq "$(json_field "$out" '.delegate_count')" "1" "mixed turbo/delegate counts one delegate-eligible plan"
+assert_eq "$(json_field "$out" '.delegation_mode')" "subagent" "mixed turbo + single delegate does not create team"
+
+# mixed routing: direct excluded + two delegates independent -> team
+make_fixture mixed-two-delegates '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+write_plan_inline 01-03-PLAN.md 01 03 '[]'
+printf '{"plans":{"01-03":{"route":"direct","reason":"internal_direct"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+out=$(run_helper --route-map .vbw-planning/.cache/execute-route-map.json)
+assert_eq "$(json_field "$out" '.delegate_count')" "2" "mixed direct/delegate counts two delegate-eligible plans"
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "mixed direct + two independent delegates creates team"
+
+# segment transitions: team -> direct, direct -> team, team -> subagent
+make_fixture segment-team-direct '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+write_plan_inline 01-03-PLAN.md 01 03 '["01-01"]'
+printf '{"plans":{"01-03":{"route":"direct","reason":"internal_direct"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+out=$(run_helper --route-map .vbw-planning/.cache/execute-route-map.json --segments)
+assert_json_array_eq "$(jq -c '[.segments[].delegation_mode]' <<< "$out")" '["team","direct"]' "segments can transition team -> direct"
+
+make_fixture segment-direct-team '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+write_plan_inline 01-03-PLAN.md 01 03 '["01-01"]'
+printf '{"plans":{"01-01":{"route":"direct","reason":"internal_direct"}}}\n' > "$FIXTURE/.vbw-planning/.cache/execute-route-map.json"
+out=$(run_helper --route-map .vbw-planning/.cache/execute-route-map.json --segments)
+assert_json_array_eq "$(jq -c '[.segments[].delegation_mode]' <<< "$out")" '["direct","team"]' "segments can transition direct -> team"
+
+make_fixture segment-team-subagent '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+write_plan_inline 01-03-PLAN.md 01 03 '["01-01", "01-02"]'
+out=$(run_helper --segments)
+assert_json_array_eq "$(jq -c '[.segments[].delegation_mode]' <<< "$out")" '["team","subagent"]' "segments can transition team -> subagent"
+
+# invalid dependency graphs fail closed
+make_fixture cyclic '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '["01-02"]'
+write_plan_inline 01-02-PLAN.md 01 02 '["01-01"]'
+expect_helper_failure "cyclic dependency graph fails closed with invalid_dependency_graph"
+
+make_fixture unresolved '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '["01-99"]'
+expect_helper_failure "unresolved dependency graph fails closed with invalid_dependency_graph"
+
+make_fixture mismatch '"auto"' balanced
+write_state '{"plans":[{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-02-PLAN.md 01 03 '[]'
+expect_helper_failure "frontmatter plan mismatch fails closed with invalid_dependency_graph"
+
+# prefer_teams canonicalization, including legacy aliases only in tests/helper code
+for raw in '"when_parallel"' 'false' 'null' '""'; do
+  make_fixture "canon-$raw" "$raw" balanced
+  write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+  write_plan_inline 01-01-PLAN.md 01 01 '[]'
+  write_plan_inline 01-02-PLAN.md 01 02 '[]'
+  out=$(run_helper)
+  assert_eq "$(json_field "$out" '.prefer_teams')" "auto" "prefer_teams $raw canonicalizes to auto"
+done
+
+make_fixture canon-true 'true' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.prefer_teams')" "always" "prefer_teams true canonicalizes to always"
+assert_eq "$(json_field "$out" '.delegation_mode')" "team" "prefer_teams true/always can force team for delegate work"
+
+make_fixture canon-unknown '"surprise"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_inline 01-02-PLAN.md 01 02 '[]'
+out=$(run_helper)
+assert_eq "$(json_field "$out" '.prefer_teams')" "surprise" "unknown prefer_teams value is preserved"
+assert_eq "$(json_field "$out" '.delegation_mode')" "subagent" "unknown prefer_teams value returns subagent"
+assert_eq "$(json_field "$out" '.reason')" "unknown_prefer_teams:surprise" "unknown prefer_teams emits diagnostic reason"
+
+# Path resolution and dependency parser forms
+make_fixture path-parser '"auto"' balanced
+write_state '{"plans":[{"id":"01-01","status":"pending"},{"id":"01-02","status":"pending"},{"id":"01-03","status":"pending"}],"effort":"balanced","phase_effort":"balanced"}'
+write_plan_inline 01-01-PLAN.md 01 01 '[]'
+write_plan_block 02-PLAN.md 01 02 1
+write_plan_inline 01-03-PLAN.md 01 03 '["01-02"]'
+out=$(run_helper)
+assert_json_array_eq "$(jq -c '.plans["01-02"].deps' <<< "$out")" '["01-01"]' "routing helper normalizes block numeric deps on legacy plan filename"
+assert_json_array_eq "$(jq -c '.plans["01-03"].deps' <<< "$out")" '["01-02"]' "routing helper retains inline full-id string deps"
+
+CONTRACT_FIXTURE="$TMPDIR_BASE/contract-parser"
+mkdir -p "$CONTRACT_FIXTURE/.vbw-planning/phases/03-test"
+printf '{"max_token_budget":50000,"task_timeout_seconds":600}\n' > "$CONTRACT_FIXTURE/.vbw-planning/config.json"
+cat > "$CONTRACT_FIXTURE/.vbw-planning/phases/03-test/03-04-PLAN.md" <<'PLAN'
+---
+phase: 3
+plan: 4
+title: Contract Parser
+depends_on:
+  - 1
+  - "03-02"
+  - custom-id
+---
+# Plan
+
+### Task 1: Work
+- **Files:** `src/contract.txt`
+PLAN
+(cd "$CONTRACT_FIXTURE" && "$GENERATE_CONTRACT" .vbw-planning/phases/03-test/03-04-PLAN.md >/dev/null)
+contract_deps=$(jq -c '.depends_on' "$CONTRACT_FIXTURE/.vbw-planning/.contracts/3-4.json")
+assert_json_array_eq "$contract_deps" '["03-01","03-02","custom-id"]' "generate-contract retains normalized string dependency edges"
+
+# state-updater: nonterminal/missing SUMMARY status must not mark complete or unlock dependents
+STATE_FIXTURE="$TMPDIR_BASE/state-updater"
+STATE_PHASE="$STATE_FIXTURE/.vbw-planning/phases/01-test"
+mkdir -p "$STATE_PHASE"
+printf '{"plans":[{"id":"01-01","status":"pending"}],"status":"running","phase":1}\n' > "$STATE_FIXTURE/.vbw-planning/.execution-state.json"
+cat > "$STATE_PHASE/01-01-SUMMARY.md" <<'SUMMARY'
+---
+phase: 1
+plan: 1
+status: pending
+---
+Not terminal.
+SUMMARY
+printf '{"tool_input":{"file_path":"%s"}}\n' "$STATE_PHASE/01-01-SUMMARY.md" | (cd "$STATE_FIXTURE" && "$STATE_UPDATER")
+state_status=$(jq -r '.plans[] | select(.id == "01-01") | .status' "$STATE_FIXTURE/.vbw-planning/.execution-state.json")
+assert_eq "$state_status" "pending" "state-updater leaves nonterminal SUMMARY status unchanged"
+cat > "$STATE_PHASE/01-01-SUMMARY.md" <<'SUMMARY'
+---
+phase: 1
+plan: 1
+status: partial
+---
+Partial but terminal.
+SUMMARY
+printf '{"tool_input":{"file_path":"%s"}}\n' "$STATE_PHASE/01-01-SUMMARY.md" | (cd "$STATE_FIXTURE" && "$STATE_UPDATER")
+state_status=$(jq -r '.plans[] | select(.id == "01-01") | .status' "$STATE_FIXTURE/.vbw-planning/.execution-state.json")
+assert_eq "$state_status" "partial" "state-updater writes verified terminal partial status"
+
+# Protocol text invariants
+if grep -q 'resolve-execute-delegation-mode\.sh' "$EXECUTE_PROTOCOL"; then
+  pass "execute-protocol references resolve-execute-delegation-mode.sh"
+else
+  fail "execute-protocol references resolve-execute-delegation-mode.sh"
+fi
+
+if grep -Fq "prefer_teams='auto': request team mode only when 2+ uncompleted plans remain" "$EXECUTE_PROTOCOL"; then
+  fail "execute-protocol no longer contains stale 2+ uncompleted auto routing wording"
+else
+  pass "execute-protocol no longer contains stale 2+ uncompleted auto routing wording"
+fi
+
+if grep -q 'delegation_mode=team' "$EXECUTE_PROTOCOL" && grep -q 'TEAM_NAME' "$EXECUTE_PROTOCOL" && grep -q 'shutdown_request' "$EXECUTE_PROTOCOL"; then
+  pass "execute-protocol keys team shutdown off actual delegation_mode=team plus TEAM_NAME"
+else
+  fail "execute-protocol keys team shutdown off actual delegation_mode=team plus TEAM_NAME"
+fi
+
+if grep -Fq 'When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "dev-{MM}"`' "$EXECUTE_PROTOCOL" \
+  && grep -Fq 'When true team mode is active, pass `team_name: "vbw-phase-{NN}"` and `name: "qa"`' "$EXECUTE_PROTOCOL"; then
+  pass "execute-protocol preserves team_name/name invariant for true team mode"
+else
+  fail "execute-protocol preserves team_name/name invariant for true team mode"
+fi
+
+echo ""
+echo "==============================="
+echo "TOTAL: $PASS PASS, $FAIL FAIL"
+echo "==============================="
+
+[ "$FAIL" -eq 0 ] || exit 1
+
+echo "All execute delegation routing contract checks passed."
+exit 0

--- a/testing/verify-summary-utils-contract.sh
+++ b/testing/verify-summary-utils-contract.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 # verify-summary-utils-contract.sh — Tests for scripts/summary-utils.sh
 #
-# Verifies the 4 functions that all runtime scripts now source:
+# Verifies the runtime functions that all runtime scripts now source:
 # - is_summary_complete (complete|completed only)
 # - is_summary_terminal (complete|completed|partial|failed)
+# - is_valid_summary_status (canonical runtime statuses only)
 # - count_complete_summaries (count completion-status files)
 # - count_terminal_summaries (count any-terminal-status files)
 
@@ -340,6 +341,27 @@ else
   fail "is_summary_terminal: quoted whitespace-padded status -> expected 0, got 1"
 fi
 
+# ===== is_valid_summary_status =====
+
+echo ""
+echo "--- is_valid_summary_status ---"
+
+for valid_status in complete partial failed; do
+  if is_valid_summary_status "$valid_status"; then
+    pass "is_valid_summary_status: $valid_status -> 0"
+  else
+    fail "is_valid_summary_status: $valid_status -> expected 0, got 1"
+  fi
+done
+
+for invalid_status in completed pending in_progress ""; do
+  if is_valid_summary_status "$invalid_status"; then
+    fail "is_valid_summary_status: '${invalid_status}' -> expected 1, got 0"
+  else
+    pass "is_valid_summary_status: '${invalid_status}' -> 1"
+  fi
+done
+
 # ===== count_complete_summaries =====
 
 echo ""
@@ -458,8 +480,8 @@ fi
 echo ""
 echo "--- Integration: runtime scripts source summary-utils.sh ---"
 
-# Verify all 6 runtime scripts that should source summary-utils.sh actually reference it
-for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh; do
+# Verify all runtime scripts that should source summary-utils.sh actually reference it
+for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh verify-state-consistency.sh; do
   if grep -q 'summary-utils\.sh' "$ROOT/scripts/$script" 2>/dev/null; then
     pass "integration: $script references summary-utils.sh"
   else
@@ -468,7 +490,7 @@ for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-
 done
 
 # Verify no runtime script still sources the deprecated lib/summary-status.sh
-for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh; do
+for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh verify-state-consistency.sh; do
   if grep -q 'lib/summary-status\.sh' "$ROOT/scripts/$script" 2>/dev/null; then
     fail "integration: $script still references deprecated lib/summary-status.sh"
   else
@@ -479,7 +501,7 @@ done
 # Verify no consumer script overrides extract_summary_status() after sourcing summary-utils.sh.
 # Fallback stubs in else-blocks (for when summary-utils.sh is missing) are allowed — only
 # definitions that coexist with the sourced helper create split-brain parsing.
-for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh; do
+for script in phase-detect.sh state-updater.sh recover-state.sh qa-gate.sh file-guard.sh session-start.sh verify-state-consistency.sh; do
   # Count function definitions of extract_summary_status()
   def_count=$(grep -cE '^[[:space:]]*extract_summary_status[[:space:]]*\(\)' "$ROOT/scripts/$script" 2>/dev/null) || def_count=0
   # Count source lines for summary-utils.sh (matches both `. file` and `source file`)

--- a/tests/contract-lite.bats
+++ b/tests/contract-lite.bats
@@ -92,6 +92,36 @@ teardown() {
   [ "$output" = "2" ]
 }
 
+@test "generate-contract.sh preserves normalized dependency references" {
+  cd "$TEST_TEMP_DIR"
+
+  cat > ".vbw-planning/phases/03-test-phase/03-02-PLAN.md" <<'EOF'
+---
+phase: 3
+plan: 2
+title: "Dependency Parser Test"
+wave: 2
+depends_on:
+  - 1
+  - "03-01"
+  - custom-id
+---
+
+# Plan 03-02: Dependency Parser Test
+
+## Tasks
+
+### Task 1: Implement dependent work
+- **Files:** `scripts/dependent.sh`
+- **Action:** Create dependent work.
+EOF
+
+  bash "$SCRIPTS_DIR/generate-contract.sh" ".vbw-planning/phases/03-test-phase/03-02-PLAN.md"
+
+  run jq -c '.depends_on' ".vbw-planning/.contracts/3-2.json"
+  [ "$output" = '["03-01","03-01","custom-id"]' ]
+}
+
 @test "validate-contract.sh start mode passes for valid task" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -551,3 +551,42 @@ EOF
   # SOURCE-UAT should be ignored — all phases should be complete
   grep -q '^Status: complete$' .vbw-planning/STATE.md
 }
+
+@test "summary update preserves parsed status when summary-utils helper is unavailable" {
+  cd "$TEST_TEMP_DIR"
+
+  local helperless_scripts
+  helperless_scripts="$TEST_TEMP_DIR/helperless-scripts"
+  mkdir -p "$helperless_scripts"
+  cp "$SCRIPTS_DIR/state-updater.sh" "$helperless_scripts/state-updater.sh"
+
+  mkdir -p .vbw-planning/phases/01-setup
+  echo "# plan" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  cat > .vbw-planning/phases/01-setup/01-01-SUMMARY.md <<'SUMMARY'
+---
+phase: 1
+plan: 1
+status: complete
+---
+# summary
+SUMMARY
+
+  cat > .vbw-planning/.execution-state.json <<'EOF'
+{
+  "phase": 1,
+  "status": "running",
+  "plans": [
+    {"id": "01-01", "status": "pending"}
+  ]
+}
+EOF
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/01-setup/01-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$helperless_scripts/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  jq -e '.plans[0].status == "complete"' .vbw-planning/.execution-state.json >/dev/null
+}


### PR DESCRIPTION
## Linked Issue

Fixes #554

## What

Adds dependency-aware Execute routing so `prefer_teams=auto` requests true Agent Teams only when the remaining delegate-eligible dependency graph has real parallel width. Linear graphs, single delegate plans, phase-level turbo, smart-routed turbo, and explicit internal-direct segments now route to non-team execution. The change also preserves verified `SUMMARY.md` terminal status in execution state and updates docs/prompts to stop biasing Lead toward fake wave-1 parallelism.

## Why

The root cause was split routing ownership: `references/execute-protocol.md` selected team mode from count-based wording before turbo/smart-routing/dependency exceptions were resolved, while runtime state could be persisted as team mode for work that was actually serial. The durable fix moves graph routing into a deterministic Bash/JQ helper, makes the protocol consume compact helper output before persisting `.delegated-workflow.json`, and preserves `complete|partial|failed` status semantics so dependency unlocking is explicit.

## How

- `scripts/resolve-execute-delegation-mode.sh` — new deterministic helper requiring `--phase-dir`, validating execution-state/route-map shapes, resolving plan dependencies, computing delegate wave width, and emitting compact routing/segment JSON.
- `references/execute-protocol.md` — routes through the helper before marker persistence, separates team/subagent/direct segment modes, requires team-marker cleanup before non-team segments, preserves terminal `SUMMARY.md` status, and moves worktree creation to just-in-time segment execution.
- `scripts/generate-contract.sh` — aligns contract metadata dependency parsing with routing helper forms: full IDs, string arrays, block arrays, and numeric current-phase refs.
- `scripts/state-updater.sh` — stops marking missing/unknown/nonterminal summaries complete; writes only verified terminal statuses.
- `scripts/summary-utils.sh` and `scripts/verify-state-consistency.sh` — move runtime summary status validation to the runtime helper and remove the deprecated `scripts/lib/summary-status.sh` dependency from state consistency checks.
- `scripts/session-start.sh` — reconciles execution state from disk `SUMMARY.md` terminal statuses without flattening `partial` or `failed`.
- `commands/vibe.md` and `agents/vbw-lead.md` — remove unconditional parallel-team planning bias; linear chains are valid when dependencies are real.
- `README.md`, `docs/vbw-vs-paul-analysis.md`, and `docs/vbw-vs-gsd-source-validated.md` — update current behavior docs for dependency-aware routing, serialized subagents, and per-plan worktree isolation.
- Tests — add/adjust routing, schema failure, segment persistence, parser parity, summary status, and guard coverage.

## Acceptance Criteria Verification

1. Helper CLI and compact JSON: satisfied by `scripts/resolve-execute-delegation-mode.sh`; covered by `testing/verify-execute-delegation-routing.sh`.
2. `prefer_teams` canonicalization and unknown diagnostics: helper invokes `normalize-prefer-teams.sh`; covered by canonicalization fixtures.
3. Full graph analysis and fail-closed invalid graphs: helper analyzes all execution-state plans, treats `complete|partial` as execute-satisfied, excludes turbo/direct, and fails malformed/cyclic/unresolved inputs with `invalid_dependency_graph`; covered by routing verifier including QA round 1 schema fixtures.
4. `auto` routes to team only when `max_parallel_width > 1`: covered by linear, independent, fan-out, and single-plan fixtures.
5. `always` override limited to delegate-eligible work: covered by linear delegate, phase turbo, smart-routed turbo, and internal-direct fixtures.
6. Protocol helper-before-marker ordering: `references/execute-protocol.md` calls the helper before `.delegated-workflow.json` persistence; contract asserted in routing verifier.
7. Segment-local mode persistence and marker cleanup: protocol now persists `team`, `subagent`, or `direct` according to helper output and forbids non-team segments while a team marker is live; covered by routing and guard tests.
8. Shutdown only for actual team mode: protocol gates `shutdown_request`/`TeamDelete` on `delegation_mode=team` plus `TEAM_NAME`; covered by routing contract text checks.
9. Just-in-time worktree isolation: protocol defers per-plan worktree create/refresh until a plan becomes runnable.
10. Summary status preservation: `state-updater.sh`, `session-start.sh`, and `summary-utils.sh` preserve `complete|partial|failed`; covered by summary and reconciliation contracts.
11. Dependency parser parity: `generate-contract.sh` and helper accept the same dependency forms; covered by routing verifier and `tests/contract-lite.bats`.
12. Routing test coverage: `testing/verify-execute-delegation-routing.sh` covers linear, independent, fan-out, single-plan, never, always, turbo, mixed routes, invalid graphs, parser/path resolution, canonicalization, and partial satisfaction.
13. No count-only user-facing `auto` docs/prompts: command/docs contracts and prefer-teams canonicalization pass.
14. Agent spawn guard intact: `testing/verify-agent-spawn-guard.sh` passes and adds direct-mode non-team coverage.
15. Full local validation: `bash testing/run-all.sh` passes with zero failures.

## Testing

- [x] `bash testing/verify-execute-delegation-routing.sh` — `57 PASS, 0 FAIL`
- [x] `bash testing/verify-delegation-guard.sh` — `33 PASS, 0 FAIL`
- [x] `bash testing/verify-agent-spawn-guard.sh` — `19 PASS, 0 FAIL`
- [x] `bash testing/verify-summary-utils-contract.sh`
- [x] `bash testing/verify-summary-status-contract.sh`
- [x] `bash testing/verify-exec-state-reconciliation.sh`
- [x] `bash testing/verify-commands-contract.sh` — `464 PASS, 0 FAIL`
- [x] `bash testing/verify-prefer-teams-canonicalization.sh`
- [x] `bash testing/verify-bash-scripts-contract.sh`
- [x] `bats tests/contract-lite.bats` — `10 tests, 0 failures`
- [x] `bash testing/verify-ghost-team-cleanup.sh`
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh` — lint `1/1`, contracts `49/49`, BATS `3229 passed, 0 failed`

## QA Summary

- Primary QA round 1 (`qa-investigator`): found 2 medium contract findings.
  - F-01 malformed execution-state/route-map shapes failed open — fixed in `9e71c485`.
  - F-02 direct/turbo segment marker persistence collapsed to subagent in protocol — fixed in `9e71c485`.
- Primary QA round 2 (`qa-investigator`): 0 legitimate findings; recorded by empty evidence commit `8aaccf72`.
- Cross-model QA: skipped per workflow gate because this is a GPT-class GitHub Copilot session and `qa-investigator-gpt-54` would not provide a different model-family review.
- Copilot PR review round 1: 2 comments fixed in `9f741b25`.
  - Explicit `phase_effort` fallback block in `scripts/resolve-execute-delegation-mode.sh`.
  - Robust missing-`summary-utils.sh` fallback in `scripts/state-updater.sh`, covered by `tests/state-updater.bats`.
- Copilot PR review round 2: clean `COMMENTED` review with no new comments and zero unresolved Copilot threads.
- CI/CD: green on latest commit `9f741b25` — all 18 checks passed.

## Commits

- `deb36058` — `fix(execute): route teams by dependency width`
- `9e71c485` — `fix(execute): address QA round 1`
- `8aaccf72` — `fix(execute): address QA round 2`
- `9f741b25` — `fix(execute): address Copilot review round 1`
