### PR TITLE
fix(hooks): guard non-pdf read pages

### DIFF
--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -13,6 +13,12 @@ disable-model-invocation: true
 
 @${CLAUDE_PLUGIN_ROOT}/references/ask-user-question.md
 
+## Tool-use compatibility
+
+<read_tool_pages_guard>
+Claude Code's `Read` `pages` argument is for PDFs only. When reading Markdown, text, source, or VBW planning artifacts, call `Read` with `file_path` only, plus `offset`/`limit` when useful; do not include `pages`, especially `pages: ""`. If a non-PDF `Read` fails with `Invalid pages parameter`, retry once immediately without `pages`; if that retry fails too, stop and report the tool error instead of looping.
+</read_tool_pages_guard>
+
 ## Context
 
 Working directory:

--- a/scripts/security-filter.sh
+++ b/scripts/security-filter.sh
@@ -13,16 +13,24 @@ fi
 INPUT=$(cat 2>/dev/null) || exit 2
 [ -z "$INPUT" ] && exit 2
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // .tool_input.pattern // ""' 2>/dev/null) || exit 2
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$INPUT" 2>/dev/null) || exit 2
+FILE_PATH=$(jq -r '.tool_input.file_path // .tool_input.path // .tool_input.pattern // ""' <<<"$INPUT" 2>/dev/null) || exit 2
 
 if [ -z "$FILE_PATH" ]; then
   exit 2
 fi
 
+is_pdf_path() {
+  case "$1" in
+    *.[pP][dD][fF]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Sensitive file patterns
 # Directory patterns use (^|/) anchoring so they match only as path components,
 # not as substrings of unrelated directory names (e.g. "corvex-build/" != "build/").
-if echo "$FILE_PATH" | grep -qE '\.env$|\.env\.|\.pem$|\.key$|\.cert$|\.p12$|\.pfx$|credentials\.json$|secrets\.json$|service-account.*\.json$|(^|/)node_modules/|(^|/)\.git/|(^|/)dist/|(^|/)build/'; then
+if grep -qE '\.env$|\.env\.|\.pem$|\.key$|\.cert$|\.p12$|\.pfx$|credentials\.json$|secrets\.json$|service-account.*\.json$|(^|/)node_modules/|(^|/)\.git/|(^|/)dist/|(^|/)build/' <<<"$FILE_PATH"; then
   echo "Blocked: sensitive file ($FILE_PATH)" >&2
   exit 2
 fi
@@ -59,7 +67,7 @@ derive_project_root() {
   printf '%s' "$root"
 }
 
-if echo "$FILE_PATH" | grep -qF '.planning/' && ! echo "$FILE_PATH" | grep -qF '.vbw-planning/'; then
+if grep -qF '.planning/' <<<"$FILE_PATH" && ! grep -qF '.vbw-planning/' <<<"$FILE_PATH"; then
   GSD_ROOT=$(derive_project_root "$FILE_PATH" ".planning")
   if is_marker_fresh "$GSD_ROOT/.vbw-planning/.active-agent" || is_marker_fresh "$GSD_ROOT/.vbw-planning/.vbw-session"; then
     echo "Blocked: .planning/ is managed by GSD, not VBW ($FILE_PATH)" >&2
@@ -73,5 +81,23 @@ fi
 # Read calls before prompt-preflight runs. GSD isolation is enforced by CLAUDE.md
 # instructions + the .planning/ block above (which prevents VBW from touching GSD).
 # Removed: self-blocking of .vbw-planning/ (v1.21.13).
+
+if [ "$TOOL_NAME" = "Read" ] && ! is_pdf_path "$FILE_PATH"; then
+  READ_HAS_EMPTY_PAGES=$(jq -r '
+    def empty_pages:
+      if (.tool_input.pages == null) then true
+      elif ((.tool_input.pages | type) == "string") then (.tool_input.pages | test("^[[:space:]]*$"))
+      else false
+      end;
+    ((.tool_input | type) == "object")
+    and (.tool_input | has("pages"))
+    and empty_pages
+  ' <<<"$INPUT" 2>/dev/null) || exit 2
+
+  if [ "$READ_HAS_EMPTY_PAGES" = "true" ]; then
+    jq -c '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",updatedInput:(.tool_input | del(.pages))}}' <<<"$INPUT" || exit 2
+    exit 0
+  fi
+fi
 
 exit 0

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -415,6 +415,14 @@ else
   fail "vibe: missing shared AskUserQuestion reference include"
 fi
 
+if grep -Fq '<read_tool_pages_guard>' "$VIBE_COMMAND_FILE" \
+  && grep -Fq "Claude Code's \`Read\` \`pages\` argument is for PDFs only" "$VIBE_COMMAND_FILE" \
+  && grep -Fq 'retry once immediately without `pages`' "$VIBE_COMMAND_FILE"; then
+  pass "vibe: guards non-PDF Read calls from empty pages loops"
+else
+  fail "vibe: missing non-PDF Read pages compatibility guard"
+fi
+
 if [ -n "$VIBE_CONFIRMATION_BLOCK" ]; then
   pass "vibe: confirmation gate block extracted for boundary checks"
 else

--- a/tests/sessionstart-compact-hooks.bats
+++ b/tests/sessionstart-compact-hooks.bats
@@ -519,6 +519,71 @@ MOCK
   INPUT='{"tool_name":"Read","tool_input":{"file_path":"src/app.js"}}'
   run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
   [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "security-filter: strips empty pages from non-pdf Read input" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/notes.md","pages":"","offset":5,"limit":10,"custom":"keep"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+  jq -e '
+    .hookSpecificOutput.hookEventName == "PreToolUse"
+    and .hookSpecificOutput.permissionDecision == "allow"
+    and .hookSpecificOutput.updatedInput.file_path == "docs/notes.md"
+    and .hookSpecificOutput.updatedInput.offset == 5
+    and .hookSpecificOutput.updatedInput.limit == 10
+    and .hookSpecificOutput.updatedInput.custom == "keep"
+    and (.hookSpecificOutput.updatedInput | has("pages") | not)
+  ' <<<"$output" >/dev/null
+}
+
+@test "security-filter: strips whitespace pages from non-pdf Read input" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/notes.md","pages":"  \t  "}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+  jq -e '
+    .hookSpecificOutput.hookEventName == "PreToolUse"
+    and (.hookSpecificOutput.updatedInput | has("pages") | not)
+  ' <<<"$output" >/dev/null
+}
+
+@test "security-filter: strips null pages from non-pdf Read input" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/notes.md","pages":null,"limit":20}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+  jq -e '
+    .hookSpecificOutput.hookEventName == "PreToolUse"
+    and .hookSpecificOutput.updatedInput.limit == 20
+    and (.hookSpecificOutput.updatedInput | has("pages") | not)
+  ' <<<"$output" >/dev/null
+}
+
+@test "security-filter: leaves non-empty pages unchanged with no stdout" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/notes.md","pages":"1-2"}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "security-filter: leaves mixed-case PDF empty pages unchanged" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/Guide.PdF","pages":""}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "security-filter: blocks .env before empty pages sanitizer" {
+  cd "$TEST_TEMP_DIR"
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":".env","pages":""}}'
+  run bash -c "echo '$INPUT' | bash '$SCRIPTS_DIR/security-filter.sh'"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Blocked: sensitive file"* ]]
+  [[ "$output" != *"hookSpecificOutput"* ]]
 }
 
 @test "security-filter: exit 2 preserved through hook-wrapper logic" {
@@ -536,6 +601,26 @@ MOCK
   INPUT='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
   run bash -c "export HOME='$TEST_TEMP_DIR'; export CLAUDE_CONFIG_DIR='$claude_dir'; echo '$INPUT' | bash '$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' security-filter.sh"
   [ "$status" -eq 2 ]
+}
+
+@test "hook-wrapper: passes through security-filter sanitizer stdout on exit 0" {
+  cd "$TEST_TEMP_DIR"
+  local claude_dir="$TEST_TEMP_DIR/.claude"
+
+  mkdir -p "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/lib"
+  cp "$SCRIPTS_DIR/hook-wrapper.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/security-filter.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/resolve-claude-dir.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/"
+  cp "$SCRIPTS_DIR/lib/vbw-config-root.sh" "$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/lib/"
+
+  INPUT='{"tool_name":"Read","tool_input":{"file_path":"docs/notes.md","pages":"","limit":10}}'
+  run bash -c "export HOME='$TEST_TEMP_DIR'; export CLAUDE_CONFIG_DIR='$claude_dir'; echo '$INPUT' | bash '$claude_dir/plugins/cache/vbw-marketplace/vbw/1.0.0/scripts/hook-wrapper.sh' security-filter.sh"
+  [ "$status" -eq 0 ]
+  jq -e '
+    .hookSpecificOutput.hookEventName == "PreToolUse"
+    and .hookSpecificOutput.updatedInput.limit == 10
+    and (.hookSpecificOutput.updatedInput | has("pages") | not)
+  ' <<<"$output" >/dev/null
 }
 
 # --- session-start.sh brownfield SUMMARY warning ---


### PR DESCRIPTION
## Linked Issue

Fixes #561

## What

Adds a defensive `Read.pages` compatibility layer for VBW workflows. `scripts/security-filter.sh` now strips only empty, whitespace-only, or explicit `null` `pages` values from non-PDF `Read` inputs while preserving every existing security block. Because runtime smoke evidence showed Claude Code can reject `Read.pages: ""` before firing `PreToolUse:Read`, `commands/vibe.md` also adds a small central prompt guard that tells `/vbw:vibe` not to include `pages` for non-PDF reads and to retry once without it if Claude Code returns the invalid-pages error.

## Why

The failing sessions were caused by a GPT/Copilot model emitting an invalid Claude Code `Read` argument for Markdown files. The durable fix is two-layered: keep the deterministic sanitizer at VBW's existing hook seam for valid hook-dispatch paths, and add a minimal `/vbw:vibe` fallback for the observed validation-before-hook path. This avoids broad prompt bloat, does not blame CCR, and preserves sensitive-file and `.planning/` isolation invariants.

## How

- `scripts/security-filter.sh` — parses `tool_name`, detects non-PDF `Read` calls with empty/whitespace/null `pages`, and emits compact `PreToolUse` `updatedInput` with only `.pages` removed after all block checks pass.
- `commands/vibe.md` — adds `<read_tool_pages_guard>` near the top of the command so `/vbw:vibe` avoids `pages` for Markdown/text/source/planning reads and retries once without `pages` on the exact error.
- `tests/sessionstart-compact-hooks.bats` — covers sanitizer behavior for normal reads, empty/whitespace/null pages, non-empty pages, mixed-case PDFs, blocked sensitive files, and wrapper stdout passthrough.
- `testing/verify-commands-contract.sh` — protects the prompt fallback guard from future drift.

## Acceptance criteria verification

1. `hooks/hooks.json` still has the single `Read|Glob|Grep|Write|Edit` `PreToolUse` matcher routed to `security-filter.sh`; no duplicate hook was added.
2. `security-filter.sh` keeps sensitive-file and GSD `.planning/` blocks before sanitizer emission; tests cover `.env` with empty `pages` exiting `2` without allow JSON.
3. Non-PDF `Read` inputs with `pages: null`, `pages: ""`, or whitespace-only `pages` remove `pages` from `updatedInput`; covered by BATS.
4. Sanitizer JSON includes `hookSpecificOutput.hookEventName: "PreToolUse"`, `permissionDecision: "allow"`, and original `.tool_input` minus only `.pages`; covered by BATS and synthetic proof.
5. Allowed `Read` calls without `pages` exit `0` with empty stdout; covered by BATS.
6. Non-empty `pages` values are not mutated; covered by BATS.
7. PDF reads, including mixed-case `.PdF`, are not mutated; covered by BATS.
8. Blocked sensitive-file reads with empty `pages` still exit `2` and emit no allow/update JSON; covered by BATS.
9. `hook-wrapper.sh security-filter.sh` preserves sanitizer stdout on exit `0` and existing block behavior on exit `2`; covered by BATS.
10. Focused sanitizer coverage lives in `tests/sessionstart-compact-hooks.bats`.
11. Required verification passed from the feature worktree: `verify-hook-event-name`, `verify-bash-scripts-contract`, `run-lint`, and full `testing/run-all.sh`.
12. Synthetic hook proof confirmed `updatedInput` removed only empty/whitespace `pages` while preserving `file_path`, `offset`, and `limit`.
13. Runtime CCR sandbox proof showed Claude Code 2.1.126 validates `Read.pages: ""` before firing `PreToolUse:Read`; therefore the minimal `commands/vibe.md` prompt fallback was added and contract-tested.

## Testing

- [x] Loaded plugin locally through `ccr code --plugin-dir /Users/dpearson/repos/vibe-better-with-claude-code-vbw-worktrees/fix-561-read-pages-sanitizer`
- [x] Smoke-tested from sandbox while loading the candidate plugin checkout via `--plugin-dir`
- [x] No plugin-load errors in CCR smoke preflight
- [x] Existing commands still pass contract and BATS coverage
- [x] Ran QA review round 1 with `qa-investigator`

Commands/evidence:

- `bash testing/verify-hook-event-name.sh` — pass, 14/14
- `bash testing/verify-bash-scripts-contract.sh` — pass, 651/651
- `bash testing/run-lint.sh` — pass
- `bats tests/sessionstart-compact-hooks.bats` — pass, 43/43
- `bash testing/verify-commands-contract.sh` — pass, 467/467
- `bash testing/run-all.sh` — pass, lint 1/1, contracts 49/49, BATS 3251/0
- CCR runtime proof: sandbox `/tmp/vbw-read-pages-smoke-561`, stream capture `/tmp/vbw-read-pages-ccr-smoke-561.jsonl`, session `05d6b760-79dd-445e-abc3-9f56a8906d06`

## QA Review Evidence

- **Primary QA rounds completed:** 1
- **Primary model/agent:** `qa-investigator`
- **Round 1 verdict:** CLEAN, zero legitimate findings
- **QA evidence commit:** `ff6a936` — `fix(hooks): address QA round 1`
- **Cross-model QA:** skipped per workflow gate because this is a GPT-class Copilot session; no different cheaper cross-model target is available.
- **Copilot PR review rounds:** pending Phase 4.5

## Notes

Runtime proof found the exact edge case the saved plan warned about: for invalid `Read.pages: ""`, Claude Code returned the validation error without any `PreToolUse:Read` hook event. That is why the branch includes both the tested sanitizer and the scoped `/vbw:vibe` fallback guard.
