### PR TITLE
fix(guards): resolve Claude sidechains to host root

### DIFF
--- a/scripts/agent-spawn-guard.sh
+++ b/scripts/agent-spawn-guard.sh
@@ -15,6 +15,8 @@ fi
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -z "$INPUT" ] && exit 0
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 find_project_root() {
   local dir="$PWD"
   while [ "$dir" != "/" ]; do
@@ -27,8 +29,26 @@ find_project_root() {
   return 1
 }
 
-PROJECT_ROOT=$(find_project_root) || exit 0
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+resolve_project_root() {
+  if [ -n "${VBW_PLANNING_DIR:-}" ] && [ -d "$VBW_PLANNING_DIR" ]; then
+    cd "$VBW_PLANNING_DIR/.." 2>/dev/null && pwd -P 2>/dev/null
+    return $?
+  fi
+
+  if [ -f "$SCRIPT_DIR/lib/vbw-config-root.sh" ]; then
+    # shellcheck source=lib/vbw-config-root.sh
+    if source "$SCRIPT_DIR/lib/vbw-config-root.sh" 2>/dev/null; then
+      if find_vbw_root "$SCRIPT_DIR" >/dev/null 2>&1 && [ -n "${VBW_CONFIG_ROOT:-}" ] && [ -n "${VBW_PLANNING_DIR:-}" ] && [ -d "$VBW_PLANNING_DIR" ]; then
+        printf '%s\n' "$VBW_CONFIG_ROOT"
+        return 0
+      fi
+    fi
+  fi
+
+  find_project_root
+}
+
+PROJECT_ROOT=$(resolve_project_root) || exit 0
 MARKER_STATUS=$(VBW_PLANNING_DIR="$PROJECT_ROOT/.vbw-planning" bash "$SCRIPT_DIR/delegated-workflow.sh" status-json 2>/dev/null) || exit 0
 [ -n "$MARKER_STATUS" ] || exit 0
 

--- a/scripts/file-guard.sh
+++ b/scripts/file-guard.sh
@@ -17,6 +17,53 @@ INPUT=$(cat 2>/dev/null) || exit 0
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
 [ -z "$FILE_PATH" ] && exit 0
 
+_FG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_FG_SHARED_ROOT_RESOLVED=false
+if [ -f "$_FG_SCRIPT_DIR/lib/vbw-config-root.sh" ]; then
+  # shellcheck source=lib/vbw-config-root.sh
+  if source "$_FG_SCRIPT_DIR/lib/vbw-config-root.sh" 2>/dev/null; then
+    if find_vbw_root "$_FG_SCRIPT_DIR" >/dev/null 2>&1; then
+      _FG_SHARED_ROOT_RESOLVED=true
+    fi
+  fi
+fi
+
+# Best-effort absolute path resolver for boundary checks.
+# - Relative paths are resolved from current working directory.
+# - Non-existent paths still get a stable absolute lexical form.
+to_abs_path() {
+  local p="$1"
+  local base dir file cwd_base probe suffix resolved_probe
+  [ -z "$p" ] && {
+    echo ""
+    return 0
+  }
+
+  case "$p" in
+    /*) base="$p" ;;
+    *)
+      cwd_base=$(pwd -P 2>/dev/null || pwd)
+      base="$cwd_base/${p#./}"
+      ;;
+  esac
+
+  dir=$(dirname "$base")
+  file=$(basename "$base")
+  probe="$dir"
+  suffix="/$file"
+  while [ ! -d "$probe" ] && [ "$probe" != "/" ]; do
+    suffix="/$(basename "$probe")$suffix"
+    probe=$(dirname "$probe")
+  done
+
+  if [ -d "$probe" ]; then
+    resolved_probe=$(cd "$probe" 2>/dev/null && pwd -P 2>/dev/null) || resolved_probe="$probe"
+    echo "${resolved_probe%/}$suffix"
+  else
+    echo "$base"
+  fi
+}
+
 # Block misnamed plan/summary/context files in phase dirs (type-first format)
 # Must precede the .vbw-planning/* exemption which exits 0 for all planning artifacts.
 # Case-insensitive on extension (.md/.MD/.Md) to prevent bypass.
@@ -43,6 +90,42 @@ case "$FILE_PATH_LC" in
     fi
     ;;
 esac
+
+# Claude Code may execute subagents from an unmanaged internal sidechain at
+# {host}/.claude/worktrees/agent-*. Relative writes from that CWD, or absolute
+# writes under the sidechain, would land in files VBW does not merge/use when
+# VBW worktree isolation is off. Block those targets before planning-artifact
+# exemptions and before the active-agent delegated workflow bypass.
+if [ -n "${VBW_CLAUDE_SIDECHAIN_ROOT:-}" ] && [ -n "${VBW_CLAUDE_SIDECHAIN_HOST_ROOT:-}" ]; then
+  _FG_SIDECHAIN_BLOCK=false
+  _FG_BLOCKED_TARGET="$FILE_PATH"
+
+  case "$FILE_PATH" in
+    /*)
+      _FG_TARGET_ABS=$(to_abs_path "$FILE_PATH")
+      case "$_FG_TARGET_ABS" in
+        "$VBW_CLAUDE_SIDECHAIN_ROOT"|"$VBW_CLAUDE_SIDECHAIN_ROOT"/*)
+          _FG_SIDECHAIN_BLOCK=true
+          _FG_BLOCKED_TARGET="$_FG_TARGET_ABS"
+          ;;
+      esac
+      ;;
+    *)
+      _FG_SIDECHAIN_BLOCK=true
+      ;;
+  esac
+
+  if [ "$_FG_SIDECHAIN_BLOCK" = "true" ]; then
+    {
+      echo "Blocked: Claude sidechain write target"
+      echo "blocked target: $_FG_BLOCKED_TARGET"
+      echo "host repo: $VBW_CLAUDE_SIDECHAIN_HOST_ROOT"
+      echo "retry: retry the same Write/Edit with an absolute path under the host repo, not the Claude sidechain path."
+      echo "reason: VBW will not merge or use writes made inside Claude's internal sidechain."
+    } >&2
+    exit 2
+  fi
+fi
 
 # Exempt planning artifacts — these are always allowed
 case "$FILE_PATH" in
@@ -95,12 +178,16 @@ find_project_root() {
   return 1
 }
 
-PROJECT_ROOT=$(find_project_root) || exit 0
-PHASES_DIR="$PROJECT_ROOT/.vbw-planning/phases"
+if [ "$_FG_SHARED_ROOT_RESOLVED" = "true" ] && [ -n "${VBW_CONFIG_ROOT:-}" ] && [ -n "${VBW_PLANNING_DIR:-}" ] && [ -d "$VBW_PLANNING_DIR/phases" ]; then
+  PROJECT_ROOT="$VBW_CONFIG_ROOT"
+  PHASES_DIR="$VBW_PLANNING_DIR/phases"
+else
+  PROJECT_ROOT=$(find_project_root) || exit 0
+  PHASES_DIR="$PROJECT_ROOT/.vbw-planning/phases"
+fi
 [ ! -d "$PHASES_DIR" ] && exit 0
 
 # Source shared summary-status helpers (fail-open: inline fallback if lib unavailable)
-_FG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _FG_STATUS_LIB="${_FG_SCRIPT_DIR}/summary-utils.sh"
 if [ -f "$_FG_STATUS_LIB" ]; then
   # shellcheck source=summary-utils.sh
@@ -114,33 +201,25 @@ fi
 # Normalize path helper
 normalize_path() {
   local p="$1"
+  local p_abs root_abs
   if [ -n "$PROJECT_ROOT" ]; then
-    p="${p#"$PROJECT_ROOT"/}"
+    case "$p" in
+      "$PROJECT_ROOT"/*)
+        p="${p#"$PROJECT_ROOT"/}"
+        ;;
+      /*)
+        p_abs=$(to_abs_path "$p")
+        root_abs=$(to_abs_path "$PROJECT_ROOT")
+        if [ "$p_abs" = "$root_abs" ]; then
+          p=""
+        elif [[ "$p_abs" == "$root_abs"/* ]]; then
+          p="${p_abs#"$root_abs"/}"
+        fi
+        ;;
+    esac
   fi
   p="${p#./}"
   echo "$p"
-}
-
-# Best-effort absolute path resolver for boundary checks.
-# - Relative paths are resolved from current working directory.
-# - Non-existent paths still get a stable absolute lexical form.
-to_abs_path() {
-  local p="$1"
-  local base dir file resolved_dir
-  [ -z "$p" ] && {
-    echo ""
-    return 0
-  }
-
-  case "$p" in
-    /*) base="$p" ;;
-    *)  base="$PWD/${p#./}" ;;
-  esac
-
-  dir=$(dirname "$base")
-  file=$(basename "$base")
-  resolved_dir=$(cd "$dir" 2>/dev/null && pwd) || resolved_dir="$dir"
-  echo "${resolved_dir%/}/$file"
 }
 
 NORM_TARGET=$(normalize_path "$FILE_PATH")

--- a/scripts/lib/vbw-config-root.sh
+++ b/scripts/lib/vbw-config-root.sh
@@ -11,6 +11,9 @@
 # After calling find_vbw_root(), these variables are exported:
 #   VBW_CONFIG_ROOT  — absolute path to the workspace root (directory containing .vbw-planning/)
 #   VBW_PLANNING_DIR — convenience alias: $VBW_CONFIG_ROOT/.vbw-planning
+#   VBW_CLAUDE_SIDECHAIN_ROOT — Claude internal sidechain root when CWD is under
+#                               {host}/.claude/worktrees/agent-* (unset otherwise)
+#   VBW_CLAUDE_SIDECHAIN_HOST_ROOT — host repo for the Claude sidechain (unset otherwise)
 #
 # Resolution strategy when start_dir is provided:
 #   1. Walk up from PWD — prefer the active workspace when the script lives in a different repo
@@ -40,6 +43,36 @@ _walk_up_for_vbw_root() {
   return 1
 }
 
+_prefer_claude_sidechain_host_root() {
+  local _cwd="$1" _probe _parent _grandparent _host
+
+  _probe="$_cwd"
+  while [ "$_probe" != "/" ]; do
+    case "$(basename "$_probe")" in
+      agent-*)
+        _parent=$(dirname "$_probe")
+        _grandparent=$(dirname "$_parent")
+        if [ "$(basename "$_parent")" = "worktrees" ] && [ "$(basename "$_grandparent")" = ".claude" ]; then
+          _host=$(dirname "$_grandparent")
+          if [ -f "$_host/.vbw-planning/config.json" ]; then
+            export VBW_CONFIG_ROOT="$_host"
+            export VBW_PLANNING_DIR="$_host/.vbw-planning"
+            export VBW_CLAUDE_SIDECHAIN_ROOT="$_probe"
+            export VBW_CLAUDE_SIDECHAIN_HOST_ROOT="$_host"
+            return 0
+          fi
+        fi
+        ;;
+    esac
+
+    _parent=$(dirname "$_probe")
+    [ "$_parent" = "$_probe" ] && break
+    _probe="$_parent"
+  done
+
+  return 1
+}
+
 find_vbw_root() {
   # Cache hit: already resolved in this shell or by a parent script
   if [ -n "${VBW_CONFIG_ROOT:-}" ]; then
@@ -52,6 +85,12 @@ find_vbw_root() {
   _cwd_dir=$(pwd -P 2>/dev/null || pwd)
 
   if [ -n "${1:-}" ]; then
+    # Claude Code can run subagents inside unmanaged internal sidechains at
+    # {host}/.claude/worktrees/agent-*. Treat those as executions of the host
+    # workspace before nearest-ancestor walking can select the copied sidechain
+    # .vbw-planning tree. VBW-managed .vbw-worktrees/* are intentionally not
+    # covered by this exception.
+    _prefer_claude_sidechain_host_root "$_cwd_dir" && return 0
     # Prefer the active workspace when CWD is already inside a VBW project.
     _walk_up_for_vbw_root "$_cwd_dir" && return 0
     # Resolve start_dir to an absolute path; suppress cd stderr so bad paths
@@ -64,6 +103,7 @@ find_vbw_root() {
       _walk_up_for_vbw_root "$_cwd_dir" && return 0
     fi
   else
+    _prefer_claude_sidechain_host_root "$_cwd_dir" && return 0
     _walk_up_for_vbw_root "$_cwd_dir" && return 0
   fi
 

--- a/testing/verify-agent-spawn-guard.sh
+++ b/testing/verify-agent-spawn-guard.sh
@@ -25,6 +25,7 @@ setup_project() {
   PROJECT="$TMPDIR_BASE/project"
   mkdir -p "$PROJECT/.vbw-planning/phases/01-test"
   mkdir -p "$PROJECT/src/nested"
+  echo '{"effort":"balanced","prefer_teams":"never"}' > "$PROJECT/.vbw-planning/config.json"
 }
 
 cleanup() {
@@ -104,6 +105,54 @@ run_guard() {
 
   (cd "$working_dir" && VBW_PLANNING_DIR="$project_dir/.vbw-planning" bash "$GUARD" <<< "$input") 2>&1
   return ${PIPESTATUS[0]}
+}
+
+run_guard_without_exported_root() {
+  local project_dir="$1"
+  local team_name="$2"
+  local run_in_background="$3"
+  local agent_name="${4-dev-01}"
+  local working_dir="${5:-$project_dir}"
+  local tool_name="${6:-Agent}"
+  local active_count="${7:-}"
+
+  local input
+  input=$(jq -n \
+    --arg tool_name "$tool_name" \
+    --arg team_name "$team_name" \
+    --arg agent_name "$agent_name" \
+    --argjson run_in_background "$run_in_background" \
+    '{
+      tool_name: $tool_name,
+      tool_input: {
+        team_name: $team_name,
+        name: $agent_name,
+        run_in_background: $run_in_background
+      }
+    }')
+
+  if [ -n "$active_count" ]; then
+    printf '%s\n' "$active_count" > "$project_dir/.vbw-planning/.active-agent-count"
+  else
+    rm -f "$project_dir/.vbw-planning/.active-agent-count" 2>/dev/null || true
+  fi
+
+  (cd "$working_dir" && unset VBW_CONFIG_ROOT VBW_PLANNING_DIR; bash "$GUARD" <<< "$input") 2>&1
+  return ${PIPESTATUS[0]}
+}
+
+setup_sidechain_project() {
+  setup_project
+  SIDECHAIN="$PROJECT/.claude/worktrees/agent-test"
+  mkdir -p "$SIDECHAIN/.vbw-planning/phases/01-copy" "$SIDECHAIN/src"
+  echo '{"effort":"turbo","prefer_teams":"always"}' > "$SIDECHAIN/.vbw-planning/config.json"
+}
+
+write_sidechain_copied_state() {
+  jq -n '{phase:1,phase_name:"copy",status:"running",effort:"balanced",correlation_id:"sidechain-corr",plans:[]}' \
+    > "$SIDECHAIN/.vbw-planning/.execution-state.json"
+  jq -n '{mode:"execute",active:true,effort:"balanced",delegation_mode:"subagent",team_name:"",started_at:"2026-04-07T00:00:00Z",session_id:"session-test",correlation_id:"sidechain-corr"}' \
+    > "$SIDECHAIN/.vbw-planning/.delegated-workflow.json"
 }
 
 echo "=== Agent Spawn Guard Tests ==="
@@ -396,6 +445,40 @@ test_aged_live_execute_marker_still_enforces_team_rules() {
   cleanup
 }
 test_aged_live_execute_marker_still_enforces_team_rules
+
+test_sidechain_taskcreate_uses_host_state_when_host_count_absent() {
+  setup_sidechain_project
+  write_execution_state "corr-123"
+  write_marker execute subagent "" "corr-123"
+  write_sidechain_copied_state
+  printf '9\n' > "$SIDECHAIN/.vbw-planning/.active-agent-count"
+
+  if run_guard_without_exported_root "$PROJECT" "" false "dev-01" "$SIDECHAIN" "TaskCreate" "" >/dev/null 2>&1; then
+    pass "Claude sidechain TaskCreate uses host state: allowed when host active count absent"
+  else
+    fail "Claude sidechain TaskCreate should ignore sidechain active count when host count is absent"
+  fi
+  cleanup
+}
+test_sidechain_taskcreate_uses_host_state_when_host_count_absent
+
+test_sidechain_taskcreate_uses_host_active_count_to_block() {
+  setup_sidechain_project
+  write_execution_state "corr-123"
+  write_marker execute subagent "" "corr-123"
+  write_sidechain_copied_state
+  printf '0\n' > "$SIDECHAIN/.vbw-planning/.active-agent-count"
+
+  local output rc
+  output=$(run_guard_without_exported_root "$PROJECT" "" false "dev-02" "$SIDECHAIN" "TaskCreate" "2" 2>&1) && rc=$? || rc=$?
+  if [ "$rc" -eq 2 ] && grep -q 'must serialize non-team TaskCreate spawns' <<< "$output"; then
+    pass "Claude sidechain TaskCreate uses host active count: blocked when host count > 0"
+  else
+    fail "Claude sidechain TaskCreate should block from host active count > 0 (rc=$rc, output=$output)"
+  fi
+  cleanup
+}
+test_sidechain_taskcreate_uses_host_active_count_to_block
 
 echo ""
 echo "==============================="

--- a/testing/verify-delegation-guard.sh
+++ b/testing/verify-delegation-guard.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FILE_GUARD="$ROOT/scripts/file-guard.sh"
 DELEG_SCRIPT="$ROOT/scripts/delegated-workflow.sh"
+HOOK_WRAPPER="$ROOT/scripts/hook-wrapper.sh"
 
 PASS=0
 FAIL=0
@@ -68,6 +69,77 @@ run_guard() {
     (cd "$project_dir" && unset VBW_AGENT_ROLE; bash "$FILE_GUARD" <<< "$input") 2>&1
   fi
   return ${PIPESTATUS[0]}
+}
+
+run_guard_from() {
+  local working_dir="$1"
+  local file_path="$2"
+  local agent_role="${3:-}"
+
+  local input
+  input=$(jq -n --arg fp "$file_path" '{"tool_input":{"file_path":$fp}}')
+
+  if [ -n "$agent_role" ]; then
+    (cd "$working_dir" && unset VBW_CONFIG_ROOT VBW_PLANNING_DIR; VBW_AGENT_ROLE="$agent_role" bash "$FILE_GUARD" <<< "$input") 2>&1
+  else
+    (cd "$working_dir" && unset VBW_AGENT_ROLE VBW_CONFIG_ROOT VBW_PLANNING_DIR; bash "$FILE_GUARD" <<< "$input") 2>&1
+  fi
+  return ${PIPESTATUS[0]}
+}
+
+setup_sidechain_project() {
+  setup_project
+  SIDECHAIN="$PROJECT/.claude/worktrees/agent-test"
+  mkdir -p "$SIDECHAIN/.vbw-planning/phases/01-copy" "$SIDECHAIN/src"
+  echo '{"effort":"turbo","prefer_teams":"always"}' > "$SIDECHAIN/.vbw-planning/config.json"
+}
+
+write_live_execute_state() {
+  jq -n '{phase:1,status:"running",effort:"balanced",correlation_id:"corr-sidechain",plans:[{id:"01-01",status:"pending"}]}' \
+    > "$PROJECT/.vbw-planning/.execution-state.json"
+  (cd "$PROJECT" && bash "$DELEG_SCRIPT" set execute balanced subagent)
+}
+
+run_sidechain_agent_hook() {
+  local hook_script="$1"
+  local input
+  input=$(jq -n '{agent_type:"vbw:vbw-dev", pid:"12345"}')
+
+  (
+    cd "$SIDECHAIN"
+    unset VBW_CONFIG_ROOT VBW_PLANNING_DIR
+    CLAUDE_CONFIG_DIR="$TMPDIR_BASE/claude" \
+      CLAUDE_PLUGIN_ROOT="$ROOT" \
+      bash "$HOOK_WRAPPER" "$hook_script" <<< "$input"
+  )
+}
+
+assert_sidechain_target_message() {
+  local output="$1"
+  local host_root="$2"
+  local label="$3"
+
+  if ! grep -qi 'blocked target:' <<< "$output"; then
+    fail "$label: missing blocked target label ($output)"
+    return 1
+  fi
+  if ! grep -q "$host_root" <<< "$output" && ! grep -qi 'host repo' <<< "$output"; then
+    fail "$label: missing host repo path/phrase ($output)"
+    return 1
+  fi
+  if ! grep -qi 'retry.*absolute path.*host repo' <<< "$output"; then
+    fail "$label: missing retry action for absolute host path ($output)"
+    return 1
+  fi
+  if ! grep -qi 'sidechain' <<< "$output" || ! grep -qiE 'not.*(merge|use)|will not.*(merge|use)' <<< "$output"; then
+    fail "$label: missing sidechain not-merged/used reason ($output)"
+    return 1
+  fi
+  if grep -qE 'CRITICAL|MUST' <<< "$output"; then
+    fail "$label: message uses aggressive CRITICAL/MUST wording ($output)"
+    return 1
+  fi
+  return 0
 }
 
 echo "=== Delegation Guard Tests ==="
@@ -614,6 +686,106 @@ test_session_stop_preserves_live_execute_team_marker() {
   cleanup
 }
 test_session_stop_preserves_live_execute_team_marker
+
+# --- Test 25: Claude sidechain agent-start/stop uses host planning dir ---
+test_claude_sidechain_agent_hooks_use_host_planning_dir() {
+  setup_sidechain_project
+  write_live_execute_state
+
+  run_sidechain_agent_hook agent-start.sh >/dev/null 2>&1 || true
+
+  local host_count sidechain_count
+  host_count=$(cat "$PROJECT/.vbw-planning/.active-agent-count" 2>/dev/null || true)
+  sidechain_count=$(cat "$SIDECHAIN/.vbw-planning/.active-agent-count" 2>/dev/null || true)
+  if [ "$host_count" = "1" ] && [ -z "$sidechain_count" ]; then
+    pass "Claude sidechain agent-start writes active count to host planning dir"
+  else
+    fail "Claude sidechain agent-start should write host count=1 and no sidechain count (host=$host_count sidechain=$sidechain_count)"
+  fi
+
+  run_sidechain_agent_hook agent-stop.sh >/dev/null 2>&1 || true
+  if [ ! -f "$PROJECT/.vbw-planning/.active-agent-count" ] && [ ! -f "$PROJECT/.vbw-planning/.active-agent" ]; then
+    pass "Claude sidechain agent-stop cleans host active-agent markers"
+  else
+    fail "Claude sidechain agent-stop should remove host active-agent markers"
+  fi
+  cleanup
+}
+test_claude_sidechain_agent_hooks_use_host_planning_dir
+
+# --- Test 26: Claude sidechain subagent can write declared host product path ---
+test_claude_sidechain_host_absolute_write_allowed_after_agent_start() {
+  setup_sidechain_project
+  write_live_execute_state
+  run_sidechain_agent_hook agent-start.sh >/dev/null 2>&1 || true
+
+  if run_guard_from "$SIDECHAIN" "$PROJECT/src/app.js" "" >/dev/null 2>&1; then
+    pass "Claude sidechain active subagent: host-root declared product write allowed"
+  else
+    fail "Claude sidechain active subagent: host-root declared product write unexpectedly blocked"
+  fi
+
+  run_sidechain_agent_hook agent-stop.sh >/dev/null 2>&1 || true
+  cleanup
+}
+test_claude_sidechain_host_absolute_write_allowed_after_agent_start
+
+# --- Test 27: Claude sidechain host write without active marker still blocks orchestrator ---
+test_claude_sidechain_host_absolute_write_blocks_without_agent_marker() {
+  setup_sidechain_project
+  write_live_execute_state
+
+  rm -f "$PROJECT/.vbw-planning/.active-agent" "$PROJECT/.vbw-planning/.active-agent-count"
+  local output rc
+  output=$(run_guard_from "$SIDECHAIN" "$PROJECT/src/app.js" "" 2>&1) && rc=$? || rc=$?
+  if [ "$rc" -eq 2 ] && grep -q 'orchestrator cannot write product files' <<< "$output"; then
+    pass "Claude sidechain orchestrator host-root product write: blocked"
+  else
+    fail "Claude sidechain orchestrator host-root product write should block (rc=$rc, output=$output)"
+  fi
+  cleanup
+}
+test_claude_sidechain_host_absolute_write_blocks_without_agent_marker
+
+# --- Test 28: Claude sidechain relative Write/Edit target is blocked early ---
+test_claude_sidechain_relative_write_target_blocks() {
+  setup_sidechain_project
+  write_live_execute_state
+  echo "1" > "$PROJECT/.vbw-planning/.active-agent-count"
+  echo "dev" > "$PROJECT/.vbw-planning/.active-agent"
+
+  local output rc
+  output=$(run_guard_from "$SIDECHAIN" "src/app.js" "" 2>&1) && rc=$? || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    if assert_sidechain_target_message "$output" "$PROJECT" "Claude sidechain relative target"; then
+      pass "Claude sidechain relative Write/Edit target: blocked with retry guidance"
+    fi
+  else
+    fail "Claude sidechain relative Write/Edit target should block (rc=$rc, output=$output)"
+  fi
+  cleanup
+}
+test_claude_sidechain_relative_write_target_blocks
+
+# --- Test 29: Claude sidechain absolute target under sidechain is blocked early ---
+test_claude_sidechain_absolute_sidechain_target_blocks() {
+  setup_sidechain_project
+  write_live_execute_state
+  echo "1" > "$PROJECT/.vbw-planning/.active-agent-count"
+  echo "dev" > "$PROJECT/.vbw-planning/.active-agent"
+
+  local output rc
+  output=$(run_guard_from "$SIDECHAIN" "$SIDECHAIN/src/app.js" "" 2>&1) && rc=$? || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    if assert_sidechain_target_message "$output" "$PROJECT" "Claude sidechain absolute target"; then
+      pass "Claude sidechain absolute sidechain target: blocked with retry guidance"
+    fi
+  else
+    fail "Claude sidechain absolute target should block (rc=$rc, output=$output)"
+  fi
+  cleanup
+}
+test_claude_sidechain_absolute_sidechain_target_blocks
 
 echo ""
 echo "==============================="

--- a/tests/monorepo-hook-cwd.bats
+++ b/tests/monorepo-hook-cwd.bats
@@ -195,6 +195,48 @@ JSON
   [ "$sidechain_host" = "$host_real" ]
 }
 
+@test "find_vbw_root: preserves nearest ancestor for VBW-managed worktrees" {
+  local host="$TEST_TEMP_DIR/vbw-managed-worktree-host"
+  setup_workspace "$host"
+  local managed="$host/.vbw-worktrees/01-01"
+  mkdir -p "$managed/.vbw-planning" "$managed/src/nested"
+  cat > "$managed/.vbw-planning/config.json" <<'JSON'
+{"effort": "balanced", "model_profile": "balanced"}
+JSON
+
+  local managed_real
+  managed_real=$(cd "$managed" && pwd -P 2>/dev/null || echo "$managed")
+
+  local result config_root planning_dir sidechain_root sidechain_host
+  result=$(
+    cd "$managed/src/nested"
+    unset VBW_CONFIG_ROOT 2>/dev/null || true
+    unset VBW_PLANNING_DIR 2>/dev/null || true
+    unset VBW_CLAUDE_SIDECHAIN_ROOT 2>/dev/null || true
+    unset VBW_CLAUDE_SIDECHAIN_HOST_ROOT 2>/dev/null || true
+    . "$LIB"
+    find_vbw_root
+    printf '%s\n%s\n%s\n%s\n' \
+      "$VBW_CONFIG_ROOT" \
+      "$VBW_PLANNING_DIR" \
+      "${VBW_CLAUDE_SIDECHAIN_ROOT:-}" \
+      "${VBW_CLAUDE_SIDECHAIN_HOST_ROOT:-}"
+  )
+  cd "$PROJECT_ROOT"
+
+  local result_lines
+  mapfile -t result_lines <<< "$result"
+  config_root="${result_lines[0]}"
+  planning_dir="${result_lines[1]}"
+  sidechain_root="${result_lines[2]}"
+  sidechain_host="${result_lines[3]}"
+
+  [ "$config_root" = "$managed_real" ]
+  [ "$planning_dir" = "$managed_real/.vbw-planning" ]
+  [ -z "$sidechain_root" ]
+  [ -z "$sidechain_host" ]
+}
+
 @test "find_vbw_root: cache hit still wins inside Claude sidechain" {
   local host="$TEST_TEMP_DIR/claude-sidechain-cache-host"
   local cached="$TEST_TEMP_DIR/cached-root"

--- a/tests/monorepo-hook-cwd.bats
+++ b/tests/monorepo-hook-cwd.bats
@@ -152,6 +152,77 @@ JSON
   [ "$result" = "$root" ]
 }
 
+@test "find_vbw_root: maps Claude internal sidechain cwd to host workspace" {
+  local host="$TEST_TEMP_DIR/claude-sidechain-host"
+  setup_workspace "$host"
+  local sidechain="$host/.claude/worktrees/agent-test"
+  mkdir -p "$sidechain/.vbw-planning" "$sidechain/src/nested"
+  cat > "$sidechain/.vbw-planning/config.json" <<'JSON'
+{"effort": "turbo", "model_profile": "budget"}
+JSON
+
+  local host_real sidechain_real
+  host_real=$(cd "$host" && pwd -P 2>/dev/null || echo "$host")
+  sidechain_real=$(cd "$sidechain" && pwd -P 2>/dev/null || echo "$sidechain")
+
+  local result config_root planning_dir sidechain_root sidechain_host
+  result=$(
+    cd "$sidechain/src/nested"
+    unset VBW_CONFIG_ROOT 2>/dev/null || true
+    unset VBW_PLANNING_DIR 2>/dev/null || true
+    unset VBW_CLAUDE_SIDECHAIN_ROOT 2>/dev/null || true
+    unset VBW_CLAUDE_SIDECHAIN_HOST_ROOT 2>/dev/null || true
+    . "$LIB"
+    find_vbw_root
+    printf '%s\n%s\n%s\n%s\n' \
+      "$VBW_CONFIG_ROOT" \
+      "$VBW_PLANNING_DIR" \
+      "${VBW_CLAUDE_SIDECHAIN_ROOT:-}" \
+      "${VBW_CLAUDE_SIDECHAIN_HOST_ROOT:-}"
+  )
+  cd "$PROJECT_ROOT"
+
+  local result_lines
+  mapfile -t result_lines <<< "$result"
+  config_root="${result_lines[0]}"
+  planning_dir="${result_lines[1]}"
+  sidechain_root="${result_lines[2]}"
+  sidechain_host="${result_lines[3]}"
+
+  [ "$config_root" = "$host_real" ]
+  [ "$planning_dir" = "$host_real/.vbw-planning" ]
+  [ "$sidechain_root" = "$sidechain_real" ]
+  [ "$sidechain_host" = "$host_real" ]
+}
+
+@test "find_vbw_root: cache hit still wins inside Claude sidechain" {
+  local host="$TEST_TEMP_DIR/claude-sidechain-cache-host"
+  local cached="$TEST_TEMP_DIR/cached-root"
+  setup_workspace "$host"
+  setup_workspace "$cached"
+  local sidechain="$host/.claude/worktrees/agent-test"
+  mkdir -p "$sidechain/.vbw-planning" "$sidechain/src"
+  cat > "$sidechain/.vbw-planning/config.json" <<'JSON'
+{"effort": "turbo", "model_profile": "budget"}
+JSON
+
+  local result
+  result=$(
+    cd "$sidechain/src"
+    export VBW_CONFIG_ROOT="$cached"
+    unset VBW_PLANNING_DIR 2>/dev/null || true
+    . "$LIB"
+    find_vbw_root
+    printf '%s\n%s\n' "$VBW_CONFIG_ROOT" "$VBW_PLANNING_DIR"
+  )
+  cd "$PROJECT_ROOT"
+
+  local result_lines
+  mapfile -t result_lines <<< "$result"
+  [ "${result_lines[0]}" = "$cached" ]
+  [ "${result_lines[1]}" = "$cached/.vbw-planning" ]
+}
+
 # --- Test 6: find_vbw_root with start_dir resolves from script location (#266) ---
 
 @test "find_vbw_root: resolves via start_dir when CWD is outside project" {


### PR DESCRIPTION
## Linked Issue

Fixes #557

## What

This PR makes VBW treat Claude Code internal sidechains at `.claude/worktrees/agent-*` as executions of the host repository for hook state, while blocking accidental writes into Claude's unmanaged sidechain copy.

## Why

Claude Code can place Dev subagents in internal sidechains even when VBW `worktree_isolation` is `off`. The root cause was inconsistent hook root resolution: shared hook wrapper state could be written into the sidechain `.vbw-planning` copy while file/spawn guards read or inferred a different planning root. The durable fix is shell-side: centralize the sidechain exception in the shared root resolver, route guards through that resolver, and reject sidechain-relative targets before they silently create unmerged sidechain-only changes.

## How

- `scripts/lib/vbw-config-root.sh`: detects `{host}/.claude/worktrees/agent-*` before normal nearest-ancestor walking, exports the host `VBW_CONFIG_ROOT` / `VBW_PLANNING_DIR`, and records sidechain metadata for guard-specific target checks.
- `scripts/file-guard.sh`: sources the shared resolver before root-dependent guard logic, blocks relative or sidechain-absolute Write/Edit targets from Claude sidechains with concise retry guidance, and normalizes physical/logical paths so existing worktree-boundary behavior remains intact.
- `scripts/agent-spawn-guard.sh`: honors exported `VBW_PLANNING_DIR`, then uses the shared resolver, then falls back to its old local walk, so sidechain TaskCreate checks read host delegated state and host active-agent counts.
- `tests/monorepo-hook-cwd.bats`: adds resolver coverage for Claude sidechains, cache-hit preservation, and VBW-managed `.vbw-worktrees/*` nearest-ancestor behavior.
- `testing/verify-delegation-guard.sh`: adds hermetic hook-wrapper/file-guard sidechain regression coverage for host marker placement, marker cleanup, host-root write allowance, orchestrator blocking, and sidechain target blocking.
- `testing/verify-agent-spawn-guard.sh`: adds sidechain TaskCreate coverage proving host state wins over stale/copied sidechain markers.

## Acceptance Criteria Verification

1. Host root wins from `.claude/worktrees/agent-*`: satisfied by `scripts/lib/vbw-config-root.sh` and `tests/monorepo-hook-cwd.bats` sidechain resolver test.
2. Cache-hit behavior remains intact: existing cache-hit branch preserved and covered by existing + sidechain cache-hit BATS tests.
3. Non-Claude nested nearest-ancestor behavior remains intact: existing nested workspace BATS coverage still passes.
4. VBW-managed `.vbw-worktrees/*` behavior unchanged: covered by the new `.vbw-worktrees/01-01` nearest-ancestor BATS regression.
5. `file-guard.sh` / `agent-spawn-guard.sh` use shared/exported root resolution with fallback: implemented in both guard scripts and covered by contract tests.
6. Sidechain `agent-start.sh` writes host `.active-agent-count=1`: covered in `testing/verify-delegation-guard.sh` via local `hook-wrapper.sh agent-start.sh` with stdin JSON.
7. Sidechain `agent-stop.sh` cleans host marker: covered in `testing/verify-delegation-guard.sh` via local `hook-wrapper.sh agent-stop.sh`.
8. Host-root declared product path allowed after agent start: covered in `testing/verify-delegation-guard.sh`.
9. Same host-root write blocks without active-agent marker: covered in `testing/verify-delegation-guard.sh`.
10. Relative sidechain Write/Edit target blocks early: covered in `testing/verify-delegation-guard.sh` with message assertions.
11. Absolute target under `.claude/worktrees/agent-*` blocks early: covered in `testing/verify-delegation-guard.sh` with message assertions.
12. Block message includes target, host repo, and retry action: implemented in `scripts/file-guard.sh`, asserted in `testing/verify-delegation-guard.sh`.
13. Block message explains sidechain writes are not merged/used and avoids `CRITICAL`/`MUST`: implemented and asserted.
14. `agent-spawn-guard.sh` reads host delegated/execution/count state from sidechain cwd: covered in `testing/verify-agent-spawn-guard.sh`.
15. Regression coverage added in the three requested test files: yes.
16. Full suite passes from the feature worktree: `bash testing/run-all.sh` passed with lint `1/1`, contracts `49/49`, and BATS `3232 passed, 0 failed`.

## Testing

- [x] `bats tests/monorepo-hook-cwd.bats`
- [x] `bash testing/verify-delegation-guard.sh`
- [x] `bash testing/verify-agent-spawn-guard.sh`
- [x] `bash testing/verify-skill-activation.sh`
- [x] `bash testing/verify-bash-scripts-contract.sh`
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh` — lint `1/1`, contracts `49/49`, BATS `3232 passed, 0 failed`
- [x] GitHub Actions — all 18 checks passed on `e40ada5b`

## QA Summary

- Primary QA round 1 (`qa-investigator`): 1 low contract finding fixed in `eb6fb690` by adding explicit `.vbw-worktrees/*` resolver coverage.
- Primary QA round 2 (`qa-investigator`): clean; recorded by empty evidence commit `e40ada5b`.
- Cross-model QA: skipped because this is a Copilot/GPT-class session and the workflow gate does not provide an eligible different-model-family reviewer.
- Copilot PR review round 1: `COMMENTED` with zero generated inline comments and zero unresolved Copilot threads; no code changes required.
- CI/CD: green — all 18 required checks passed on `e40ada5b`.
- Post-review main sync: no new commits on `origin/main`; no conflict-resolution QA rerun needed.
