### PR TITLE
Fix deterministic STATE.md reconciliation for UAT drift

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'w=$(ls -1 \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1); [ ! -f \"$w\" ] && w=\"${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}\"; [ ! -f \"$w\" ] && for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do [ -f \"$f\" ] && w=\"$f\" && break; done; [ ! -f \"$w\" ] && { D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- \"--plugin-dir [^ ]+\" | head -1); D=\"${D#--plugin-dir }\"; [ -n \"$D\" ] && w=\"$D/scripts/hook-wrapper.sh\"; }; [ -f \"$w\" ] && exec bash \"$w\" validate-summary.sh; exit 0'",
+            "command": "bash -c 'w=$(ls -1 \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1); [ ! -f \"$w\" ] && w=\"${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}\"; [ ! -f \"$w\" ] && for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do [ -f \"$f\" ] && w=\"$f\" && break; done; [ ! -f \"$w\" ] && { D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- \"--plugin-dir [^ ]+\" | head -1); D=\"${D#--plugin-dir }\"; [ -n \"$D\" ] && w=\"$D/scripts/hook-wrapper.sh\"; }; [ -f \"$w\" ] && exec bash \"$w\" validate-summary.sh PostToolUse; exit 0'",
             "timeout": 15
           }
         ]
@@ -154,7 +154,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'w=$(ls -1 \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1); [ ! -f \"$w\" ] && w=\"${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}\"; [ ! -f \"$w\" ] && for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do [ -f \"$f\" ] && w=\"$f\" && break; done; [ ! -f \"$w\" ] && { D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- \"--plugin-dir [^ ]+\" | head -1); D=\"${D#--plugin-dir }\"; [ -n \"$D\" ] && w=\"$D/scripts/hook-wrapper.sh\"; }; [ -f \"$w\" ] && exec bash \"$w\" validate-summary.sh; exit 0'",
+            "command": "bash -c 'w=$(ls -1 \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/vbw-marketplace/vbw/*/scripts/hook-wrapper.sh 2>/dev/null | (sort -V 2>/dev/null || sort -t. -k1,1n -k2,2n -k3,3n) | tail -1); [ ! -f \"$w\" ] && w=\"${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/scripts/hook-wrapper.sh}\"; [ ! -f \"$w\" ] && for f in /tmp/.vbw-plugin-root-link-*/scripts/hook-wrapper.sh; do [ -f \"$f\" ] && w=\"$f\" && break; done; [ ! -f \"$w\" ] && { D=$(ps axww -o args= 2>/dev/null | grep -v grep | grep -oE -- \"--plugin-dir [^ ]+\" | head -1); D=\"${D#--plugin-dir }\"; [ -n \"$D\" ] && w=\"$D/scripts/hook-wrapper.sh\"; }; [ -f \"$w\" ] && exec bash \"$w\" validate-summary.sh SubagentStop; exit 0'",
             "timeout": 15
           }
         ]

--- a/scripts/agent-health.sh
+++ b/scripts/agent-health.sh
@@ -294,6 +294,16 @@ orphan_recovery() {
   echo "$advisory"
 }
 
+log_health_advisory() {
+  local advisory="$1"
+  local timestamp
+
+  [ -n "$advisory" ] || return 0
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%d %H:%M:%S")
+  mkdir -p "$PLANNING_DIR" 2>/dev/null || true
+  echo "[$timestamp] $advisory" >> "$PLANNING_DIR/.hook-errors.log" 2>/dev/null || true
+}
+
 cmd_start() {
   local input pid key role team_name key_role now
   input=$(cat)
@@ -336,16 +346,6 @@ cmd_start() {
       last_event: "start",
       idle_count: 0
     }' > "$HEALTH_DIR/${key}.json"
-
-  # Output hook response
-  jq -n \
-    --arg event "SubagentStart" \
-    '{
-      hookSpecificOutput: {
-        hookEventName: $event,
-        additionalContext: ""
-      }
-    }'
 }
 
 cmd_idle() {
@@ -477,16 +477,7 @@ cmd_stop() {
     rm -f "$health_file"
   fi
 
-  # Output hook response
-  jq -n \
-    --arg event "SubagentStop" \
-    --arg context "$advisory" \
-    '{
-      hookSpecificOutput: {
-        hookEventName: $event,
-        additionalContext: $context
-      }
-    }'
+  log_health_advisory "$advisory"
 }
 
 cmd_cleanup() {

--- a/scripts/finalize-uat-status.sh
+++ b/scripts/finalize-uat-status.sh
@@ -22,6 +22,7 @@
 set -euo pipefail
 
 UAT_FILE="${1:?Usage: finalize-uat-status.sh <uat-file-path>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P 2>/dev/null || pwd)"
 
 if [ ! -f "$UAT_FILE" ]; then
   echo "Error: UAT file not found: $UAT_FILE" >&2
@@ -169,5 +170,7 @@ awk -v status="$STATUS" -v completed="$TODAY" -v passed="$PASSED" \
   }
   { print }
 ' "$UAT_FILE" > "${UAT_FILE}.tmp" && mv "${UAT_FILE}.tmp" "$UAT_FILE"
+
+bash "$SCRIPT_DIR/reconcile-state-md.sh" --changed "$UAT_FILE" >/dev/null 2>&1 || true
 
 echo "status=${STATUS} passed=${PASSED} skipped=${SKIPPED} issues=${ISSUES} total=${TOTAL}"

--- a/scripts/lib/hook-output-guard.sh
+++ b/scripts/lib/hook-output-guard.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# hook-output-guard.sh — shared allowlist for hookSpecificOutput stdout.
+#
+# Hook lifecycle events without a verified JSON stdout contract should communicate
+# through logs or state files instead of hookSpecificOutput.
+
+should_emit_hook_output() {
+  local event_name="${1:-}"
+
+  case "$event_name" in
+    SessionStart|PreToolUse|PostToolUse|UserPromptSubmit|PreCompact)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  should_emit_hook_output "${1:-}"
+  exit $?
+fi

--- a/scripts/prepare-reverification.sh
+++ b/scripts/prepare-reverification.sh
@@ -40,6 +40,13 @@ _SCRIPT_DIR_PR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=uat-utils.sh
 . "$_SCRIPT_DIR_PR/uat-utils.sh"
 
+reconcile_changed_artifact() {
+  local changed_path="$1"
+
+  [ -f "$_SCRIPT_DIR_PR/reconcile-state-md.sh" ] || return 0
+  bash "$_SCRIPT_DIR_PR/reconcile-state-md.sh" --changed "$changed_path" >/dev/null 2>&1 || true
+}
+
 resolve_config_path() {
   local phase_dir="${1%/}"
   local planning_dir
@@ -171,6 +178,7 @@ case "$UAT_FILE" in
         git add "${PHASE_DIR}remediation/uat/.uat-remediation-stage" 2>/dev/null || true
         git rm -f --quiet "${PHASE_DIR}.uat-remediation-stage" 2>/dev/null || true
       fi
+      reconcile_changed_artifact "${PHASE_DIR}remediation/uat/.uat-remediation-stage"
       echo "archived=in-round-dir"
       echo "round_file=$UAT_BASENAME"
       echo "phase=$PHASE_NUM"
@@ -182,6 +190,7 @@ case "$UAT_FILE" in
       if [ "$_REM_STAGE" = "done" ]; then
         bash "$_SCRIPT_DIR_PR/uat-remediation-state.sh" advance "${PHASE_DIR%/}" >/dev/null
       fi
+      reconcile_changed_artifact "${PHASE_DIR}remediation/uat/.uat-remediation-stage"
       echo "skipped=ready_for_verify"
       echo "phase=$PHASE_NUM"
       echo "layout=$_LAYOUT"
@@ -208,6 +217,8 @@ if [ "$_LAYOUT" = "round-dir" ]; then
     git add "${PHASE_DIR}remediation/uat/.uat-remediation-stage" 2>/dev/null || true
     git rm -f --quiet "${PHASE_DIR}.uat-remediation-stage" 2>/dev/null || true
   fi
+
+  reconcile_changed_artifact "${PHASE_DIR}remediation/uat/.uat-remediation-stage"
 
   echo "archived=kept"
   echo "phase=$PHASE_NUM"
@@ -255,6 +266,8 @@ bash "$_SCRIPT_DIR_PR/uat-remediation-state.sh" needs-round "${PHASE_DIR%/}" >/d
 
 # Clean up legacy state file if present (new-location state file persists with updated round)
 rm -f "${PHASE_DIR}.uat-remediation-stage"
+
+reconcile_changed_artifact "${PHASE_DIR}remediation/uat/.uat-remediation-stage"
 
 # Pre-stage changes in git so boundary commits capture them even if the
 # LLM improvises a manual commit instead of using planning-git.sh.

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# reconcile-state-md.sh — Deterministically reconcile STATE.md current phase
+# projection from phase PLAN/SUMMARY/UAT artifacts.
+#
+# Default mode is intentionally quiet and fail-open so hooks and SessionStart
+# can call it without injecting context or breaking Claude Code sessions.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P 2>/dev/null || pwd)"
+JSON_OUTPUT=false
+MODE="planning"
+TARGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json)
+      JSON_OUTPUT=true
+      ;;
+    --changed)
+      MODE="changed"
+      shift
+      TARGET="${1:-}"
+      ;;
+    *)
+      if [ -z "$TARGET" ]; then
+        TARGET="$1"
+      fi
+      ;;
+  esac
+  shift || break
+done
+
+quiet_json() {
+  if [ "$JSON_OUTPUT" = true ] && command -v jq >/dev/null 2>&1; then
+    jq -n --arg status "$1" --arg detail "${2:-}" '{status:$status,detail:$detail}'
+  fi
+}
+
+# Source shared helpers. Missing dependencies are a quiet no-op by default.
+if [ -f "$SCRIPT_DIR/summary-utils.sh" ]; then
+  # shellcheck source=summary-utils.sh
+  . "$SCRIPT_DIR/summary-utils.sh" || { quiet_json "skipped" "summary-utils unavailable"; exit 0; }
+fi
+if [ -f "$SCRIPT_DIR/phase-state-utils.sh" ]; then
+  # shellcheck source=phase-state-utils.sh
+  . "$SCRIPT_DIR/phase-state-utils.sh" || { quiet_json "skipped" "phase-state-utils unavailable"; exit 0; }
+fi
+if [ -f "$SCRIPT_DIR/uat-utils.sh" ]; then
+  # shellcheck source=uat-utils.sh
+  . "$SCRIPT_DIR/uat-utils.sh" || { quiet_json "skipped" "uat-utils unavailable"; exit 0; }
+fi
+
+REQUIRED_FUNCTIONS=(
+  list_canonical_phase_dirs
+  count_phase_plans
+  count_complete_summaries
+  count_terminal_summaries
+  current_uat
+  extract_status_value
+  phase_dir_display_name
+)
+for fn in "${REQUIRED_FUNCTIONS[@]}"; do
+  if ! type "$fn" >/dev/null 2>&1; then
+    quiet_json "skipped" "missing required function: $fn"
+    exit 0
+  fi
+done
+
+physical_dir() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    (cd "$dir" 2>/dev/null && pwd -P 2>/dev/null) || printf '%s\n' "$dir"
+  else
+    printf '%s\n' "$dir"
+  fi
+}
+
+resolve_planning_root_from_changed() {
+  local changed="$1"
+  local dir parent traversals
+
+  [ -n "$changed" ] || return 0
+
+  if [ -d "$changed" ]; then
+    dir="$changed"
+  elif [ -f "$changed" ]; then
+    dir=$(dirname "$changed")
+  else
+    dir=$(dirname "$changed")
+  fi
+
+  dir=$(physical_dir "$dir")
+  traversals=0
+  while [ -n "$dir" ] && [ "$traversals" -le 10 ]; do
+    if [ -f "$dir/STATE.md" ] && [ -d "$dir/phases" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    parent=$(dirname "$dir")
+    [ "$parent" = "$dir" ] && break
+    dir="$parent"
+    traversals=$((traversals + 1))
+  done
+
+  return 0
+}
+
+resolve_planning_root() {
+  local target="$1"
+
+  if [ "$MODE" = "changed" ]; then
+    resolve_planning_root_from_changed "$target"
+    return 0
+  fi
+
+  [ -n "$target" ] || target="${VBW_PLANNING_DIR:-.vbw-planning}"
+  if [ -d "$target" ]; then
+    physical_dir "$target"
+  else
+    printf '%s\n' "$target"
+  fi
+}
+
+phase_has_unresolved_uat() {
+  local phase_dir="$1"
+  local uat_file status_val
+
+  uat_file=$(current_uat "$phase_dir")
+  [ -n "$uat_file" ] && [ -f "$uat_file" ] || return 1
+  status_val=$(extract_status_value "$uat_file")
+  [ "$status_val" = "issues_found" ]
+}
+
+status_label_for_phase() {
+  local idx="$1" plan_count="$2" terminal_count="$3" complete_count="$4" unresolved="$5"
+
+  if [ "$unresolved" = true ]; then
+    printf '%s\n' "Needs remediation"
+  elif [ "$plan_count" -gt 0 ] && [ "$complete_count" -ge "$plan_count" ]; then
+    printf '%s\n' "Complete"
+  elif [ "$terminal_count" -gt 0 ]; then
+    printf '%s\n' "In progress"
+  elif [ "$plan_count" -gt 0 ]; then
+    printf '%s\n' "Planned"
+  elif [ "$idx" -eq 1 ]; then
+    printf '%s\n' "Pending planning"
+  else
+    printf '%s\n' "Pending"
+  fi
+}
+
+rewrite_current_phase_section() {
+  local state_file="$1" phase_line="$2" plans_line="$3" progress_line="$4" status_line="$5"
+  local tmp
+
+  tmp="${state_file}.tmp-current.$$.${RANDOM:-0}"
+  if grep -q '^## Current Phase$' "$state_file" 2>/dev/null; then
+    PHASE_LINE="$phase_line" PLANS_LINE="$plans_line" PROGRESS_LINE="$progress_line" STATUS_LINE="$status_line" awk '
+      /^## Current Phase$/ {
+        print
+        print ENVIRON["PHASE_LINE"]
+        print ENVIRON["PLANS_LINE"]
+        print ENVIRON["PROGRESS_LINE"]
+        print ENVIRON["STATUS_LINE"]
+        skip = 1
+        next
+      }
+      skip && /^## / { skip = 0; print ""; print; next }
+      skip { next }
+      { print }
+    ' "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && mv "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  else
+    PHASE_LINE="$phase_line" PLANS_LINE="$plans_line" PROGRESS_LINE="$progress_line" STATUS_LINE="$status_line" awk '
+      !seen_phase && /^Phase:/ { print ENVIRON["PHASE_LINE"]; seen_phase = 1; next }
+      !seen_plans && /^Plans:/ { print ENVIRON["PLANS_LINE"]; seen_plans = 1; next }
+      !seen_progress && /^Progress:/ { print ENVIRON["PROGRESS_LINE"]; seen_progress = 1; next }
+      !seen_status && /^Status:/ { print ENVIRON["STATUS_LINE"]; seen_status = 1; next }
+      { print }
+    ' "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && mv "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  fi
+}
+
+rewrite_phase_status_section() {
+  local state_file="$1" status_lines_file="$2"
+  local tmp
+
+  [ -s "$status_lines_file" ] || return 0
+  grep -q '^## Phase Status$' "$state_file" 2>/dev/null || return 0
+
+  tmp="${state_file}.tmp-status.$$.${RANDOM:-0}"
+  STATUS_LINES_FILE="$status_lines_file" awk '
+    /^## Phase Status$/ {
+      print
+      while ((getline line < ENVIRON["STATUS_LINES_FILE"]) > 0) print line
+      skip = 1
+      next
+    }
+    skip && /^- \*\*Phase [0-9]/ { next }
+    skip && /^$/ { skip = 0; print; next }
+    skip && /^## / { skip = 0; print ""; print; next }
+    skip { next }
+    { print }
+  ' "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && mv "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+}
+
+PLANNING_DIR=$(resolve_planning_root "$TARGET")
+[ -n "$PLANNING_DIR" ] || { quiet_json "skipped" "planning root not found"; exit 0; }
+
+STATE_FILE="$PLANNING_DIR/STATE.md"
+PHASES_DIR="$PLANNING_DIR/phases"
+[ -f "$STATE_FILE" ] && [ -d "$PHASES_DIR" ] || { quiet_json "skipped" "missing STATE.md or phases directory"; exit 0; }
+
+phase_dirs=()
+while IFS= read -r phase_dir; do
+  [ -n "$phase_dir" ] || continue
+  phase_dirs+=("$phase_dir")
+done < <(list_canonical_phase_dirs "$PHASES_DIR")
+
+TOTAL=${#phase_dirs[@]}
+[ "$TOTAL" -gt 0 ] || { quiet_json "skipped" "no canonical phases"; exit 0; }
+
+plan_counts=()
+terminal_counts=()
+complete_counts=()
+unresolved_flags=()
+names=()
+labels=()
+
+active_idx=0
+active_unresolved=false
+all_done=true
+idx=0
+for phase_dir in "${phase_dirs[@]}"; do
+  idx=$((idx + 1))
+  plan_count=$(count_phase_plans "$phase_dir")
+  terminal_count=$(count_terminal_summaries "$phase_dir")
+  complete_count=$(count_complete_summaries "$phase_dir")
+  unresolved=false
+  if phase_has_unresolved_uat "$phase_dir"; then
+    unresolved=true
+  fi
+
+  plan_counts+=("$plan_count")
+  terminal_counts+=("$terminal_count")
+  complete_counts+=("$complete_count")
+  unresolved_flags+=("$unresolved")
+  names+=("$(phase_dir_display_name "$phase_dir")")
+  labels+=("$(status_label_for_phase "$idx" "$plan_count" "$terminal_count" "$complete_count" "$unresolved")")
+
+  if [ "$active_idx" -eq 0 ]; then
+    if [ "$plan_count" -eq 0 ] || [ "$complete_count" -lt "$plan_count" ] || [ "$unresolved" = true ]; then
+      active_idx="$idx"
+      active_unresolved="$unresolved"
+      all_done=false
+    fi
+  fi
+done
+
+if [ "$active_idx" -eq 0 ]; then
+  active_idx="$TOTAL"
+  all_done=true
+  active_unresolved=false
+fi
+
+array_idx=$((active_idx - 1))
+active_plan_count=${plan_counts[$array_idx]}
+active_terminal_count=${terminal_counts[$array_idx]}
+active_complete_count=${complete_counts[$array_idx]}
+active_name=${names[$array_idx]}
+
+if [ "$active_plan_count" -gt 0 ]; then
+  progress=$((active_terminal_count * 100 / active_plan_count))
+else
+  progress=0
+fi
+
+if [ "$all_done" = true ]; then
+  active_status="complete"
+elif [ "$active_unresolved" = true ]; then
+  active_status="needs_remediation"
+elif [ "$active_plan_count" -eq 0 ]; then
+  active_status="ready"
+elif [ "$active_terminal_count" -gt 0 ] && [ "$active_complete_count" -lt "$active_plan_count" ]; then
+  active_status="active"
+else
+  active_status="ready"
+fi
+
+phase_line="Phase: ${active_idx} of ${TOTAL} (${active_name})"
+plans_line="Plans: ${active_terminal_count}/${active_plan_count}"
+progress_line="Progress: ${progress}%"
+status_line="Status: ${active_status}"
+
+status_lines_file="${STATE_FILE}.phase-status.$$.${RANDOM:-0}"
+: > "$status_lines_file" 2>/dev/null || exit 0
+idx=0
+for phase_dir in "${phase_dirs[@]}"; do
+  idx=$((idx + 1))
+  name=${names[$((idx - 1))]}
+  label=${labels[$((idx - 1))]}
+  printf -- '- **Phase %s (%s):** %s\n' "$idx" "$name" "$label" >> "$status_lines_file" 2>/dev/null || true
+done
+
+rewrite_current_phase_section "$STATE_FILE" "$phase_line" "$plans_line" "$progress_line" "$status_line"
+rewrite_phase_status_section "$STATE_FILE" "$status_lines_file"
+rm -f "$status_lines_file" 2>/dev/null || true
+
+if [ "$JSON_OUTPUT" = true ] && command -v jq >/dev/null 2>&1; then
+  jq -n \
+    --arg status "reconciled" \
+    --arg planning_dir "$PLANNING_DIR" \
+    --arg phase "$active_idx" \
+    --arg total "$TOTAL" \
+    --arg phase_status "$active_status" \
+    '{status:$status,planning_dir:$planning_dir,phase:($phase|tonumber),total:($total|tonumber),phase_status:$phase_status}'
+fi
+
+exit 0

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -956,6 +956,8 @@ if [ -f "$CONFIG_FILE" ]; then
   config_caveman_review=$(jq -r 'if .caveman_review == null then false else .caveman_review end' "$CONFIG_FILE" 2>/dev/null)
 fi
 
+bash "$SCRIPT_DIR/reconcile-state-md.sh" "$PLANNING_DIR" >/dev/null 2>&1 || true
+
 # --- Parse STATE.md ---
 STATE_FILE="$MILESTONE_DIR/STATE.md"
 phase_pos="unknown"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -62,29 +62,87 @@ planning_root_from_phase_dir() {
   echo ".vbw-planning"
 }
 
+reconcile_state_md_for_changed_path() {
+  local changed_path="$1"
+
+  [ -n "$changed_path" ] || return 0
+  [ -f "$SCRIPT_DIR/reconcile-state-md.sh" ] || return 0
+  bash "$SCRIPT_DIR/reconcile-state-md.sh" --changed "$changed_path" >/dev/null 2>&1 || true
+}
+
 update_state_md() {
   local phase_dir="$1"
-  local planning_root state_md
 
-  planning_root=$(planning_root_from_phase_dir "$phase_dir")
-  state_md="${planning_root}/STATE.md"
+  reconcile_state_md_for_changed_path "$phase_dir"
+}
 
-  [ -f "$state_md" ] || return 0
+is_reconciliation_artifact() {
+  local changed_path="$1"
 
-  local plan_count summary_count pct
-  plan_count=$(count_phase_plans "$phase_dir")
-  summary_count=$(count_terminal_summaries "$phase_dir")
+  case "$changed_path" in
+    phases/[0-9]*-*/*-PLAN.md|*/phases/[0-9]*-*/*-PLAN.md|\
+    phases/[0-9]*-*/PLAN.md|*/phases/[0-9]*-*/PLAN.md|\
+    phases/[0-9]*-*/*-SUMMARY.md|*/phases/[0-9]*-*/*-SUMMARY.md|\
+    phases/[0-9]*-*/SUMMARY.md|*/phases/[0-9]*-*/SUMMARY.md|\
+    phases/[0-9]*-*/*-UAT.md|*/phases/[0-9]*-*/*-UAT.md|\
+    phases/[0-9]*-*/*-VERIFICATION.md|*/phases/[0-9]*-*/*-VERIFICATION.md|\
+    phases/[0-9]*-*/remediation/uat/round-*/R*-PLAN.md|*/phases/[0-9]*-*/remediation/uat/round-*/R*-PLAN.md|\
+    phases/[0-9]*-*/remediation/uat/round-*/R*-SUMMARY.md|*/phases/[0-9]*-*/remediation/uat/round-*/R*-SUMMARY.md|\
+    phases/[0-9]*-*/remediation/uat/round-*/R*-UAT.md|*/phases/[0-9]*-*/remediation/uat/round-*/R*-UAT.md|\
+    phases/[0-9]*-*/remediation/uat/round-*/R*-VERIFICATION.md|*/phases/[0-9]*-*/remediation/uat/round-*/R*-VERIFICATION.md|\
+    phases/[0-9]*-*/remediation/round-*/R*-PLAN.md|*/phases/[0-9]*-*/remediation/round-*/R*-PLAN.md|\
+    phases/[0-9]*-*/remediation/round-*/R*-SUMMARY.md|*/phases/[0-9]*-*/remediation/round-*/R*-SUMMARY.md|\
+    phases/[0-9]*-*/remediation/round-*/R*-UAT.md|*/phases/[0-9]*-*/remediation/round-*/R*-UAT.md|\
+    phases/[0-9]*-*/remediation/round-*/R*-VERIFICATION.md|*/phases/[0-9]*-*/remediation/round-*/R*-VERIFICATION.md|\
+    phases/[0-9]*-*/remediation/uat/.uat-remediation-stage|*/phases/[0-9]*-*/remediation/uat/.uat-remediation-stage|\
+    phases/[0-9]*-*/remediation/.uat-remediation-stage|*/phases/[0-9]*-*/remediation/.uat-remediation-stage|\
+    phases/[0-9]*-*/.uat-remediation-stage|*/phases/[0-9]*-*/.uat-remediation-stage)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
-  if [ "$plan_count" -gt 0 ]; then
-    pct=$(( (summary_count * 100) / plan_count ))
+find_phase_dir_for_changed_path() {
+  local changed_path="$1"
+  local dir parent base parent_base
+
+  [ -n "$changed_path" ] || { echo ""; return 0; }
+  if [ -d "$changed_path" ]; then
+    dir="$changed_path"
   else
-    pct=0
+    dir=$(dirname "$changed_path")
   fi
 
-  local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
-  sed "s/^Plans: .*/Plans: ${summary_count}\/${plan_count}/" "$state_md" | \
-    sed "s/^Progress: .*/Progress: ${pct}%/" > "$tmp" 2>/dev/null && \
-    [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+    base=$(basename "$dir")
+    parent=$(dirname "$dir")
+    parent_base=$(basename "$parent")
+    case "$base" in
+      [0-9]*-*)
+        if [ "$parent_base" = "phases" ]; then
+          echo "$dir"
+          return 0
+        fi
+        ;;
+    esac
+    dir="$parent"
+  done
+
+  echo ""
+  return 0
+}
+
+is_phase_root_artifact() {
+  local changed_path="$1"
+  local phase_dir parent_dir
+
+  phase_dir=$(find_phase_dir_for_changed_path "$changed_path")
+  [ -n "$phase_dir" ] || return 1
+  parent_dir=$(dirname "$changed_path")
+  [ "${parent_dir%/}" = "${phase_dir%/}" ]
 }
 
 slug_to_name() {
@@ -227,193 +285,126 @@ update_model_profile() {
 
 advance_phase() {
   local phase_dir="$1"
-  local planning_root state_md
 
-  planning_root=$(planning_root_from_phase_dir "$phase_dir")
-  state_md="${planning_root}/STATE.md"
-
-  [ -f "$state_md" ] || return 0
-
-  # Check if triggering phase is complete (terminal status, not just existence)
-  local plan_count summary_count
-  plan_count=$(count_phase_plans "$phase_dir")
-  summary_count=$(count_complete_summaries "$phase_dir")
-  [ "$plan_count" -gt 0 ] && [ "$summary_count" -eq "$plan_count" ] || return 0
-
-  # Scan all phase dirs to find next incomplete
-  local phases_dir total next_num next_name next_has_uat all_done sorted_dirs_file phase_idx
-  phases_dir=$(dirname "$phase_dir")
-  sorted_dirs_file="${state_md}.phases.$$"
-  list_canonical_phase_dirs "$phases_dir" > "$sorted_dirs_file"
-  total=$(wc -l < "$sorted_dirs_file" | tr -d ' ')
-  next_num=""
-  next_name=""
-  next_has_uat=false
-  all_done=true
-  phase_idx=0
-
-  while IFS= read -r dir; do
-    local dirname p s
-    dirname=$(basename "$dir")
-    phase_idx=$((phase_idx + 1))
-    p=$(count_phase_plans "$dir")
-    s=$(count_complete_summaries "$dir")
-
-    if [ "$p" -eq 0 ] || [ "$s" -lt "$p" ]; then
-      if [ -z "$next_num" ]; then
-        next_num="$phase_idx"
-        next_name=$(phase_dir_display_name "$dir")
-      fi
-      all_done=false
-      break
-    fi
-    # Also not done if phase has unresolved UAT issues
-    if phase_has_uat_issues "$dir"; then
-      if [ -z "$next_num" ]; then
-        next_num="$phase_idx"
-        next_name=$(phase_dir_display_name "$dir")
-        next_has_uat=true
-      fi
-      all_done=false
-      break
-    fi
-  done < "$sorted_dirs_file"
-
-  rm -f "$sorted_dirs_file" 2>/dev/null
-
-  [ "$total" -eq 0 ] && return 0
-
-  local tmp="${state_md}.tmp.$$.${RANDOM:-0}"
-  if [ "$all_done" = true ]; then
-    sed "s/^Status: .*/Status: complete/" "$state_md" > "$tmp" 2>/dev/null && \
-      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-  elif [ -n "$next_num" ]; then
-    local next_status="ready"
-    [ "$next_has_uat" = true ] && next_status="needs_remediation"
-    sed "s/^Phase: .*/Phase: ${next_num} of ${total} (${next_name})/" "$state_md" | \
-      sed "s/^Status: .*/Status: ${next_status}/" > "$tmp" 2>/dev/null && \
-      [ -s "$tmp" ] && mv "$tmp" "$state_md" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-  fi
+  reconcile_state_md_for_changed_path "$phase_dir"
 }
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
-
-# PLAN.md trigger: update plan count + activate status
-if echo "$FILE_PATH" | grep -qE 'phases/[^/]+/([0-9]+(-[0-9]+)?-PLAN|PLAN)\.md$'; then
-  update_state_md "$(dirname "$FILE_PATH")"
-  update_roadmap "$(dirname "$FILE_PATH")"
-  # Status: ready → active when a plan is written
-  _sm="$(planning_root_from_phase_dir "$(dirname "$FILE_PATH")")/STATE.md"
-  if [ -f "$_sm" ] && grep -q '^Status: ready' "$_sm" 2>/dev/null; then
-    _tmp="${_sm}.tmp.$$.${RANDOM:-0}"
-    sed 's/^Status: ready/Status: active/' "$_sm" > "$_tmp" 2>/dev/null && \
-      [ -s "$_tmp" ] && mv "$_tmp" "$_sm" 2>/dev/null || rm -f "$_tmp" 2>/dev/null
+RECONCILE_AFTER=false
+if is_reconciliation_artifact "$FILE_PATH"; then
+  _changed_phase_dir=$(find_phase_dir_for_changed_path "$FILE_PATH")
+  if [ -n "$_changed_phase_dir" ]; then
+    RECONCILE_AFTER=true
   fi
 fi
 
-# UAT.md trigger: update roadmap + state when UAT results are written
-if echo "$FILE_PATH" | grep -qE 'phases/[^/]+/[0-9]+(-[0-9]+)?-UAT\.md$'; then
-  [ -f "$FILE_PATH" ] || exit 0
+# Phase-root PLAN.md trigger: update ROADMAP. STATE.md is reconciled below.
+if is_phase_root_artifact "$FILE_PATH" && echo "$FILE_PATH" | grep -qE 'phases/[^/]+/([0-9]+(-[0-9]+)?-PLAN|PLAN)\.md$'; then
   update_roadmap "$(dirname "$FILE_PATH")"
-  advance_phase "$(dirname "$FILE_PATH")"
-  exit 0
 fi
 
-# SUMMARY.md trigger: update execution state + progress
-if ! echo "$FILE_PATH" | grep -qE 'phases/[^/]+/([0-9]+(-[0-9]+)?-SUMMARY|SUMMARY)\.md$'; then
-  exit 0
+# Phase-root UAT.md trigger: update ROADMAP. STATE.md is reconciled below.
+if is_phase_root_artifact "$FILE_PATH" && echo "$FILE_PATH" | grep -qE 'phases/[^/]+/[0-9]+(-[0-9]+)?-UAT\.md$'; then
+  if [ -f "$FILE_PATH" ]; then
+    update_roadmap "$(dirname "$FILE_PATH")"
+  fi
 fi
 
-[ -f "$FILE_PATH" ] || exit 0
+# Phase-root SUMMARY.md trigger: update execution state, ROADMAP, and model profile.
+# Remediation R*-SUMMARY.md files may affect current UAT routing but must not
+# mark phase-root execution plans complete.
+if is_phase_root_artifact "$FILE_PATH" && echo "$FILE_PATH" | grep -qE 'phases/[^/]+/([0-9]+(-[0-9]+)?-SUMMARY|SUMMARY)\.md$' && [ -f "$FILE_PATH" ]; then
+  PHASE_DIR="$(dirname "$FILE_PATH")"
+  PLANNING_ROOT="$(planning_root_from_phase_dir "$PHASE_DIR")"
+  STATE_FILE="${PLANNING_ROOT}/.execution-state.json"
+  case "$(basename "$FILE_PATH")" in
+    SUMMARY.md) SUMMARY_ID="" ;;
+    *) SUMMARY_ID="$(basename "$FILE_PATH" | sed 's/-SUMMARY\.md$//')" ;;
+  esac
 
-PHASE_DIR="$(dirname "$FILE_PATH")"
-PLANNING_ROOT="$(planning_root_from_phase_dir "$PHASE_DIR")"
-STATE_FILE="${PLANNING_ROOT}/.execution-state.json"
-case "$(basename "$FILE_PATH")" in
-  SUMMARY.md) SUMMARY_ID="" ;;
-  *) SUMMARY_ID="$(basename "$FILE_PATH" | sed 's/-SUMMARY\.md$//')" ;;
-esac
+  # Parse SUMMARY.md YAML frontmatter for phase, plan, status
+  PHASE=""
+  PLAN=""
+  STATUS=""
+  IN_FRONTMATTER=0
 
-# Parse SUMMARY.md YAML frontmatter for phase, plan, status
-PHASE=""
-PLAN=""
-STATUS=""
-IN_FRONTMATTER=0
+  while IFS= read -r line; do
+    if [ "$line" = "---" ]; then
+      if [ "$IN_FRONTMATTER" -eq 0 ]; then
+        IN_FRONTMATTER=1
+        continue
+      else
+        break
+      fi
+    fi
+    if [ "$IN_FRONTMATTER" -eq 1 ]; then
+      key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
+      val=$(echo "$line" | cut -d: -f2- | sed 's/^ *//')
+      case "$key" in
+        phase) PHASE="$val" ;;
+        plan) PLAN="$val" ;;
+        status) STATUS="$val" ;;
+      esac
+    fi
+  done < "$FILE_PATH"
 
-while IFS= read -r line; do
-  if [ "$line" = "---" ]; then
-    if [ "$IN_FRONTMATTER" -eq 0 ]; then
-      IN_FRONTMATTER=1
-      continue
-    else
-      break
+  # Best-effort fallback for non-frontmatter summaries
+  if [ -z "$PHASE" ]; then
+    PHASE=$(basename "$PHASE_DIR" | sed 's/^\([0-9]*\).*/\1/' | sed 's/^0*//')
+  fi
+
+  if [ -z "$PLAN" ]; then
+    PLAN=$(echo "$SUMMARY_ID" | sed 's/^[0-9]*-//')
+    [ "$PLAN" = "$SUMMARY_ID" ] && PLAN="$SUMMARY_ID"
+  fi
+
+  # Normalize status: only verified terminal SUMMARY statuses update execution-state.
+  # Missing, unknown, and nonterminal statuses are intentionally ignored so a
+  # partial product write cannot preemptively unlock dependent plans.
+  STATUS_RAW="$STATUS"
+  if type extract_summary_status >/dev/null 2>&1; then
+    _summary_status_raw=$(extract_summary_status "$FILE_PATH" 2>/dev/null || true)
+    if [ -n "$_summary_status_raw" ]; then
+      STATUS_RAW="$_summary_status_raw"
     fi
   fi
-  if [ "$IN_FRONTMATTER" -eq 1 ]; then
-    key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
-    val=$(echo "$line" | cut -d: -f2- | sed 's/^ *//')
-    case "$key" in
-      phase) PHASE="$val" ;;
-      plan) PLAN="$val" ;;
-      status) STATUS="$val" ;;
-    esac
+  STATUS_RAW=$(printf '%s' "${STATUS_RAW:-}" | tr '[:upper:]' '[:lower:]' | tr -d "\r\"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  STATUS=""
+  case "$STATUS_RAW" in
+    complete|completed) STATUS="complete" ;;
+    partial) STATUS="partial" ;;
+    failed) STATUS="failed" ;;
+  esac
+
+  # Update execution-state as best-effort only (never gates STATE/ROADMAP updates)
+  if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ] && [ -n "$STATUS" ]; then
+    TEMP_FILE="${STATE_FILE}.tmp.$$.${RANDOM:-0}"
+    jq --arg phase "$PHASE" --arg plan "$PLAN" --arg status "$STATUS" --arg summary_id "$SUMMARY_ID" '
+      def as_num: (try tonumber catch null);
+      if (.plans | type) == "array" then
+        .plans |= map(
+          if (.id == $summary_id)
+             or (.id == $plan)
+             or ((.id | split("-") | last | as_num) != null and ($plan | as_num) != null and ((.id | split("-") | last | as_num) == ($plan | as_num)))
+          then .status = $status
+          else .
+          end
+        )
+      elif (.phases | type) == "object" and .phases[$phase] and (.phases[$phase] | type) == "object" and .phases[$phase][$plan] then
+        .phases[$phase][$plan].status = $status
+      else
+        .
+      end
+    ' "$STATE_FILE" > "$TEMP_FILE" 2>/dev/null && [ -s "$TEMP_FILE" ] && mv "$TEMP_FILE" "$STATE_FILE" 2>/dev/null || rm -f "$TEMP_FILE" 2>/dev/null
   fi
-done < "$FILE_PATH"
 
-# Best-effort fallback for non-frontmatter summaries
-if [ -z "$PHASE" ]; then
-  PHASE=$(basename "$PHASE_DIR" | sed 's/^\([0-9]*\).*/\1/' | sed 's/^0*//')
+  update_roadmap "$PHASE_DIR"
+  update_model_profile "$PHASE_DIR"
 fi
 
-if [ -z "$PLAN" ]; then
-  PLAN=$(echo "$SUMMARY_ID" | sed 's/^[0-9]*-//')
-  [ "$PLAN" = "$SUMMARY_ID" ] && PLAN="$SUMMARY_ID"
+if [ "$RECONCILE_AFTER" = true ]; then
+  reconcile_state_md_for_changed_path "$FILE_PATH"
 fi
-
-# Normalize status: only verified terminal SUMMARY statuses update execution-state.
-# Missing, unknown, and nonterminal statuses are intentionally ignored so a
-# partial product write cannot preemptively unlock dependent plans.
-STATUS_RAW="$STATUS"
-if type extract_summary_status >/dev/null 2>&1; then
-  _summary_status_raw=$(extract_summary_status "$FILE_PATH" 2>/dev/null || true)
-  if [ -n "$_summary_status_raw" ]; then
-    STATUS_RAW="$_summary_status_raw"
-  fi
-fi
-STATUS_RAW=$(printf '%s' "${STATUS_RAW:-}" | tr '[:upper:]' '[:lower:]' | tr -d "\r\"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-STATUS=""
-case "$STATUS_RAW" in
-  complete|completed) STATUS="complete" ;;
-  partial) STATUS="partial" ;;
-  failed) STATUS="failed" ;;
-esac
-
-# Update execution-state as best-effort only (never gates STATE/ROADMAP updates)
-if [ -f "$STATE_FILE" ] && [ -n "$PLAN" ] && [ -n "$STATUS" ]; then
-  TEMP_FILE="${STATE_FILE}.tmp.$$.${RANDOM:-0}"
-  jq --arg phase "$PHASE" --arg plan "$PLAN" --arg status "$STATUS" --arg summary_id "$SUMMARY_ID" '
-    def as_num: (try tonumber catch null);
-    if (.plans | type) == "array" then
-      .plans |= map(
-        if (.id == $summary_id)
-           or (.id == $plan)
-           or ((.id | split("-") | last | as_num) != null and ($plan | as_num) != null and ((.id | split("-") | last | as_num) == ($plan | as_num)))
-        then .status = $status
-        else .
-        end
-      )
-    elif (.phases | type) == "object" and .phases[$phase] and (.phases[$phase] | type) == "object" and .phases[$phase][$plan] then
-      .phases[$phase][$plan].status = $status
-    else
-      .
-    end
-  ' "$STATE_FILE" > "$TEMP_FILE" 2>/dev/null && [ -s "$TEMP_FILE" ] && mv "$TEMP_FILE" "$STATE_FILE" 2>/dev/null || rm -f "$TEMP_FILE" 2>/dev/null
-fi
-
-update_state_md "$(dirname "$FILE_PATH")"
-update_roadmap "$(dirname "$FILE_PATH")"
-update_model_profile "$(dirname "$FILE_PATH")"
-advance_phase "$(dirname "$FILE_PATH")"
 
 exit 0

--- a/scripts/uat-remediation-state.sh
+++ b/scripts/uat-remediation-state.sh
@@ -71,6 +71,17 @@ STATE_FILE="$PHASE_DIR/remediation/uat/.uat-remediation-stage"
 LEGACY_STATE_FILE="$PHASE_DIR/.uat-remediation-stage"
 LEGACY_REMED_STATE_FILE="$PHASE_DIR/remediation/.uat-remediation-stage"
 
+reconcile_uat_state() {
+  local changed_path="${1:-$STATE_FILE}"
+
+  [ -f "$SCRIPT_DIR/reconcile-state-md.sh" ] || return 0
+  if [ -e "$changed_path" ]; then
+    bash "$SCRIPT_DIR/reconcile-state-md.sh" --changed "$changed_path" >/dev/null 2>&1 || true
+  else
+    bash "$SCRIPT_DIR/reconcile-state-md.sh" --changed "$PHASE_DIR" >/dev/null 2>&1 || true
+  fi
+}
+
 # Auto-migrate: if old-location state file exists but new doesn't, migrate
 if [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ]; then
   mkdir -p "$PHASE_DIR/remediation/uat"
@@ -84,6 +95,7 @@ if [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ]; then
     fi
   done
   rm -f "$LEGACY_REMED_STATE_FILE"
+  reconcile_uat_state "$STATE_FILE"
 fi
 
 # Major/critical chain order (UAT report serves as discussion — no separate discuss step)
@@ -221,6 +233,7 @@ start_new_round() {
   mkdir -p "$PHASE_DIR/remediation/uat/round-${next_round_padded}"
   printf 'stage=research\nround=%s\nlayout=round-dir\n' "$next_round_padded" > "$STATE_FILE"
   [ -f "$LEGACY_STATE_FILE" ] && rm -f "$LEGACY_STATE_FILE"
+  reconcile_uat_state "$STATE_FILE"
   echo "research"
   echo "round=${next_round_padded}"
   echo "round_dir=$PHASE_DIR/remediation/uat/round-${next_round_padded}"
@@ -271,6 +284,8 @@ do_init() {
   # Remove legacy state files if they exist (migrated to new location)
   rm -f "$LEGACY_STATE_FILE"
   rm -f "$LEGACY_REMED_STATE_FILE"
+
+  reconcile_uat_state "$STATE_FILE"
 
   echo "$initial_stage"
 
@@ -459,12 +474,14 @@ case "$CMD" in
       printf 'stage=%s\nround=%s\nlayout=%s\n' "$new_stage" "$round" "$layout" > "$STATE_FILE"
       # Remove legacy state file if we migrated to new location
       [ -f "$LEGACY_STATE_FILE" ] && rm -f "$LEGACY_STATE_FILE"
+      reconcile_uat_state "$STATE_FILE"
       echo "$new_stage"
     fi
     ;;
 
   reset)
     rm -f "$STATE_FILE" "$LEGACY_STATE_FILE"
+    reconcile_uat_state "$PHASE_DIR"
     echo "none"
     ;;
 
@@ -508,6 +525,7 @@ case "$CMD" in
         # layout=legacy: phase-root artifacts are current work (migrated from old format)
         printf 'stage=%s\nround=%s\nlayout=legacy\n' "$existing" "$_resume_round" > "$STATE_FILE"
         rm -f "$LEGACY_STATE_FILE"
+        reconcile_uat_state "$STATE_FILE"
       fi
       echo "$existing"
       emit_plan_metadata

--- a/scripts/validate-summary.sh
+++ b/scripts/validate-summary.sh
@@ -2,8 +2,39 @@
 set -u
 # PostToolUse/SubagentStop: Validate SUMMARY.md structure (non-blocking, exit 0)
 
+HOOK_EVENT="${1:-PostToolUse}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_OUTPUT_GUARD="$SCRIPT_DIR/lib/hook-output-guard.sh"
+if [ -f "$HOOK_OUTPUT_GUARD" ]; then
+  # shellcheck source=scripts/lib/hook-output-guard.sh
+  source "$HOOK_OUTPUT_GUARD"
+fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.command // ""')
+
+hook_event_allows_output() {
+  local event_name="$1"
+
+  if type should_emit_hook_output >/dev/null 2>&1; then
+    should_emit_hook_output "$event_name"
+    return $?
+  fi
+
+  [ "$event_name" = "PostToolUse" ]
+}
+
+emit_posttool_context() {
+  local context="$1"
+
+  [ "$HOOK_EVENT" = "PostToolUse" ] || return 0
+  hook_event_allows_output "$HOOK_EVENT" || return 0
+  jq -n --arg context "$context" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PostToolUse",
+      "additionalContext": $context
+    }
+  }'
+}
 
 # Only check SUMMARY.md files in .vbw-planning/
 if ! echo "$FILE_PATH" | grep -qE '\.vbw-planning/.*SUMMARY\.md$'; then
@@ -41,19 +72,9 @@ if [ ! -f "$FILE_PATH" ]; then
     done
 
     if [ -n "$FALLBACK_FOUND" ]; then
-      jq -n --arg file "$(basename "$FALLBACK_FOUND")" '{
-        "hookSpecificOutput": {
-          "hookEventName": "PostToolUse",
-          "additionalContext": ("SUMMARY.md missing but crash recovery fallback available: " + $file + ". Agent may have crashed before writing SUMMARY.md. Check .agent-last-words/ for final output.")
-        }
-      }'
+      emit_posttool_context "SUMMARY.md missing but crash recovery fallback available: $(basename "$FALLBACK_FOUND"). Agent may have crashed before writing SUMMARY.md. Check .agent-last-words/ for final output."
     elif [ "$STALE_FOUND" = true ]; then
-      jq -n '{
-        "hookSpecificOutput": {
-          "hookEventName": "PostToolUse",
-          "additionalContext": "SUMMARY.md missing and only stale crash recovery artifacts were found in .agent-last-words/ (>60s old). Check those files if this was a prior crash, then rerun or regenerate SUMMARY.md."
-        }
-      }'
+      emit_posttool_context "SUMMARY.md missing and only stale crash recovery artifacts were found in .agent-last-words/ (>60s old). Check those files if this was a prior crash, then rerun or regenerate SUMMARY.md."
     fi
   fi
 
@@ -135,12 +156,7 @@ fi
 esac
 
 if [ -n "$MISSING" ]; then
-  jq -n --arg msg "$MISSING" '{
-    "hookSpecificOutput": {
-      "hookEventName": "PostToolUse",
-      "additionalContext": ("SUMMARY validation: " + $msg)
-    }
-  }'
+  emit_posttool_context "SUMMARY validation: $MISSING"
 fi
 
 exit 0

--- a/tests/agent-health-integration.bats
+++ b/tests/agent-health-integration.bats
@@ -22,7 +22,9 @@ teardown() {
   kill -0 "$live_pid" 2>/dev/null || fail "live pid fixture is not alive"
 
   # Simulate SubagentStart hook
-  echo "{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  run bash -c "echo '{\"pid\":\"$live_pid\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' start"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 
   # Verify health file created
   [ -f "$HEALTH_DIR/dev.json" ]
@@ -39,7 +41,9 @@ teardown() {
   [ "$output" = "1" ]
 
   # Simulate SubagentStop hook
-  echo '{"agent_type":"vbw-dev"}' | bash "$SCRIPTS_DIR/agent-health.sh" stop >/dev/null
+  run bash -c "echo '{\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 
   # Verify health file removed
   [ ! -f "$HEALTH_DIR/dev.json" ]

--- a/tests/agent-health.bats
+++ b/tests/agent-health.bats
@@ -22,7 +22,9 @@ run_health_via_wrapper() {
 # Test 1: start creates health file
 @test "agent-health: start creates health file" {
   cd "$TEST_TEMP_DIR"
-  echo '{"pid":"12345","agent_type":"vbw-dev"}' | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
+  run bash -c "echo '{\"pid\":\"12345\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' start"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
   [ -f "$HEALTH_DIR/dev.json" ]
   run jq -r '.pid' "$HEALTH_DIR/dev.json"
   [ "$output" = "12345" ]
@@ -173,11 +175,14 @@ EOF
   dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
-  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
-  [[ "$output" == *"task-stop"* ]]
+  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-stop-001\",\"agent_type\":\"vbw:vbw-dev\",\"name\":\"dev-01\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 
   run jq -r '.owner' "$TASKS_DIR/task-stop.json"
   [ "$output" = "" ]
+
+  grep -q 'task-stop' .vbw-planning/.hook-errors.log
 
   rm -rf "$TASKS_DIR"
 }
@@ -206,11 +211,14 @@ EOF
   dead_pid=$(get_dead_pid) || fail "get_dead_pid failed"
   echo "{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}" | bash "$SCRIPTS_DIR/agent-health.sh" start >/dev/null
 
-  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop | jq -r '.hookSpecificOutput.additionalContext'"
-  [[ "$output" == *"another live teammate"* ]]
+  run bash -c "echo '{\"pid\":\"$dead_pid\",\"agent_id\":\"agent-dead\",\"agent_type\":\"vbw-dev\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 
   run jq -r '.owner' "$TASKS_DIR/task-shared.json"
   [ "$output" = "dev" ]
+
+  grep -q 'another live teammate' .vbw-planning/.hook-errors.log
 
   rm -rf "$TASKS_DIR"
 }
@@ -238,7 +246,9 @@ EOF
   [ -f "$HEALTH_DIR/qa.json" ]
 
   # Stop
-  echo '{"agent_type":"vbw-qa"}' | bash "$SCRIPTS_DIR/agent-health.sh" stop >/dev/null
+  run bash -c "echo '{\"agent_type\":\"vbw-qa\"}' | bash '$SCRIPTS_DIR/agent-health.sh' stop"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 
   # Verify file removed
   [ ! -f "$HEALTH_DIR/qa.json" ]

--- a/tests/crash-recovery.bats
+++ b/tests/crash-recovery.bats
@@ -178,6 +178,35 @@ SUMMARY
   [[ "$output" == *"Missing"* ]]
 }
 
+@test "validate-summary: PostToolUse preserves advisory JSON" {
+  echo "No frontmatter here" > .vbw-planning/phases/01-test/01-01-SUMMARY.md
+
+  local input
+  input=$(jq -n --arg fp "$TEST_TEMP_DIR/.vbw-planning/phases/01-test/01-01-SUMMARY.md" '{"tool_input":{"file_path":$fp}}')
+  run bash -c "echo '$input' | bash '$SCRIPTS_DIR/validate-summary.sh' PostToolUse"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"' >/dev/null
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("SUMMARY validation")' >/dev/null
+}
+
+@test "hook-output-guard: allowlist includes PostToolUse and excludes SubagentStop" {
+  run bash "$SCRIPTS_DIR/lib/hook-output-guard.sh" PostToolUse
+  [ "$status" -eq 0 ]
+
+  run bash "$SCRIPTS_DIR/lib/hook-output-guard.sh" SubagentStop
+  [ "$status" -eq 1 ]
+}
+
+@test "validate-summary: SubagentStop suppresses PostToolUse advisory JSON" {
+  echo "No frontmatter here" > .vbw-planning/phases/01-test/01-01-SUMMARY.md
+
+  local input
+  input=$(jq -n --arg fp "$TEST_TEMP_DIR/.vbw-planning/phases/01-test/01-01-SUMMARY.md" '{"tool_input":{"file_path":$fp}}')
+  run bash -c "echo '$input' | bash '$SCRIPTS_DIR/validate-summary.sh' SubagentStop"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "validate-summary: ignores non-SUMMARY.md files" {
   local input
   input=$(jq -n '{"tool_input":{"file_path":"src/app.ts"}}')

--- a/tests/hooks-bash-classifier.bats
+++ b/tests/hooks-bash-classifier.bats
@@ -295,6 +295,8 @@ setup() {
 
   # Verify it's a valid bash -c command
   echo "$INVOCATION" | grep -q 'bash -c'
+  grep -q 'validate-summary.sh PostToolUse' "$PROJECT_ROOT/hooks/hooks.json"
+  grep -q 'validate-summary.sh SubagentStop' "$PROJECT_ROOT/hooks/hooks.json"
 }
 
 @test "script invocation: bash-guard.sh with grep pattern matching" {

--- a/tests/sessionstart-compact-hooks.bats
+++ b/tests/sessionstart-compact-hooks.bats
@@ -50,6 +50,63 @@ teardown() {
   echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
 }
 
+@test "session-start: self-heals STATE drift before additionalContext" {
+  cd "$TEST_TEMP_DIR"
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 3 (Order Backed Sync Integration)
+Plans: 2/2
+Progress: 100%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Complete
+- **Phase 3:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Foundation
+- [ ] Phase 2: Ios Orders Client Models
+- [ ] Phase 3: Order Backed Sync Integration
+
+### Phase 1: Foundation
+### Phase 2: Ios Orders Client Models
+### Phase 3: Order Backed Sync Integration
+ROADMAP
+
+  rm -rf .vbw-planning/phases
+  mkdir -p \
+    .vbw-planning/phases/01-foundation \
+    .vbw-planning/phases/02-ios-orders-client-models \
+    .vbw-planning/phases/03-order-backed-sync-integration
+
+  echo '# Plan 1' > .vbw-planning/phases/01-foundation/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-foundation/01-01-SUMMARY.md
+  echo '# Plan 1' > .vbw-planning/phases/02-ios-orders-client-models/02-01-PLAN.md
+  echo '# Plan 2' > .vbw-planning/phases/02-ios-orders-client-models/02-02-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-ios-orders-client-models/02-01-SUMMARY.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-ios-orders-client-models/02-02-SUMMARY.md
+  printf '%s\n' '---' 'status: issues_found' '---' 'Failed.' > .vbw-planning/phases/02-ios-orders-client-models/02-UAT.md
+
+  run bash "$SCRIPTS_DIR/session-start.sh"
+  [ "$status" -eq 0 ]
+
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("Phase: 2/3 (Ios Orders Client Models) -- needs_remediation.")' >/dev/null
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("Progress: 100%.")' >/dev/null
+  ! echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("State drift detected (state_vs_filesystem)")' >/dev/null
+  grep -q '^Phase: 2 of 3 (Ios Orders Client Models)$' .vbw-planning/STATE.md
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+}
+
 @test "session-start: no phases does not crash and suggests scoping" {
   cd "$TEST_TEMP_DIR"
   rm -rf .vbw-planning/phases

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_temp_dir
+  create_test_config
+  cd "$TEST_TEMP_DIR" || exit 1
+}
+
+teardown() {
+  teardown_temp_dir
+}
+
+write_drift_fixture() {
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 3 (Order Backed Sync Integration)
+Plans: 2/2
+Progress: 100%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Complete
+- **Phase 3:** Planned
+
+## Key Decisions
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Keep deterministic state shell-side | 2026-05-01 | Avoid token repair |
+
+## Todos
+None.
+
+## Blockers
+None
+STATE
+
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Foundation
+- [ ] Phase 2: Ios Orders Client Models
+- [ ] Phase 3: Order Backed Sync Integration
+
+### Phase 1: Foundation
+### Phase 2: Ios Orders Client Models
+### Phase 3: Order Backed Sync Integration
+ROADMAP
+
+  mkdir -p \
+    .vbw-planning/phases/01-foundation \
+    .vbw-planning/phases/02-ios-orders-client-models \
+    .vbw-planning/phases/03-order-backed-sync-integration
+
+  echo '# Plan 1' > .vbw-planning/phases/01-foundation/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-foundation/01-01-SUMMARY.md
+
+  echo '# Plan 1' > .vbw-planning/phases/02-ios-orders-client-models/02-01-PLAN.md
+  echo '# Plan 2' > .vbw-planning/phases/02-ios-orders-client-models/02-02-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-ios-orders-client-models/02-01-SUMMARY.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-ios-orders-client-models/02-02-SUMMARY.md
+  cat > .vbw-planning/phases/02-ios-orders-client-models/02-UAT.md <<'UAT'
+---
+phase: 02
+status: issues_found
+---
+Failed tests.
+UAT
+}
+
+@test "reconcile-state repairs drift fixture and clears state_vs_filesystem" {
+  write_drift_fixture
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^Phase: 2 of 3 (Ios Orders Client Models)$' .vbw-planning/STATE.md
+  grep -q '^Plans: 2/2$' .vbw-planning/STATE.md
+  grep -q '^Progress: 100%$' .vbw-planning/STATE.md
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Ios Orders Client Models):\*\* Needs remediation$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Order Backed Sync Integration):\*\* Pending$' .vbw-planning/STATE.md
+  grep -q 'Keep deterministic state shell-side' .vbw-planning/STATE.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode advisory
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.failed_checks | index("state_vs_filesystem") | not' >/dev/null
+}
+
+@test "reconcile-state preserves terminal-summary display semantics" {
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Setup)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Planned
+STATE
+
+  mkdir -p .vbw-planning/phases/01-setup
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: failed' '---' 'Failed.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+
+  grep -q '^Phase: 1 of 1 (Setup)$' .vbw-planning/STATE.md
+  grep -q '^Plans: 1/1$' .vbw-planning/STATE.md
+  grep -q '^Progress: 100%$' .vbw-planning/STATE.md
+  grep -q '^Status: active$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 1 (Setup):\*\* In progress$' .vbw-planning/STATE.md
+}
+
+@test "finalize-uat-status reconciles STATE after Bash-only UAT finalization" {
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Setup)
+Plans: 1/1
+Progress: 100%
+Status: complete
+
+## Phase Status
+- **Phase 1:** Complete
+STATE
+
+  mkdir -p .vbw-planning/phases/01-setup
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  cat > .vbw-planning/phases/01-setup/01-UAT.md <<'UAT'
+---
+phase: 01
+status: in_progress
+completed:
+passed: 0
+skipped: 0
+issues: 0
+total_tests: 1
+---
+# UAT
+
+### P01: Broken flow
+- **Result:** issue
+UAT
+
+  run bash "$SCRIPTS_DIR/finalize-uat-status.sh" .vbw-planning/phases/01-setup/01-UAT.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=issues_found"* ]]
+
+  grep -q '^status: issues_found$' .vbw-planning/phases/01-setup/01-UAT.md
+  grep -q '^Phase: 1 of 1 (Setup)$' .vbw-planning/STATE.md
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 1 (Setup):\*\* Needs remediation$' .vbw-planning/STATE.md
+}
+
+@test "round-dir current UAT affects STATE and phase-root fallback remains intact" {
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Setup)
+Plans: 1/1
+Progress: 100%
+Status: complete
+
+## Phase Status
+- **Phase 1:** Complete
+STATE
+
+  mkdir -p .vbw-planning/phases/01-setup/remediation/uat/round-01
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  printf '%s\n' '---' 'status: complete' '---' 'Passed.' > .vbw-planning/phases/01-setup/01-UAT.md
+  printf '%s\n' 'stage=verify' 'round=01' 'layout=round-dir' > .vbw-planning/phases/01-setup/remediation/uat/.uat-remediation-stage
+  printf '%s\n' '---' 'status: issues_found' '---' 'Round failed.' > .vbw-planning/phases/01-setup/remediation/uat/round-01/R01-UAT.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+
+  rm -f .vbw-planning/phases/01-setup/remediation/uat/.uat-remediation-stage
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  grep -q '^Status: complete$' .vbw-planning/STATE.md
+}
+
+@test "legacy remediation current UAT affects STATE" {
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Setup)
+Plans: 1/1
+Progress: 100%
+Status: complete
+
+## Phase Status
+- **Phase 1:** Complete
+STATE
+
+  mkdir -p .vbw-planning/phases/01-setup/remediation/round-01
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  printf '%s\n' 'stage=verify' 'round=01' 'layout=legacy' > .vbw-planning/phases/01-setup/remediation/.uat-remediation-stage
+  printf '%s\n' '---' 'status: issues_found' '---' 'Legacy round failed.' > .vbw-planning/phases/01-setup/remediation/round-01/R01-UAT.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+}

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -95,7 +95,7 @@ EOF
   jq -e '.plans[0].status == "complete"' .vbw-planning/.execution-state.json >/dev/null
 }
 
-@test "PLAN trigger supports NN-PLAN naming and flips status ready to active" {
+@test "PLAN trigger supports NN-PLAN naming and reconciles planned status" {
   cd "$TEST_TEMP_DIR"
   create_state_and_roadmap "$TEST_TEMP_DIR/.vbw-planning" 2
   sed -i.bak 's/^Status: .*/Status: ready/' .vbw-planning/STATE.md && rm -f .vbw-planning/STATE.md.bak
@@ -111,10 +111,10 @@ EOF
   [ "$status" -eq 0 ]
 
   grep -q '^Plans: 0/1$' .vbw-planning/STATE.md
-  grep -q '^Status: active$' .vbw-planning/STATE.md
+  grep -q '^Status: ready$' .vbw-planning/STATE.md
 }
 
-@test "PLAN trigger supports legacy PLAN.md naming and flips status ready to active" {
+@test "PLAN trigger supports legacy PLAN.md naming and reconciles planned status" {
   cd "$TEST_TEMP_DIR"
   create_state_and_roadmap "$TEST_TEMP_DIR/.vbw-planning" 2
   sed -i.bak 's/^Status: .*/Status: ready/' .vbw-planning/STATE.md && rm -f .vbw-planning/STATE.md.bak
@@ -130,7 +130,7 @@ EOF
   [ "$status" -eq 0 ]
 
   grep -q '^Plans: 0/1$' .vbw-planning/STATE.md
-  grep -q '^Status: active$' .vbw-planning/STATE.md
+  grep -q '^Status: ready$' .vbw-planning/STATE.md
 }
 
 @test "summary update is milestone-aware for state, roadmap, and execution-state" {
@@ -224,15 +224,19 @@ SUMMARY
   run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
   [ "$status" -eq 0 ]
 
-  run grep -q '^Plans: 1/1$' .vbw-planning/STATE.md
+  run grep -q '^Plans: 0/1$' .vbw-planning/STATE.md
   if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
   [ "$status" -eq 0 ]
 
-  run grep -q '^Progress: 100%$' .vbw-planning/STATE.md
+  run grep -q '^Progress: 0%$' .vbw-planning/STATE.md
   if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
   [ "$status" -eq 0 ]
 
   run grep -q '^Phase: 2 of 2 (Core)$' .vbw-planning/STATE.md
+  if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
+  [ "$status" -eq 0 ]
+
+  run grep -q '^Status: ready$' .vbw-planning/STATE.md
   if [ "$status" -ne 0 ]; then echo "STATE.md contents:" >&2; cat .vbw-planning/STATE.md >&2; fi
   [ "$status" -eq 0 ]
 
@@ -589,4 +593,93 @@ EOF
   [ "$status" -eq 0 ]
 
   jq -e '.plans[0].status == "complete"' .vbw-planning/.execution-state.json >/dev/null
+}
+
+@test "remediation round-dir UAT write triggers STATE reconciliation" {
+  cd "$TEST_TEMP_DIR"
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+Phase: 1 of 1 (Setup)
+Plans: 1/1
+Progress: 100%
+Status: complete
+EOF
+
+  mkdir -p .vbw-planning/phases/01-setup/remediation/uat/round-01
+  echo "# plan" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  printf '%s\n' 'stage=verify' 'round=01' 'layout=round-dir' > .vbw-planning/phases/01-setup/remediation/uat/.uat-remediation-stage
+  printf '%s\n' '---' 'status: issues_found' '---' 'Round failed.' > .vbw-planning/phases/01-setup/remediation/uat/round-01/R01-UAT.md
+
+  local uat_path input
+  uat_path="$TEST_TEMP_DIR/.vbw-planning/phases/01-setup/remediation/uat/round-01/R01-UAT.md"
+  input=$(jq -nc --arg p "$uat_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+}
+
+@test "legacy remediation round UAT write triggers STATE reconciliation" {
+  cd "$TEST_TEMP_DIR"
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+Phase: 1 of 1 (Setup)
+Plans: 1/1
+Progress: 100%
+Status: complete
+EOF
+
+  mkdir -p .vbw-planning/phases/01-setup/remediation/round-01
+  echo "# plan" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  printf '%s\n' 'stage=verify' 'round=01' 'layout=legacy' > .vbw-planning/phases/01-setup/remediation/.uat-remediation-stage
+  printf '%s\n' '---' 'status: issues_found' '---' 'Legacy round failed.' > .vbw-planning/phases/01-setup/remediation/round-01/R01-UAT.md
+
+  local uat_path input
+  uat_path="$TEST_TEMP_DIR/.vbw-planning/phases/01-setup/remediation/round-01/R01-UAT.md"
+  input=$(jq -nc --arg p "$uat_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^Status: needs_remediation$' .vbw-planning/STATE.md
+}
+
+@test "remediation summary reconciles but does not complete phase-root execution plan" {
+  cd "$TEST_TEMP_DIR"
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+Phase: 1 of 1 (Setup)
+Plans: 0/1
+Progress: 0%
+Status: active
+EOF
+
+  mkdir -p .vbw-planning/phases/01-setup/remediation/uat/round-01
+  echo "# plan" > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' 'stage=execute' 'round=01' 'layout=round-dir' > .vbw-planning/phases/01-setup/remediation/uat/.uat-remediation-stage
+  printf '%s\n' '---' 'status: complete' '---' 'Remediation done.' > .vbw-planning/phases/01-setup/remediation/uat/round-01/R01-SUMMARY.md
+
+  cat > .vbw-planning/.execution-state.json <<'EOF'
+{
+  "phase": 1,
+  "status": "running",
+  "plans": [
+    {"id": "01-01", "title": "setup", "status": "pending"}
+  ]
+}
+EOF
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/01-setup/remediation/uat/round-01/R01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  jq -e '.plans[0].status == "pending"' .vbw-planning/.execution-state.json >/dev/null
+  grep -q '^Plans: 0/1$' .vbw-planning/STATE.md
+  grep -q '^Status: ready$' .vbw-planning/STATE.md
 }


### PR DESCRIPTION
## Linked Issue

Fixes #559

## What

Adds deterministic, zero-token `STATE.md` reconciliation for VBW phase/UAT/remediation artifacts and removes invalid Subagent lifecycle hook JSON. The fix introduces `scripts/reconcile-state-md.sh` as the shell-side projection writer, wires deterministic Bash UAT/remediation writers to call it, expands `scripts/state-updater.sh` remediation trigger coverage, self-heals state during SessionStart before context injection, and makes Subagent lifecycle hook output silent where Claude Code rejects `hookSpecificOutput`.

## Why

The root cause was architectural: Bash scripts mutate authoritative UAT/remediation artifacts without going through Claude Code `Write|Edit` hooks, so the existing PostToolUse-only `state-updater.sh` path could not keep `STATE.md` synchronized. The correct durable fix is to make `STATE.md` a deterministic shell-computed projection of canonical phase/summary/UAT artifacts, using the same ordered active-phase semantics as `verify-state-consistency.sh`, rather than asking the LLM to notice and repair drift. The Subagent hook error is fixed locally by suppressing unsupported lifecycle JSON while preserving health/task side effects.

## How

- `scripts/reconcile-state-md.sh`: new quiet/fail-open reconciler for current-phase fields and `## Phase Status` bullets; supports `<planning-dir>` and `--changed <artifact-path>`, resolves nearest planning root, and reuses `summary-utils.sh`, `phase-state-utils.sh`, and `uat-utils.sh`.
- `scripts/state-updater.sh`: delegates `STATE.md` projection to the reconciler, recognizes phase-root and UAT remediation artifact families, and keeps `.execution-state.json` updates limited to phase-root SUMMARY files.
- `scripts/finalize-uat-status.sh`: calls the reconciler after successful UAT frontmatter rewrites.
- `scripts/prepare-reverification.sh`: calls the reconciler after UAT archive/stage mutations and remediation state transitions.
- `scripts/uat-remediation-state.sh`: calls the reconciler after commands that mutate stage files, legacy state, or round directories.
- `scripts/session-start.sh`: runs reconciliation after config/execution-state recovery and before parsing `STATE.md` into additional context.
- `scripts/agent-health.sh`: preserves health-file/orphan-recovery side effects but stops emitting invalid SubagentStart/SubagentStop `hookSpecificOutput` JSON.
- `scripts/validate-summary.sh` and `hooks/hooks.json`: pass explicit hook event identity; PostToolUse advisories remain JSON, SubagentStop is silent.
- `scripts/lib/hook-output-guard.sh`: shared allowlist helper for events verified to accept `hookSpecificOutput`.
- Tests: add drift/self-heal, remediation trigger, Bash-only UAT finalization, hook lifecycle output, and validate-summary event behavior coverage.

## Acceptance criteria verification

1. Drift fixture is repaired by `scripts/reconcile-state-md.sh`: covered by `tests/state-reconcile.bats` (`reconcile-state repairs drift fixture and clears state_vs_filesystem`).
2. Earlier unresolved UAT wins over later empty phase: same drift fixture asserts phase 2 is selected while phase 3 is empty.
3. `Plans`/`Progress` use terminal summaries while strict completion uses complete summaries: covered by `tests/state-reconcile.bats` (`reconcile-state preserves terminal-summary display semantics`).
4. `finalize-uat-status.sh` updates `STATE.md`: covered by `tests/state-reconcile.bats` (`finalize-uat-status reconciles STATE after Bash-only UAT finalization`).
5. Round-dir and legacy remediation UAT artifacts trigger reconciliation: covered by `tests/state-updater.bats` and `tests/state-reconcile.bats` remediation UAT tests.
6. Remediation summaries do not complete phase-root execution plans: covered by `tests/state-updater.bats` (`remediation summary reconciles but does not complete phase-root execution plan`).
7. SessionStart self-heals before assembling additionalContext: covered by `tests/sessionstart-compact-hooks.bats` (`session-start: self-heals STATE drift before additionalContext`).
8. SessionStart no longer emits `state_vs_filesystem` for repaired fixture: same SessionStart test asserts the warning is absent.
9. `agent-health.sh start`/`stop` no longer emit invalid Subagent lifecycle JSON: covered by `tests/agent-health.bats` and `tests/agent-health-integration.bats`.
10. `validate-summary.sh SubagentStop` emits no invalid PostToolUse JSON: covered by `tests/crash-recovery.bats`.
11. `validate-summary.sh PostToolUse` retains advisory behavior: covered by `tests/crash-recovery.bats`.
12. Targeted regression tests pass: focused state/reconciliation, UAT, hook, agent-health, validate-summary, and SessionStart BATS/contract checks passed locally.
13. `bash testing/run-all.sh` passes: local full suite passed with `Lint checks: 1/1`, `Contract checks: 49/49`, `BATS: 3244 passed, 0 failed`.

## Testing

- [x] `bash testing/verify-hook-event-name.sh`
- [x] `bash testing/verify-bash-scripts-contract.sh`
- [x] Focused BATS: `tests/state-reconcile.bats`, `tests/state-updater.bats`, `tests/agent-health.bats`, `tests/agent-health-idle.bats`, `tests/agent-health-integration.bats`, `tests/crash-recovery.bats`, `tests/sessionstart-compact-hooks.bats`, `tests/hooks-bash-classifier.bats`, `tests/auto-uat.bats`, `tests/uat-utils.bats`
- [x] `bash testing/run-all.sh` — `3244 passed, 0 failed`
- [x] Remote CI — all 18 checks passed on `429929e128632eb46bf4f59353cffab109944c60`

## QA summary

- Primary QA: 1 round with `qa-investigator`; verdict PASS, no contract/regression findings. One low observation about concurrent identical reconciliation writes was classified as harmless/non-blocking because all writers derive the same projection and converge.
- Cross-model QA: skipped due GPT-class Copilot session model; no distinct more-expensive cross-model reviewer is available under this workflow gate.
- Copilot PR review: 1 round; fresh review on `429929e128632eb46bf4f59353cffab109944c60` returned COMMENTED with “generated no comments”; zero unresolved Copilot threads.
- Post-review main sync: checked after Copilot/CI; `origin/main` had 0 new commits, so no conflict-resolution QA rerun was needed.

## Scope notes

No consumer target repo changes, no version bumps, no broad command markdown rewrites, and no QA known-issue/remediation registry wiring were included.
