### PR TITLE
Fix linked ROADMAP checklist drift in archive state consistency

### DIFF
--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -56,6 +56,117 @@ phase_dir_position() {
   echo ""
 }
 
+normalize_roadmap_phase_num() {
+  local num="$1"
+  num=$(printf '%s' "$num" | sed 's/^0*//')
+  printf '%s\n' "${num:-0}"
+}
+
+roadmap_checklist_phase_num_from_line() {
+  local line="$1" raw_num
+  if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+    raw_num="${BASH_REMATCH[1]}"
+    normalize_roadmap_phase_num "$raw_num"
+    return 0
+  fi
+  return 1
+}
+
+roadmap_phase_dir_prefix_num() {
+  local phase_dir="$1" num
+  num=$(basename "$phase_dir" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
+  normalize_roadmap_phase_num "$num"
+}
+
+roadmap_numbering_scheme() {
+  local roadmap_file="$1" phases_dir="$2"
+  local checklist_nums=() prefix_nums=() ordinal_nums=()
+  local line num dir idx checklist_seq prefix_seq ordinal_seq
+
+  [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
+  [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+      checklist_nums+=("$num")
+    fi
+  done < "$roadmap_file"
+
+  idx=0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    idx=$((idx + 1))
+    prefix_nums+=("$(roadmap_phase_dir_prefix_num "$dir")")
+    ordinal_nums+=("$idx")
+  done < <(list_canonical_phase_dirs "$phases_dir")
+
+  if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#checklist_nums[@]}" -ne "${#prefix_nums[@]}" ]; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
+
+  checklist_seq=$(printf '%s\n' "${checklist_nums[@]}")
+  prefix_seq=$(printf '%s\n' "${prefix_nums[@]}")
+  ordinal_seq=$(printf '%s\n' "${ordinal_nums[@]}")
+
+  if [ "$checklist_seq" = "$prefix_seq" ]; then
+    printf '%s\n' "prefix"
+  elif [ "$checklist_seq" = "$ordinal_seq" ]; then
+    printf '%s\n' "ordinal"
+  else
+    printf '%s\n' "unknown"
+  fi
+}
+
+roadmap_phase_num_for_dir() {
+  local scheme="$1" phase_dir="$2" phases_dir
+  phases_dir="${3:-$(dirname "$phase_dir")}"
+
+  case "$scheme" in
+    prefix)
+      roadmap_phase_dir_prefix_num "$phase_dir"
+      ;;
+    ordinal)
+      phase_dir_position "$phase_dir" "$phases_dir"
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
+}
+
+roadmap_phase_dir_for_num() {
+  local scheme="$1" phases_dir="$2" phase_num="$3"
+  local wanted dir idx dir_num
+
+  wanted=$(normalize_roadmap_phase_num "$phase_num")
+  [ -n "$wanted" ] || return 1
+  [ "$wanted" != "0" ] || return 1
+
+  idx=0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    idx=$((idx + 1))
+    case "$scheme" in
+      prefix)
+        dir_num=$(roadmap_phase_dir_prefix_num "$dir")
+        ;;
+      ordinal)
+        dir_num="$idx"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+    if [ "$dir_num" = "$wanted" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+  done < <(list_canonical_phase_dirs "$phases_dir")
+
+  return 1
+}
+
 find_phase_dir_by_ref() {
   local planning_dir="$1"
   local phase_ref="$2"

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -139,8 +139,12 @@ roadmap_numbering_scheme() {
     ordinal_nums+=("$idx")
   done < <(list_canonical_phase_dirs "$phases_dir")
 
-  if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#prefix_nums[@]}" -eq 0 ]; then
+  if [ "${#prefix_nums[@]}" -eq 0 ]; then
     printf '%s\n' "unknown"
+    return 0
+  fi
+  if [ "${#checklist_nums[@]}" -eq 0 ]; then
+    printf '%s\n' "prefix"
     return 0
   fi
 

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -78,10 +78,49 @@ roadmap_phase_dir_prefix_num() {
   normalize_roadmap_phase_num "$num"
 }
 
+_roadmap_index_in_sequence() {
+  local wanted="$1" sequence="$2" idx=0 candidate
+
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    idx=$((idx + 1))
+    if [ "$candidate" = "$wanted" ]; then
+      printf '%s\n' "$idx"
+      return 0
+    fi
+  done <<< "$sequence"
+
+  return 1
+}
+
+_roadmap_candidate_score() {
+  local checklist_seq="$1" expected_seq="$2"
+  local seen="" last_idx=0 score=0 num expected_idx
+
+  [ -n "$expected_seq" ] || { printf '%s\n' "0"; return 0; }
+
+  while IFS= read -r num; do
+    [ -n "$num" ] || continue
+    case " $seen " in *" $num "*) continue ;; esac
+    seen="$seen $num"
+
+    if expected_idx=$(_roadmap_index_in_sequence "$num" "$expected_seq"); then
+      if [ "$expected_idx" -le "$last_idx" ]; then
+        printf '%s\n' "0"
+        return 0
+      fi
+      last_idx="$expected_idx"
+      score=$((score + 1))
+    fi
+  done <<< "$checklist_seq"
+
+  printf '%s\n' "$score"
+}
+
 roadmap_numbering_scheme() {
   local roadmap_file="$1" phases_dir="$2"
   local checklist_nums=() prefix_nums=() ordinal_nums=()
-  local line num dir idx checklist_seq prefix_seq ordinal_seq
+  local line num dir idx checklist_seq prefix_seq ordinal_seq prefix_score ordinal_score
 
   [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
   [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
@@ -100,7 +139,7 @@ roadmap_numbering_scheme() {
     ordinal_nums+=("$idx")
   done < <(list_canonical_phase_dirs "$phases_dir")
 
-  if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#checklist_nums[@]}" -ne "${#prefix_nums[@]}" ]; then
+  if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#prefix_nums[@]}" -eq 0 ]; then
     printf '%s\n' "unknown"
     return 0
   fi
@@ -108,10 +147,20 @@ roadmap_numbering_scheme() {
   checklist_seq=$(printf '%s\n' "${checklist_nums[@]}")
   prefix_seq=$(printf '%s\n' "${prefix_nums[@]}")
   ordinal_seq=$(printf '%s\n' "${ordinal_nums[@]}")
+  prefix_score=$(_roadmap_candidate_score "$checklist_seq" "$prefix_seq")
+  ordinal_score=$(_roadmap_candidate_score "$checklist_seq" "$ordinal_seq")
 
-  if [ "$checklist_seq" = "$prefix_seq" ]; then
+  if [ "$prefix_score" -le 0 ] && [ "$ordinal_score" -le 0 ]; then
+    printf '%s\n' "unknown"
+  elif [ "$prefix_seq" = "$ordinal_seq" ]; then
     printf '%s\n' "prefix"
-  elif [ "$checklist_seq" = "$ordinal_seq" ]; then
+  elif [ "$prefix_score" -gt 0 ] && [ "$ordinal_score" -le 0 ]; then
+    printf '%s\n' "prefix"
+  elif [ "$ordinal_score" -gt 0 ] && [ "$prefix_score" -le 0 ]; then
+    printf '%s\n' "ordinal"
+  elif [ "$prefix_score" -gt "$ordinal_score" ]; then
+    printf '%s\n' "prefix"
+  elif [ "$ordinal_score" -gt "$prefix_score" ]; then
     printf '%s\n' "ordinal"
   else
     printf '%s\n' "unknown"

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -72,6 +72,48 @@ roadmap_checklist_phase_num_from_line() {
   return 1
 }
 
+roadmap_checklist_duplicate_phase_nums() {
+  local roadmap_file="$1"
+  local seen="" emitted="" line num
+
+  [ -f "$roadmap_file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+      case " $seen " in
+        *" $num "*)
+          case " $emitted " in
+            *" $num "*) ;;
+            *)
+              printf '%s\n' "$num"
+              emitted="$emitted $num"
+              ;;
+          esac
+          ;;
+      esac
+      seen="$seen $num"
+    fi
+  done < "$roadmap_file"
+}
+
+roadmap_checklist_has_duplicate_phase_nums() {
+  local roadmap_file="$1"
+  local seen="" line num
+
+  [ -f "$roadmap_file" ] || return 1
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+      case " $seen " in
+        *" $num "*) return 0 ;;
+      esac
+      seen="$seen $num"
+    fi
+  done < "$roadmap_file"
+
+  return 1
+}
+
 roadmap_phase_dir_prefix_num() {
   local phase_dir="$1" num
   num=$(basename "$phase_dir" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
@@ -124,6 +166,10 @@ roadmap_numbering_scheme() {
 
   [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
   [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
+  if roadmap_checklist_has_duplicate_phase_nums "$roadmap_file"; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
 
   while IFS= read -r line || [ -n "$line" ]; do
     if num=$(roadmap_checklist_phase_num_from_line "$line"); then

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -235,7 +235,7 @@ desired_roadmap_marker_for_phase_num() {
 
 rewrite_roadmap_checklist_projection() {
   local roadmap_file="$1"
-  local tmp line raw_num line_num marker scheme
+  local tmp line line_num marker scheme
 
   [ -f "$roadmap_file" ] || return 0
   scheme=$(roadmap_numbering_scheme "$roadmap_file" "$PHASES_DIR")
@@ -245,9 +245,7 @@ rewrite_roadmap_checklist_projection() {
   : > "$tmp" 2>/dev/null || return 0
 
   while IFS= read -r line || [ -n "$line" ]; do
-    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
-      raw_num="${BASH_REMATCH[1]}"
-      line_num=$(normalize_roadmap_phase_num "$raw_num")
+    if line_num=$(roadmap_checklist_phase_num_from_line "$line"); then
       if marker=$(desired_roadmap_marker_for_phase_num "$scheme" "$line_num"); then
         line="- [${marker}]${line:5}"
       fi

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -59,6 +59,12 @@ REQUIRED_FUNCTIONS=(
   current_uat
   extract_status_value
   phase_dir_display_name
+  normalize_roadmap_phase_num
+  roadmap_checklist_phase_num_from_line
+  roadmap_phase_dir_prefix_num
+  roadmap_numbering_scheme
+  roadmap_phase_num_for_dir
+  roadmap_phase_dir_for_num
 )
 for fn in "${REQUIRED_FUNCTIONS[@]}"; do
   if ! type "$fn" >/dev/null 2>&1; then

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -204,24 +204,14 @@ rewrite_phase_status_section() {
   ' "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && mv "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 }
 
-normalize_roadmap_phase_num() {
-  local num="$1"
-  num=$(printf '%s' "$num" | sed 's/^0*//')
-  printf '%s\n' "${num:-0}"
-}
-
-phase_dir_prefix_num() {
-  local phase_dir="$1" num
-  num=$(basename "$phase_dir" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
-  normalize_roadmap_phase_num "$num"
-}
-
 desired_roadmap_marker_for_phase_num() {
-  local wanted_num="$1" idx phase_dir prefix_num plan_count complete_count unresolved
+  local scheme="$1" wanted_num="$2" idx phase_dir candidate_phase_dir plan_count complete_count unresolved
+  phase_dir=$(roadmap_phase_dir_for_num "$scheme" "$PHASES_DIR" "$wanted_num") || return 1
+  [ -n "$phase_dir" ] || return 1
+
   idx=0
-  for phase_dir in "${phase_dirs[@]}"; do
-    prefix_num=$(phase_dir_prefix_num "$phase_dir")
-    if [ "$prefix_num" = "$wanted_num" ]; then
+  for candidate_phase_dir in "${phase_dirs[@]}"; do
+    if [ "${candidate_phase_dir%/}" = "${phase_dir%/}" ]; then
       plan_count=${plan_counts[$idx]}
       complete_count=${complete_counts[$idx]}
       unresolved=${unresolved_flags[$idx]}
@@ -239,9 +229,11 @@ desired_roadmap_marker_for_phase_num() {
 
 rewrite_roadmap_checklist_projection() {
   local roadmap_file="$1"
-  local tmp line raw_num line_num marker
+  local tmp line raw_num line_num marker scheme
 
   [ -f "$roadmap_file" ] || return 0
+  scheme=$(roadmap_numbering_scheme "$roadmap_file" "$PHASES_DIR")
+  [ "$scheme" != "unknown" ] || return 0
 
   tmp="${roadmap_file}.tmp-checklist.$$.${RANDOM:-0}"
   : > "$tmp" 2>/dev/null || return 0
@@ -250,7 +242,7 @@ rewrite_roadmap_checklist_projection() {
     if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
       raw_num="${BASH_REMATCH[1]}"
       line_num=$(normalize_roadmap_phase_num "$raw_num")
-      if marker=$(desired_roadmap_marker_for_phase_num "$line_num"); then
+      if marker=$(desired_roadmap_marker_for_phase_num "$scheme" "$line_num"); then
         line="- [${marker}]${line:5}"
       fi
     fi

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -204,6 +204,62 @@ rewrite_phase_status_section() {
   ' "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && mv "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 }
 
+normalize_roadmap_phase_num() {
+  local num="$1"
+  num=$(printf '%s' "$num" | sed 's/^0*//')
+  printf '%s\n' "${num:-0}"
+}
+
+phase_dir_prefix_num() {
+  local phase_dir="$1" num
+  num=$(basename "$phase_dir" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
+  normalize_roadmap_phase_num "$num"
+}
+
+desired_roadmap_marker_for_phase_num() {
+  local wanted_num="$1" idx phase_dir prefix_num plan_count complete_count unresolved
+  idx=0
+  for phase_dir in "${phase_dirs[@]}"; do
+    prefix_num=$(phase_dir_prefix_num "$phase_dir")
+    if [ "$prefix_num" = "$wanted_num" ]; then
+      plan_count=${plan_counts[$idx]}
+      complete_count=${complete_counts[$idx]}
+      unresolved=${unresolved_flags[$idx]}
+      if [ "$plan_count" -gt 0 ] && [ "$complete_count" -ge "$plan_count" ] && [ "$unresolved" != true ]; then
+        printf '%s\n' "x"
+      else
+        printf '%s\n' " "
+      fi
+      return 0
+    fi
+    idx=$((idx + 1))
+  done
+  return 1
+}
+
+rewrite_roadmap_checklist_projection() {
+  local roadmap_file="$1"
+  local tmp line raw_num line_num marker
+
+  [ -f "$roadmap_file" ] || return 0
+
+  tmp="${roadmap_file}.tmp-checklist.$$.${RANDOM:-0}"
+  : > "$tmp" 2>/dev/null || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+      raw_num="${BASH_REMATCH[1]}"
+      line_num=$(normalize_roadmap_phase_num "$raw_num")
+      if marker=$(desired_roadmap_marker_for_phase_num "$line_num"); then
+        line="- [${marker}]${line:5}"
+      fi
+    fi
+    printf '%s\n' "$line" >> "$tmp" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 0; }
+  done < "$roadmap_file"
+
+  [ -s "$tmp" ] && mv "$tmp" "$roadmap_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+}
+
 PLANNING_DIR=$(resolve_planning_root "$TARGET")
 [ -n "$PLANNING_DIR" ] || { quiet_json "skipped" "planning root not found"; exit 0; }
 
@@ -305,6 +361,7 @@ done
 rewrite_current_phase_section "$STATE_FILE" "$phase_line" "$plans_line" "$progress_line" "$status_line"
 rewrite_phase_status_section "$STATE_FILE" "$status_lines_file"
 rm -f "$status_lines_file" 2>/dev/null || true
+rewrite_roadmap_checklist_projection "$PLANNING_DIR/ROADMAP.md"
 
 if [ "$JSON_OUTPUT" = true ] && command -v jq >/dev/null 2>&1; then
   jq -n \

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -65,6 +65,7 @@ REQUIRED_FUNCTIONS=(
   roadmap_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
+  roadmap_checklist_has_duplicate_phase_nums
 )
 for fn in "${REQUIRED_FUNCTIONS[@]}"; do
   if ! type "$fn" >/dev/null 2>&1; then
@@ -238,6 +239,9 @@ rewrite_roadmap_checklist_projection() {
   local tmp line line_num marker scheme
 
   [ -f "$roadmap_file" ] || return 0
+  if roadmap_checklist_has_duplicate_phase_nums "$roadmap_file"; then
+    return 0
+  fi
   scheme=$(roadmap_numbering_scheme "$roadmap_file" "$PHASES_DIR")
   [ "$scheme" != "unknown" ] || return 0
 

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -48,6 +48,26 @@ else
   }
 fi
 
+if ! type normalize_roadmap_phase_num >/dev/null 2>&1; then
+  normalize_roadmap_phase_num() {
+    local num="$1"
+    num=$(printf '%s' "$num" | sed 's/^0*//')
+    printf '%s\n' "${num:-0}"
+  }
+fi
+
+if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
+  roadmap_numbering_scheme() {
+    printf '%s\n' "unknown"
+  }
+fi
+
+if ! type roadmap_phase_num_for_dir >/dev/null 2>&1; then
+  roadmap_phase_num_for_dir() {
+    printf '\n'
+  }
+fi
+
 planning_root_from_phase_dir() {
   local phase_dir="$1"
   local phases_dir root
@@ -149,12 +169,6 @@ slug_to_name() {
   echo "$1" | sed 's/^[0-9]*-//' | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1'
 }
 
-normalize_roadmap_phase_num() {
-  local num="$1"
-  num=$(printf '%s' "$num" | sed 's/^0*//')
-  printf '%s\n' "${num:-0}"
-}
-
 rewrite_roadmap_checkboxes_for_phase() {
   local roadmap="$1" marker="$2"
   shift 2
@@ -209,14 +223,15 @@ update_roadmap() {
 
   [ -f "$roadmap" ] || return 0
 
-  local dirname phase_num prefix_phase_num plan_count summary_count status date_str
+  local dirname ordinal_phase_num table_phase_num checkbox_phase_num checkbox_scheme prefix_phase_num plan_count summary_count status date_str
   dirname=$(basename "$phase_dir")
   prefix_phase_num=$(echo "$dirname" | sed 's/^\([0-9]*\).*/\1/' | sed 's/^0*//')
-  phase_num=$(phase_dir_position "$phase_dir")
-  if [ -z "$phase_num" ]; then
-    phase_num="$prefix_phase_num"
+  ordinal_phase_num=$(phase_dir_position "$phase_dir")
+  if [ -z "$ordinal_phase_num" ]; then
+    ordinal_phase_num="$prefix_phase_num"
   fi
-  [ -z "$phase_num" ] && return 0
+  [ -z "$ordinal_phase_num" ] && return 0
+  table_phase_num="$ordinal_phase_num"
 
   plan_count=$(count_phase_plans "$phase_dir")
   summary_count=$(count_terminal_summaries "$phase_dir")
@@ -246,21 +261,21 @@ update_roadmap() {
 
   # Update extended progress table row (| num - name | done | status | date |)
   local existing_name
-  existing_name=$(grep -E "^\| *${phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
-  if [ -z "$existing_name" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$phase_num" ]; then
-    phase_num="$prefix_phase_num"
-    existing_name=$(grep -E "^\| *${phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
+  existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
+  if [ -z "$existing_name" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$table_phase_num" ]; then
+    table_phase_num="$prefix_phase_num"
+    existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
   fi
   if [ -n "$existing_name" ]; then
     local tmp_ext="${roadmap}.tmp_ext.$$.${RANDOM:-0}"
-    sed "s/^| *${phase_num} - .*/| ${phase_num} - ${existing_name} | ${summary_count}\/${plan_count} | ${status} | ${date_str} |/" "$tmp" > "$tmp_ext" 2>/dev/null && \
+    sed "s/^| *${table_phase_num} - .*/| ${table_phase_num} - ${existing_name} | ${summary_count}\/${plan_count} | ${status} | ${date_str} |/" "$tmp" > "$tmp_ext" 2>/dev/null && \
       [ -s "$tmp_ext" ] && mv "$tmp_ext" "$tmp" 2>/dev/null || rm -f "$tmp_ext" 2>/dev/null
   fi
 
   # Update simple progress table format (| 01 | ● Done |)
   local padded_num
-  padded_num=$(printf '%02d' "$phase_num" 2>/dev/null || echo "$phase_num")
-  if grep -qE "^\| *0*${phase_num} *\|" "$tmp" 2>/dev/null; then
+  padded_num=$(printf '%02d' "$table_phase_num" 2>/dev/null || echo "$table_phase_num")
+  if grep -qE "^\| *0*${table_phase_num} *\|" "$tmp" 2>/dev/null; then
     local simple_status
     case "$status" in
       complete)      simple_status="● Done" ;;
@@ -270,15 +285,20 @@ update_roadmap() {
       *)             simple_status="$status" ;;
     esac
     local tmp_simple="${roadmap}.tmp_s.$$.${RANDOM:-0}"
-    sed "s/^| *0*${phase_num} *|.*/| ${padded_num} | ${simple_status} |/" "$tmp" > "$tmp_simple" 2>/dev/null && \
+    sed "s/^| *0*${table_phase_num} *|.*/| ${padded_num} | ${simple_status} |/" "$tmp" > "$tmp_simple" 2>/dev/null && \
       [ -s "$tmp_simple" ] && mv "$tmp_simple" "$tmp" 2>/dev/null || rm -f "$tmp_simple" 2>/dev/null
   fi
 
+  checkbox_scheme=$(roadmap_numbering_scheme "$tmp" "$(dirname "$phase_dir")")
+  checkbox_phase_num=$(roadmap_phase_num_for_dir "$checkbox_scheme" "$phase_dir" "$(dirname "$phase_dir")")
+
   # Check/uncheck checkbox based on status
-  if [ "$status" = "complete" ]; then
-    rewrite_roadmap_checkboxes_for_phase "$tmp" "x" "$phase_num" "$prefix_phase_num"
-  elif [ "$status" = "uat issues" ]; then
-    rewrite_roadmap_checkboxes_for_phase "$tmp" " " "$phase_num" "$prefix_phase_num"
+  if [ -n "$checkbox_phase_num" ]; then
+    if [ "$status" = "complete" ]; then
+      rewrite_roadmap_checkboxes_for_phase "$tmp" "x" "$checkbox_phase_num"
+    elif [ "$status" = "uat issues" ]; then
+      rewrite_roadmap_checkboxes_for_phase "$tmp" " " "$checkbox_phase_num"
+    fi
   fi
 
   mv "$tmp" "$roadmap" 2>/dev/null || rm -f "$tmp" 2>/dev/null

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -149,6 +149,46 @@ slug_to_name() {
   echo "$1" | sed 's/^[0-9]*-//' | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1'
 }
 
+normalize_roadmap_phase_num() {
+  local num="$1"
+  num=$(printf '%s' "$num" | sed 's/^0*//')
+  printf '%s\n' "${num:-0}"
+}
+
+rewrite_roadmap_checkboxes_for_phase() {
+  local roadmap="$1" marker="$2"
+  shift 2
+
+  [ -f "$roadmap" ] || return 0
+  [ "$#" -gt 0 ] || return 0
+
+  local tmp line raw_num line_num target target_num matched
+  tmp="${roadmap}.tmp_checkbox.$$.${RANDOM:-0}"
+  : > "$tmp" 2>/dev/null || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    matched=false
+    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+      raw_num="${BASH_REMATCH[1]}"
+      line_num=$(normalize_roadmap_phase_num "$raw_num")
+      for target in "$@"; do
+        [ -n "$target" ] || continue
+        target_num=$(normalize_roadmap_phase_num "$target")
+        if [ "$line_num" = "$target_num" ]; then
+          matched=true
+          break
+        fi
+      done
+      if [ "$matched" = true ]; then
+        line="- [${marker}]${line:5}"
+      fi
+    fi
+    printf '%s\n' "$line" >> "$tmp" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 0; }
+  done < "$roadmap"
+
+  [ -s "$tmp" ] && mv "$tmp" "$roadmap" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+}
+
 # Check if a phase has unresolved UAT issues
 # Uses shared extract_status_value() + current_uat() from uat-utils.sh
 phase_has_uat_issues() {
@@ -235,13 +275,10 @@ update_roadmap() {
   fi
 
   # Check/uncheck checkbox based on status
-  local tmp2="${roadmap}.tmp2.$$.${RANDOM:-0}"
   if [ "$status" = "complete" ]; then
-    sed "s/^- \[ \] Phase ${phase_num}:/- [x] Phase ${phase_num}:/" "$tmp" > "$tmp2" 2>/dev/null && \
-      [ -s "$tmp2" ] && mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
+    rewrite_roadmap_checkboxes_for_phase "$tmp" "x" "$phase_num" "$prefix_phase_num"
   elif [ "$status" = "uat issues" ]; then
-    sed "s/^- \[[xX]\] Phase ${phase_num}:/- [ ] Phase ${phase_num}:/" "$tmp" > "$tmp2" 2>/dev/null && \
-      [ -s "$tmp2" ] && mv "$tmp2" "$tmp" 2>/dev/null || rm -f "$tmp2" 2>/dev/null
+    rewrite_roadmap_checkboxes_for_phase "$tmp" " " "$phase_num" "$prefix_phase_num"
   fi
 
   mv "$tmp" "$roadmap" 2>/dev/null || rm -f "$tmp" 2>/dev/null

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -320,15 +320,13 @@ rewrite_roadmap_checkboxes_for_phase() {
   [ -f "$roadmap" ] || return 0
   [ "$#" -gt 0 ] || return 0
 
-  local tmp line raw_num line_num target target_num matched
+  local tmp line line_num target target_num matched
   tmp="${roadmap}.tmp_checkbox.$$.${RANDOM:-0}"
   : > "$tmp" 2>/dev/null || return 0
 
   while IFS= read -r line || [ -n "$line" ]; do
     matched=false
-    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
-      raw_num="${BASH_REMATCH[1]}"
-      line_num=$(normalize_roadmap_phase_num "$raw_num")
+    if line_num=$(roadmap_checklist_phase_num_from_line "$line"); then
       for target in "$@"; do
         [ -n "$target" ] || continue
         target_num=$(normalize_roadmap_phase_num "$target")

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -86,6 +86,52 @@ if ! type roadmap_checklist_phase_num_from_line >/dev/null 2>&1; then
   }
 fi
 
+if ! type roadmap_checklist_duplicate_phase_nums >/dev/null 2>&1; then
+  roadmap_checklist_duplicate_phase_nums() {
+    local roadmap_file="$1"
+    local seen="" emitted="" line num
+
+    [ -f "$roadmap_file" ] || return 0
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+        case " $seen " in
+          *" $num "*)
+            case " $emitted " in
+              *" $num "*) ;;
+              *)
+                printf '%s\n' "$num"
+                emitted="$emitted $num"
+                ;;
+            esac
+            ;;
+        esac
+        seen="$seen $num"
+      fi
+    done < "$roadmap_file"
+  }
+fi
+
+if ! type roadmap_checklist_has_duplicate_phase_nums >/dev/null 2>&1; then
+  roadmap_checklist_has_duplicate_phase_nums() {
+    local roadmap_file="$1"
+    local seen="" line num
+
+    [ -f "$roadmap_file" ] || return 1
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+        case " $seen " in
+          *" $num "*) return 0 ;;
+        esac
+        seen="$seen $num"
+      fi
+    done < "$roadmap_file"
+
+    return 1
+  }
+fi
+
 if ! type roadmap_phase_dir_prefix_num >/dev/null 2>&1; then
   roadmap_phase_dir_prefix_num() {
     local phase_dir="$1" num
@@ -145,6 +191,10 @@ if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
 
     [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
     [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
+    if roadmap_checklist_has_duplicate_phase_nums "$roadmap_file"; then
+      printf '%s\n' "unknown"
+      return 0
+    fi
 
     while IFS= read -r line || [ -n "$line" ]; do
       if num=$(roadmap_checklist_phase_num_from_line "$line"); then
@@ -319,6 +369,9 @@ rewrite_roadmap_checkboxes_for_phase() {
 
   [ -f "$roadmap" ] || return 0
   [ "$#" -gt 0 ] || return 0
+  if roadmap_checklist_has_duplicate_phase_nums "$roadmap"; then
+    return 0
+  fi
 
   local tmp line line_num target target_num matched
   tmp="${roadmap}.tmp_checkbox.$$.${RANDOM:-0}"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -160,8 +160,12 @@ if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
       ordinal_nums+=("$idx")
     done < <(list_canonical_phase_dirs "$phases_dir")
 
-    if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#prefix_nums[@]}" -eq 0 ]; then
+    if [ "${#prefix_nums[@]}" -eq 0 ]; then
       printf '%s\n' "unknown"
+      return 0
+    fi
+    if [ "${#checklist_nums[@]}" -eq 0 ]; then
+      printf '%s\n' "prefix"
       return 0
     fi
 

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -56,15 +56,155 @@ if ! type normalize_roadmap_phase_num >/dev/null 2>&1; then
   }
 fi
 
+if ! type phase_dir_position >/dev/null 2>&1; then
+  phase_dir_position() {
+    local phase_dir="$1"
+    local phases_parent="${2:-$(dirname "$phase_dir")}" idx=0 dir
+
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      idx=$((idx + 1))
+      if [ "${dir%/}" = "${phase_dir%/}" ]; then
+        echo "$idx"
+        return 0
+      fi
+    done < <(list_canonical_phase_dirs "$phases_parent")
+
+    echo ""
+  }
+fi
+
+if ! type roadmap_checklist_phase_num_from_line >/dev/null 2>&1; then
+  roadmap_checklist_phase_num_from_line() {
+    local line="$1" raw_num
+    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+      raw_num="${BASH_REMATCH[1]}"
+      normalize_roadmap_phase_num "$raw_num"
+      return 0
+    fi
+    return 1
+  }
+fi
+
+if ! type roadmap_phase_dir_prefix_num >/dev/null 2>&1; then
+  roadmap_phase_dir_prefix_num() {
+    local phase_dir="$1" num
+    num=$(basename "$phase_dir" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
+    normalize_roadmap_phase_num "$num"
+  }
+fi
+
+if ! type _roadmap_index_in_sequence >/dev/null 2>&1; then
+  _roadmap_index_in_sequence() {
+    local wanted="$1" sequence="$2" idx=0 candidate
+
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      idx=$((idx + 1))
+      if [ "$candidate" = "$wanted" ]; then
+        printf '%s\n' "$idx"
+        return 0
+      fi
+    done <<< "$sequence"
+
+    return 1
+  }
+fi
+
+if ! type _roadmap_candidate_score >/dev/null 2>&1; then
+  _roadmap_candidate_score() {
+    local checklist_seq="$1" expected_seq="$2"
+    local seen="" last_idx=0 score=0 num expected_idx
+
+    [ -n "$expected_seq" ] || { printf '%s\n' "0"; return 0; }
+
+    while IFS= read -r num; do
+      [ -n "$num" ] || continue
+      case " $seen " in *" $num "*) continue ;; esac
+      seen="$seen $num"
+
+      if expected_idx=$(_roadmap_index_in_sequence "$num" "$expected_seq"); then
+        if [ "$expected_idx" -le "$last_idx" ]; then
+          printf '%s\n' "0"
+          return 0
+        fi
+        last_idx="$expected_idx"
+        score=$((score + 1))
+      fi
+    done <<< "$checklist_seq"
+
+    printf '%s\n' "$score"
+  }
+fi
+
 if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
   roadmap_numbering_scheme() {
-    printf '%s\n' "unknown"
+    local roadmap_file="$1" phases_dir="$2"
+    local checklist_nums=() prefix_nums=() ordinal_nums=()
+    local line num dir idx checklist_seq prefix_seq ordinal_seq prefix_score ordinal_score
+
+    [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
+    [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+        checklist_nums+=("$num")
+      fi
+    done < "$roadmap_file"
+
+    idx=0
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      idx=$((idx + 1))
+      prefix_nums+=("$(roadmap_phase_dir_prefix_num "$dir")")
+      ordinal_nums+=("$idx")
+    done < <(list_canonical_phase_dirs "$phases_dir")
+
+    if [ "${#checklist_nums[@]}" -eq 0 ] || [ "${#prefix_nums[@]}" -eq 0 ]; then
+      printf '%s\n' "unknown"
+      return 0
+    fi
+
+    checklist_seq=$(printf '%s\n' "${checklist_nums[@]}")
+    prefix_seq=$(printf '%s\n' "${prefix_nums[@]}")
+    ordinal_seq=$(printf '%s\n' "${ordinal_nums[@]}")
+    prefix_score=$(_roadmap_candidate_score "$checklist_seq" "$prefix_seq")
+    ordinal_score=$(_roadmap_candidate_score "$checklist_seq" "$ordinal_seq")
+
+    if [ "$prefix_score" -le 0 ] && [ "$ordinal_score" -le 0 ]; then
+      printf '%s\n' "unknown"
+    elif [ "$prefix_seq" = "$ordinal_seq" ]; then
+      printf '%s\n' "prefix"
+    elif [ "$prefix_score" -gt 0 ] && [ "$ordinal_score" -le 0 ]; then
+      printf '%s\n' "prefix"
+    elif [ "$ordinal_score" -gt 0 ] && [ "$prefix_score" -le 0 ]; then
+      printf '%s\n' "ordinal"
+    elif [ "$prefix_score" -gt "$ordinal_score" ]; then
+      printf '%s\n' "prefix"
+    elif [ "$ordinal_score" -gt "$prefix_score" ]; then
+      printf '%s\n' "ordinal"
+    else
+      printf '%s\n' "unknown"
+    fi
   }
 fi
 
 if ! type roadmap_phase_num_for_dir >/dev/null 2>&1; then
   roadmap_phase_num_for_dir() {
-    printf '\n'
+    local scheme="$1" phase_dir="$2" phases_dir
+    phases_dir="${3:-$(dirname "$phase_dir")}"
+
+    case "$scheme" in
+      prefix)
+        roadmap_phase_dir_prefix_num "$phase_dir"
+        ;;
+      ordinal)
+        phase_dir_position "$phase_dir" "$phases_dir"
+        ;;
+      *)
+        printf '\n'
+        ;;
+    esac
   }
 fi
 

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -53,6 +53,12 @@ REQUIRED_FUNCTIONS=(
   is_valid_summary_status
   current_uat
   extract_status_value
+  normalize_roadmap_phase_num
+  roadmap_checklist_phase_num_from_line
+  roadmap_phase_dir_prefix_num
+  roadmap_numbering_scheme
+  roadmap_phase_num_for_dir
+  roadmap_phase_dir_for_num
 )
 MISSING_FUNCTIONS=()
 for fn in "${REQUIRED_FUNCTIONS[@]}"; do

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -443,7 +443,7 @@ run_check_roadmap_vs_summaries() {
   done < "$ROADMAP_FILE"
 
   # Reverse check: every phase dir should have a matching ROADMAP entry
-  local rd rd_num rd_idx
+  local rd rd_num rd_idx rd_base rd_prefix
   rd_idx=0
   while IFS= read -r rd; do
     [ -n "$rd" ] || continue
@@ -461,7 +461,18 @@ run_check_roadmap_vs_summaries() {
     esac
     case " $seen_phases " in
       *" $rd_num "*) ;; # found in roadmap
-      *) mismatches="${mismatches:+$mismatches, }phase directory $rd_num exists on disk but no matching ROADMAP checklist entry" ;;
+      *)
+        case "$scheme" in
+          ordinal)
+            rd_base=$(basename "$rd")
+            rd_prefix=$(roadmap_phase_dir_prefix_num "$rd")
+            mismatches="${mismatches:+$mismatches, }ordinal phase position $rd_num maps to phase directory $rd_base (prefix $rd_prefix) but no matching ROADMAP checklist entry"
+            ;;
+          prefix)
+            mismatches="${mismatches:+$mismatches, }phase directory $rd_num exists on disk but no matching ROADMAP checklist entry"
+            ;;
+        esac
+        ;;
     esac
   done < <(list_canonical_phase_dirs "$PHASES_DIR")
 

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -378,7 +378,7 @@ run_check_roadmap_vs_summaries() {
   scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
   if [ "$scheme" = "unknown" ]; then
     mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
-    while IFS= read -r line; do
+    while IFS= read -r line || [ -n "$line" ]; do
       phase_num=$(roadmap_checklist_phase_num_from_line "$line") || continue
       case " $seen_phases " in
         *" $phase_num "*)
@@ -393,7 +393,7 @@ run_check_roadmap_vs_summaries() {
     return
   fi
 
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     phase_num=$(roadmap_checklist_phase_num_from_line "$line") || continue
 
     # Duplicate detection
@@ -840,7 +840,7 @@ run_check_state_vs_roadmap() {
   local roadmap_checklist_count roadmap_section_count
   # Accept both plain "- [ ] Phase N:" and bootstrap link "- [ ] [Phase N:"
   roadmap_checklist_count=0
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     if roadmap_checklist_phase_num_from_line "$line" >/dev/null 2>&1; then
       roadmap_checklist_count=$((roadmap_checklist_count + 1))
     fi

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -59,6 +59,7 @@ REQUIRED_FUNCTIONS=(
   roadmap_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
+  roadmap_checklist_has_duplicate_phase_nums
 )
 MISSING_FUNCTIONS=()
 for fn in "${REQUIRED_FUNCTIONS[@]}"; do

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -379,16 +379,14 @@ run_check_roadmap_vs_summaries() {
   if [ "$scheme" = "unknown" ]; then
     mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
     while IFS= read -r line; do
-      phase_num=$(echo "$line" | sed -n 's/^- \[.\] \[\{0,1\}Phase \([0-9][0-9]*\):.*/\1/p')
-      [ -n "$phase_num" ] || continue
-      phase_num=$(normalize_roadmap_phase_num "$phase_num")
+      phase_num=$(roadmap_checklist_phase_num_from_line "$line") || continue
       case " $seen_phases " in
         *" $phase_num "*)
           mismatches="${mismatches:+$mismatches, }duplicate ROADMAP checklist entry for phase $phase_num"
           ;;
       esac
       seen_phases="$seen_phases $phase_num"
-    done < <(grep -iE '^\- \[(x| )\] (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
+    done < "$ROADMAP_FILE"
 
     check_roadmap_vs_summaries_pass=false
     check_roadmap_vs_summaries_detail="$mismatches"
@@ -396,12 +394,7 @@ run_check_roadmap_vs_summaries() {
   fi
 
   while IFS= read -r line; do
-    # Accept both plain "- [ ] Phase N:" and bootstrap link "- [ ] [Phase N:"
-    phase_num=$(echo "$line" | sed -n 's/^- \[.\] \[\{0,1\}Phase \([0-9][0-9]*\):.*/\1/p')
-    [ -n "$phase_num" ] || continue
-    # Remove leading zeros (sed, not arithmetic — avoids octal for 08/09)
-    phase_num=$(printf '%s' "$phase_num" | sed 's/^0*//')
-    phase_num=${phase_num:-0}
+    phase_num=$(roadmap_checklist_phase_num_from_line "$line") || continue
 
     # Duplicate detection
     case " $seen_phases " in
@@ -412,9 +405,9 @@ run_check_roadmap_vs_summaries() {
     seen_phases="$seen_phases $phase_num"
 
     checked=false
-    if echo "$line" | grep -qi '^\- \[x\]'; then
-      checked=true
-    fi
+    case "$line" in
+      -\ \[x\]*|-\ \[X\]*) checked=true ;;
+    esac
 
     # Find phase dir using the ROADMAP's existing numbering scheme.
     phase_dir=""
@@ -447,7 +440,7 @@ run_check_roadmap_vs_summaries() {
         mismatches="${mismatches:+$mismatches, }phase $phase_num marked [ ] but all plans complete ($complete/$plans)"
       fi
     fi
-  done < <(grep -iE '^\- \[(x| )\] (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
+  done < "$ROADMAP_FILE"
 
   # Reverse check: every phase dir should have a matching ROADMAP entry
   local rd rd_num rd_idx
@@ -846,7 +839,12 @@ run_check_state_vs_roadmap() {
 
   local roadmap_checklist_count roadmap_section_count
   # Accept both plain "- [ ] Phase N:" and bootstrap link "- [ ] [Phase N:"
-  roadmap_checklist_count=$(grep -cE '^\- \[.\] (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
+  roadmap_checklist_count=0
+  while IFS= read -r line; do
+    if roadmap_checklist_phase_num_from_line "$line" >/dev/null 2>&1; then
+      roadmap_checklist_count=$((roadmap_checklist_count + 1))
+    fi
+  done < "$ROADMAP_FILE"
   # Accept ### or ## section headings (bootstrap may use ## instead of ###)
   roadmap_section_count=$(grep -cE '^#{2,3} (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
 

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -372,6 +372,21 @@ run_check_roadmap_vs_summaries() {
   scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
   if [ "$scheme" = "unknown" ]; then
     mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
+    while IFS= read -r line; do
+      phase_num=$(echo "$line" | sed -n 's/^- \[.\] \[\{0,1\}Phase \([0-9][0-9]*\):.*/\1/p')
+      [ -n "$phase_num" ] || continue
+      phase_num=$(normalize_roadmap_phase_num "$phase_num")
+      case " $seen_phases " in
+        *" $phase_num "*)
+          mismatches="${mismatches:+$mismatches, }duplicate ROADMAP checklist entry for phase $phase_num"
+          ;;
+      esac
+      seen_phases="$seen_phases $phase_num"
+    done < <(grep -iE '^\- \[(x| )\] (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
+
+    check_roadmap_vs_summaries_pass=false
+    check_roadmap_vs_summaries_detail="$mismatches"
+    return
   fi
 
   while IFS= read -r line; do
@@ -438,8 +453,11 @@ run_check_roadmap_vs_summaries() {
       ordinal)
         rd_num="$rd_idx"
         ;;
-      *)
+      prefix)
         rd_num=$(roadmap_phase_dir_prefix_num "$rd")
+        ;;
+      *)
+        continue
         ;;
     esac
     case " $seen_phases " in

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -366,8 +366,13 @@ run_check_roadmap_vs_summaries() {
   fi
 
   local mismatches=""
-  local phase_num checked plans complete phase_dir
+  local phase_num checked plans complete phase_dir scheme
   local seen_phases=""
+
+  scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
+  if [ "$scheme" = "unknown" ]; then
+    mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
+  fi
 
   while IFS= read -r line; do
     # Accept both plain "- [ ] Phase N:" and bootstrap link "- [ ] [Phase N:"
@@ -390,20 +395,11 @@ run_check_roadmap_vs_summaries() {
       checked=true
     fi
 
-    # Find phase dir with matching number
+    # Find phase dir using the ROADMAP's existing numbering scheme.
     phase_dir=""
-    local d d_num
-    while IFS= read -r d; do
-      [ -n "$d" ] || continue
-      d_num=$(basename "$d" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
-      # Remove leading zeros for comparison (sed, not arithmetic — avoids octal for 08/09)
-      d_num=$(printf '%s' "$d_num" | sed 's/^0*//')
-      d_num=${d_num:-0}
-      if [ "$d_num" -eq "$phase_num" ]; then
-        phase_dir="$d"
-        break
-      fi
-    done < <(list_canonical_phase_dirs "$PHASES_DIR")
+    if [ "$scheme" != "unknown" ]; then
+      phase_dir=$(roadmap_phase_dir_for_num "$scheme" "$PHASES_DIR" "$phase_num" 2>/dev/null || true)
+    fi
 
     if [ -z "$phase_dir" ]; then
       mismatches="${mismatches:+$mismatches, }phase $phase_num referenced in ROADMAP.md but no matching phase directory"
@@ -433,12 +429,19 @@ run_check_roadmap_vs_summaries() {
   done < <(grep -iE '^\- \[(x| )\] (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
 
   # Reverse check: every phase dir should have a matching ROADMAP entry
-  local rd rd_num
+  local rd rd_num rd_idx
+  rd_idx=0
   while IFS= read -r rd; do
     [ -n "$rd" ] || continue
-    rd_num=$(basename "$rd" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
-    rd_num=$(printf '%s' "$rd_num" | sed 's/^0*//')
-    rd_num=${rd_num:-0}
+    rd_idx=$((rd_idx + 1))
+    case "$scheme" in
+      ordinal)
+        rd_num="$rd_idx"
+        ;;
+      *)
+        rd_num=$(roadmap_phase_dir_prefix_num "$rd")
+        ;;
+    esac
     case " $seen_phases " in
       *" $rd_num "*) ;; # found in roadmap
       *) mismatches="${mismatches:+$mismatches, }phase directory $rd_num exists on disk but no matching ROADMAP checklist entry" ;;

--- a/testing/list-contract-tests.sh
+++ b/testing/list-contract-tests.sh
@@ -60,5 +60,6 @@ printf '%s\t%s\n' \
   research-storage-contract    testing/verify-research-storage-contract.sh \
   readme-config-reference      testing/verify-readme-config-reference.sh \
   config-defaults-sync         testing/verify-config-defaults-sync.sh \
+  roadmap-checklist-parser     testing/verify-roadmap-checklist-parser-contract.sh \
   caveman-contract             testing/verify-caveman-contract.sh \
   verify-vibe                  scripts/verify-vibe.sh

--- a/testing/verify-roadmap-checklist-parser-contract.sh
+++ b/testing/verify-roadmap-checklist-parser-contract.sh
@@ -42,7 +42,7 @@ assert_not_contains_literal() {
 verify_phase_number_consumer() {
   local file="$1" fn="$2" label="$3" body
   body=$(function_body "$ROOT_DIR/$file" "$fn")
-  [ -n "$body" ] || fail "$label: function body found"
+  [ -n "$body" ] || fail "$label: function body missing"
   pass "$label: function body found"
   assert_contains_literal "$body" "roadmap_checklist_phase_num_from_line" "$label: uses shared checklist parser"
   assert_not_contains_literal "$body" "BASH_REMATCH[1]" "$label: no BASH_REMATCH phase extraction"
@@ -53,15 +53,26 @@ verify_phase_number_consumer() {
 verify_checklist_counter() {
   local file="$1" fn="$2" label="$3" body
   body=$(function_body "$ROOT_DIR/$file" "$fn")
-  [ -n "$body" ] || fail "$label: function body found"
+  [ -n "$body" ] || fail "$label: function body missing"
   pass "$label: function body found"
   assert_contains_literal "$body" "roadmap_checklist_phase_num_from_line" "$label: checklist count uses shared parser"
   assert_not_contains_literal "$body" "grep -cE '^\\- \\[.\\] (\\[)?Phase [0-9]+:'" "$label: no grep checklist count parser"
+}
+
+verify_duplicate_guard() {
+  local file="$1" fn="$2" label="$3" body
+  body=$(function_body "$ROOT_DIR/$file" "$fn")
+  [ -n "$body" ] || fail "$label: function body missing"
+  pass "$label: function body found"
+  assert_contains_literal "$body" "roadmap_checklist_has_duplicate_phase_nums" "$label: guards duplicate checklist phase numbers"
 }
 
 verify_phase_number_consumer "scripts/verify-state-consistency.sh" "run_check_roadmap_vs_summaries" "verify-state-consistency run_check_roadmap_vs_summaries"
 verify_checklist_counter "scripts/verify-state-consistency.sh" "run_check_state_vs_roadmap" "verify-state-consistency run_check_state_vs_roadmap"
 verify_phase_number_consumer "scripts/reconcile-state-md.sh" "rewrite_roadmap_checklist_projection" "reconcile-state-md rewrite_roadmap_checklist_projection"
 verify_phase_number_consumer "scripts/state-updater.sh" "rewrite_roadmap_checkboxes_for_phase" "state-updater rewrite_roadmap_checkboxes_for_phase"
+verify_duplicate_guard "scripts/phase-state-utils.sh" "roadmap_numbering_scheme" "phase-state-utils roadmap_numbering_scheme"
+verify_duplicate_guard "scripts/reconcile-state-md.sh" "rewrite_roadmap_checklist_projection" "reconcile-state-md rewrite_roadmap_checklist_projection"
+verify_duplicate_guard "scripts/state-updater.sh" "rewrite_roadmap_checkboxes_for_phase" "state-updater rewrite_roadmap_checkboxes_for_phase"
 
 printf '\nAll ROADMAP checklist parser contract checks passed.\n'

--- a/testing/verify-roadmap-checklist-parser-contract.sh
+++ b/testing/verify-roadmap-checklist-parser-contract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; exit 1; }
+
+function_body() {
+  local file="$1" fn="$2"
+  awk -v fn="$fn" '
+    $0 ~ "^" fn "\\(\\)[[:space:]]*\\{" { in_fn = 1; depth = 0 }
+    in_fn {
+      print
+      opens = gsub(/\{/, "{")
+      closes = gsub(/\}/, "}")
+      depth += opens - closes
+      if (started && depth <= 0) exit
+      started = 1
+    }
+  ' "$file"
+}
+
+assert_contains_literal() {
+  local body="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" <<< "$body"; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+assert_not_contains_literal() {
+  local body="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" <<< "$body"; then
+    fail "$label"
+  else
+    pass "$label"
+  fi
+}
+
+verify_phase_number_consumer() {
+  local file="$1" fn="$2" label="$3" body
+  body=$(function_body "$ROOT_DIR/$file" "$fn")
+  [ -n "$body" ] || fail "$label: function body found"
+  pass "$label: function body found"
+  assert_contains_literal "$body" "roadmap_checklist_phase_num_from_line" "$label: uses shared checklist parser"
+  assert_not_contains_literal "$body" "BASH_REMATCH[1]" "$label: no BASH_REMATCH phase extraction"
+  assert_not_contains_literal "$body" "Phase \\([0-9][0-9]*\\)" "$label: no sed phase extraction"
+  assert_not_contains_literal "$body" "grep -iE '^\\- \\[(x| )\\]" "$label: no grep checklist phase filter"
+}
+
+verify_checklist_counter() {
+  local file="$1" fn="$2" label="$3" body
+  body=$(function_body "$ROOT_DIR/$file" "$fn")
+  [ -n "$body" ] || fail "$label: function body found"
+  pass "$label: function body found"
+  assert_contains_literal "$body" "roadmap_checklist_phase_num_from_line" "$label: checklist count uses shared parser"
+  assert_not_contains_literal "$body" "grep -cE '^\\- \\[.\\] (\\[)?Phase [0-9]+:'" "$label: no grep checklist count parser"
+}
+
+verify_phase_number_consumer "scripts/verify-state-consistency.sh" "run_check_roadmap_vs_summaries" "verify-state-consistency run_check_roadmap_vs_summaries"
+verify_checklist_counter "scripts/verify-state-consistency.sh" "run_check_state_vs_roadmap" "verify-state-consistency run_check_state_vs_roadmap"
+verify_phase_number_consumer "scripts/reconcile-state-md.sh" "rewrite_roadmap_checklist_projection" "reconcile-state-md rewrite_roadmap_checklist_projection"
+verify_phase_number_consumer "scripts/state-updater.sh" "rewrite_roadmap_checkboxes_for_phase" "state-updater rewrite_roadmap_checkboxes_for_phase"
+
+printf '\nAll ROADMAP checklist parser contract checks passed.\n'

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -99,6 +99,59 @@ UAT
   echo "$output" | jq -e '.failed_checks | index("state_vs_filesystem") | not' >/dev/null
 }
 
+@test "reconcile-state repairs linked ROADMAP checklist drift by phase prefix" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 2 (Api Contracts)
+Plans: 1/1
+Progress: 100%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] [Phase 01: Foundation](#phase-01-foundation)
+- [ ] [Phase 03: Api Contracts](#phase-03-api-contracts)
+
+## Phase 01: Foundation
+## Phase 03: Api Contracts
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-foundation .vbw-planning/phases/03-api-contracts
+  echo '# Plan' > .vbw-planning/phases/01-foundation/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-foundation/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-api-contracts/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-api-contracts/03-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^- \[x\] \[Phase 03: Api Contracts\](#phase-03-api-contracts)$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
 @test "reconcile-state preserves terminal-summary display semantics" {
   cat > .vbw-planning/STATE.md <<'STATE'
 # State

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -260,6 +260,64 @@ ROADMAP
   [ "$status" -eq 0 ]
 }
 
+@test "reconcile-state repairs ordinal ROADMAP checklist drift by sorted phase position" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 3 (Deploy)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+- **Phase 3:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 3: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
+  grep -q '^- \[ \] Phase 3: Deploy$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
 @test "reconcile-state preserves terminal-summary display semantics" {
   cat > .vbw-planning/STATE.md <<'STATE'
 # State

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -375,6 +375,85 @@ ROADMAP
   echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
 }
 
+@test "reconcile-state skips quietly when ROADMAP helpers are missing" {
+  local partial_scripts
+  partial_scripts="$TEST_TEMP_DIR/partial-reconcile-scripts"
+  mkdir -p "$partial_scripts"
+  cp "$SCRIPTS_DIR/reconcile-state-md.sh" "$partial_scripts/reconcile-state-md.sh"
+  cp "$SCRIPTS_DIR/summary-utils.sh" "$partial_scripts/summary-utils.sh"
+  cp "$SCRIPTS_DIR/uat-utils.sh" "$partial_scripts/uat-utils.sh"
+  cat > "$partial_scripts/phase-state-utils.sh" <<'PHASEUTILS'
+list_canonical_phase_dirs() { :; }
+count_phase_plans() { echo "0"; }
+phase_dir_display_name() { echo "Stub"; }
+PHASEUTILS
+
+  run bash "$partial_scripts/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  run bash "$partial_scripts/reconcile-state-md.sh" --json .vbw-planning
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.status == "skipped"' >/dev/null
+  echo "$output" | jq -r '.detail' | grep -q 'missing required function: normalize_roadmap_phase_num'
+}
+
+@test "reconcile-state repairs resolvable ROADMAP despite stray extra entry" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+- **Phase 3:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+- [ ] Phase 4: Stray
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 3: Deploy
+## Phase 4: Stray
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/02-build .vbw-planning/phases/03-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/02-build/02-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-build/02-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-deploy/03-01-PLAN.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
+  grep -q '^- \[ \] Phase 4: Stray$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'phase 4 referenced in ROADMAP.md but no matching phase directory'
+}
+
 @test "reconcile-state preserves terminal-summary display semantics" {
   cat > .vbw-planning/STATE.md <<'STATE'
 # State

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -318,6 +318,65 @@ ROADMAP
   [ "$status" -eq 0 ]
 }
 
+@test "reconcile-state leaves duplicate ordinal ROADMAP entries verifier-owned" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 3 (Deploy)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+- **Phase 3:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 2: Duplicate Build
+- [ ] Phase 3: Deploy
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 2: Duplicate Build
+## Phase 3: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  grep -E '^- \[[ xX]\] Phase 2:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-before.txt"
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -E '^- \[[ xX]\] Phase 2:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-after.txt"
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.txt" "$TEST_TEMP_DIR/roadmap-after.txt"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'duplicate ROADMAP checklist entry for phase 2'
+}
+
 @test "reconcile-state leaves unknown ROADMAP checklist scheme untouched" {
   cat > .vbw-planning/PROJECT.md <<'PROJECT'
 # Test Project

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -152,6 +152,114 @@ ROADMAP
   [ "$status" -eq 0 ]
 }
 
+@test "reconcile-state unchecks linked ROADMAP entry when current UAT has issues" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Api Contracts)
+Plans: 1/1
+Progress: 100%
+Status: complete
+
+## Phase Status
+- **Phase 1:** Complete
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] [Phase 03: Api Contracts](#phase-03-api-contracts)
+
+## Phase 03: Api Contracts
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/03-api-contracts
+  echo '# Plan' > .vbw-planning/phases/03-api-contracts/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-api-contracts/03-01-SUMMARY.md
+  cat > .vbw-planning/phases/03-api-contracts/03-UAT.md <<'UAT'
+---
+phase: 03
+status: issues_found
+---
+# UAT
+UAT
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^- \[ \] \[Phase 03: Api Contracts\](#phase-03-api-contracts)$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
+@test "reconcile-state repairs plain ROADMAP checklist drift by phase prefix" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 2 (Api Contracts)
+Plans: 1/1
+Progress: 100%
+Status: ready
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 01: Foundation
+- [ ] Phase 03: Api Contracts
+
+## Phase 01: Foundation
+## Phase 03: Api Contracts
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-foundation .vbw-planning/phases/03-api-contracts
+  echo '# Plan' > .vbw-planning/phases/01-foundation/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-foundation/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-api-contracts/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-api-contracts/03-01-SUMMARY.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^- \[x\] Phase 03: Api Contracts$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
 @test "reconcile-state preserves terminal-summary display semantics" {
   cat > .vbw-planning/STATE.md <<'STATE'
 # State

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -318,6 +318,63 @@ ROADMAP
   [ "$status" -eq 0 ]
 }
 
+@test "reconcile-state leaves unknown ROADMAP checklist scheme untouched" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+
+## Phase Status
+- **Phase 1:** Complete
+- **Phase 2:** Planned
+- **Phase 3:** Planned
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 4: Deploy
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 4: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  grep -E '^- \[(x| )\] Phase ' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-before.txt"
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -E '^- \[(x| )\] Phase ' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-after.txt"
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.txt" "$TEST_TEMP_DIR/roadmap-after.txt"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
+}
+
 @test "reconcile-state preserves terminal-summary display semantics" {
   cat > .vbw-planning/STATE.md <<'STATE'
 # State

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -582,6 +582,7 @@ EOF
 
   grep -q '^Phase: 3 of 3 (Deploy)$' .vbw-planning/STATE.md
   grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
+  grep -q '^- \[ \] Phase 3: Deploy$' .vbw-planning/ROADMAP.md
   grep -Eq '^\| 2 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
 }
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -31,6 +31,57 @@ EOF
 EOF
 }
 
+create_linked_archive_fixture() {
+  local checkbox="$1" uat_status="${2:-}"
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Service Utility Tests)
+Plans: 0/1
+Progress: 0%
+Status: active
+
+## Phase Status
+- **Phase 1:** Planned
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<EOF
+# Roadmap
+
+- [${checkbox}] [Phase 02: Service Utility Tests](#phase-02-service-utility-tests)
+
+## Phase 02: Service Utility Tests
+EOF
+
+  mkdir -p .vbw-planning/phases/02-service-utility-tests
+  echo "# plan" > .vbw-planning/phases/02-service-utility-tests/02-01-PLAN.md
+  cat > .vbw-planning/phases/02-service-utility-tests/02-01-SUMMARY.md <<'EOF'
+---
+status: complete
+---
+# Summary
+EOF
+
+  if [ -n "$uat_status" ]; then
+    cat > .vbw-planning/phases/02-service-utility-tests/02-UAT.md <<EOF
+---
+phase: 02
+status: ${uat_status}
+---
+# UAT
+EOF
+  fi
+}
+
 @test "summary update advances STATE/ROADMAP without execution-state file" {
   cd "$TEST_TEMP_DIR"
   create_state_and_roadmap "$TEST_TEMP_DIR/.vbw-planning" 3
@@ -55,6 +106,42 @@ SUMMARY
   grep -q '^Progress: 100%$' .vbw-planning/STATE.md
   grep -q '^- \[x\] Phase 3: Service Utility Tests$' .vbw-planning/ROADMAP.md
   grep -Eq '^\| 3 - Service Utility Tests \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+}
+
+@test "summary update checks linked ROADMAP entry and preserves anchor" {
+  cd "$TEST_TEMP_DIR"
+  create_linked_archive_fixture " "
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-service-utility-tests/02-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^- \[x\] \[Phase 02: Service Utility Tests\](#phase-02-service-utility-tests)$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
+@test "UAT update unchecks linked ROADMAP entry when current UAT has issues" {
+  cd "$TEST_TEMP_DIR"
+  create_linked_archive_fixture "x" "issues_found"
+
+  local uat_path input
+  uat_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-service-utility-tests/02-UAT.md"
+  input=$(jq -nc --arg p "$uat_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^- \[ \] \[Phase 02: Service Utility Tests\](#phase-02-service-utility-tests)$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
 }
 
 @test "summary update patches execution state in .plans[] schema" {

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -82,6 +82,59 @@ EOF
   fi
 }
 
+create_duplicate_linked_archive_fixture() {
+  local first_checkbox="$1" second_checkbox="${2:-$1}" uat_status="${3:-}"
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 1 of 1 (Service Utility Tests)
+Plans: 0/1
+Progress: 0%
+Status: active
+
+## Phase Status
+- **Phase 1:** Planned
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<EOF
+# Roadmap
+
+- [${first_checkbox}] [Phase 02: Service Utility Tests](#phase-02-service-utility-tests)
+- [${second_checkbox}] [Phase 02: Duplicate Service Utility Tests](#phase-02-duplicate-service-utility-tests)
+
+## Phase 02: Service Utility Tests
+## Phase 02: Duplicate Service Utility Tests
+EOF
+
+  mkdir -p .vbw-planning/phases/02-service-utility-tests
+  echo "# plan" > .vbw-planning/phases/02-service-utility-tests/02-01-PLAN.md
+  cat > .vbw-planning/phases/02-service-utility-tests/02-01-SUMMARY.md <<'EOF'
+---
+status: complete
+---
+# Summary
+EOF
+
+  if [ -n "$uat_status" ]; then
+    cat > .vbw-planning/phases/02-service-utility-tests/02-UAT.md <<EOF
+---
+phase: 02
+status: ${uat_status}
+---
+# UAT
+EOF
+  fi
+}
+
 @test "summary update advances STATE/ROADMAP without execution-state file" {
   cd "$TEST_TEMP_DIR"
   create_state_and_roadmap "$TEST_TEMP_DIR/.vbw-planning" 3
@@ -142,6 +195,50 @@ SUMMARY
   run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
   if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
   [ "$status" -eq 0 ]
+}
+
+@test "summary update leaves duplicate linked ROADMAP entries verifier-owned" {
+  cd "$TEST_TEMP_DIR"
+  create_duplicate_linked_archive_fixture " "
+
+  grep -E '^- \[[ xX]\] \[Phase 02:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-before.txt"
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-service-utility-tests/02-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -E '^- \[[ xX]\] \[Phase 02:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-after.txt"
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.txt" "$TEST_TEMP_DIR/roadmap-after.txt"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'duplicate ROADMAP checklist entry for phase 2'
+}
+
+@test "UAT update leaves duplicate linked ROADMAP entries checked" {
+  cd "$TEST_TEMP_DIR"
+  create_duplicate_linked_archive_fixture "x" "x" "issues_found"
+
+  grep -E '^- \[[ xX]\] \[Phase 02:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-before.txt"
+
+  local uat_path input
+  uat_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-service-utility-tests/02-UAT.md"
+  input=$(jq -nc --arg p "$uat_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -E '^- \[[ xX]\] \[Phase 02:' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-after.txt"
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.txt" "$TEST_TEMP_DIR/roadmap-after.txt"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'duplicate ROADMAP checklist entry for phase 2'
 }
 
 @test "summary update patches execution state in .plans[] schema" {

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -639,6 +639,94 @@ EOF
   echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
 }
 
+@test "summary update repairs resolvable ROADMAP despite stray extra entry" {
+  cd "$TEST_TEMP_DIR"
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/02-build .vbw-planning/phases/03-deploy
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+**Project:** Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+- [ ] Phase 4: Stray
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 3: Deploy
+### Phase 4: Stray
+EOF
+
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/02-build/02-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-build/02-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-deploy/03-01-PLAN.md
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-build/02-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
+  grep -q '^- \[ \] Phase 4: Stray$' .vbw-planning/ROADMAP.md
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'phase 4 referenced in ROADMAP.md but no matching phase directory'
+}
+
+@test "summary update preserves plain ROADMAP fallback without phase-state-utils" {
+  cd "$TEST_TEMP_DIR"
+
+  local helperless_scripts
+  helperless_scripts="$TEST_TEMP_DIR/helperless-roadmap-scripts"
+  mkdir -p "$helperless_scripts"
+  cp "$SCRIPTS_DIR/state-updater.sh" "$helperless_scripts/state-updater.sh"
+  cp "$SCRIPTS_DIR/summary-utils.sh" "$helperless_scripts/summary-utils.sh"
+  cp "$SCRIPTS_DIR/uat-utils.sh" "$helperless_scripts/uat-utils.sh"
+
+  mkdir -p .vbw-planning/phases/01-setup
+  cat > .vbw-planning/STATE.md <<'EOF'
+Phase: 1 of 1 (Setup)
+Plans: 0/1
+Progress: 0%
+Status: active
+EOF
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+- [ ] Phase 1: Setup
+| Phase | Progress | Status | Completed |
+|------|----------|--------|-----------|
+| 1 - Setup | 0/1 | pending | - |
+EOF
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'phase: 1' 'plan: 1' 'status: complete' '---' '# Summary' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/01-setup/01-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$helperless_scripts/state-updater.sh'"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"command not found"* ]]
+  grep -q '^- \[x\] Phase 1: Setup$' .vbw-planning/ROADMAP.md
+}
+
 @test "advance_phase skips SOURCE-UAT files via shared uat-utils" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -586,6 +586,59 @@ EOF
   grep -Eq '^\| 2 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
 }
 
+@test "summary update leaves unknown ROADMAP checklist scheme untouched" {
+  cd "$TEST_TEMP_DIR"
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+**Project:** Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 4: Deploy
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 4: Deploy
+EOF
+
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  grep -E '^- \[(x| )\] Phase ' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-before.txt"
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/03-build/03-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -E '^- \[(x| )\] Phase ' .vbw-planning/ROADMAP.md > "$TEST_TEMP_DIR/roadmap-after.txt"
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.txt" "$TEST_TEMP_DIR/roadmap-after.txt"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
+}
+
 @test "advance_phase skips SOURCE-UAT files via shared uat-utils" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2044,6 +2044,53 @@ ROADMAP
   [[ "$c2_detail" == *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
+@test "roadmap_vs_summaries describes missing ordinal checklist entry with actual dir" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 4 (Build)
+Plans: 0/1
+Progress: 0%
+Status: running
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 3: Test
+- [ ] Phase 4: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/05-test" "$root/phases/06-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  echo '# Plan' > "$root/phases/05-test/05-01-PLAN.md"
+  echo '# Plan' > "$root/phases/06-deploy/06-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"ordinal phase position 2"* ]]
+  [[ "$c2_detail" == *"03-build"* ]]
+  [[ "$c2_detail" == *"prefix 3"* ]]
+  [[ "$c2_detail" == *"no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" != *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
+}
+
 @test "roadmap_vs_summaries passes when roadmap and dirs fully aligned" {
   cd "$TEST_TEMP_DIR"
   scaffold_consistent_workspace

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1210,8 +1210,7 @@ EOF
 
   local c2_detail
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
-  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
-  [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
+  [[ "$c2_detail" == *"phase 4 referenced in ROADMAP.md but no matching phase directory"* ]]
 }
 
 @test "roadmap references phase with no matching dir fails in advisory mode too" {
@@ -1237,8 +1236,7 @@ EOF
 
   local c2_detail
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
-  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
-  [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
+  [[ "$c2_detail" == *"phase 4 referenced in ROADMAP.md but no matching phase directory"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -1980,8 +1978,7 @@ ROADMAP
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
   [ "$c2_pass" = "false" ]
-  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
-  [[ "$c2_detail" != *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
 @test "roadmap_vs_summaries passes when roadmap and dirs fully aligned" {
@@ -2061,9 +2058,11 @@ EOF
 
 - [x] Phase 1: Setup
 - [ ] Phase 2: Build
+- [ ] Phase 4: Deploy
 
 ### Phase 1: Setup
 ### Phase 2: Build
+### Phase 4: Deploy
 EOF
 
   mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
@@ -2085,6 +2084,29 @@ EOF
   [[ "$c2_detail" != *"phase 2 referenced in ROADMAP.md but no matching phase directory"* ]]
   [[ "$c2_detail" != *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]
   [[ "$c2_detail" != *"phase directory 4 exists on disk but no matching ROADMAP checklist entry"* ]]
+}
+
+@test "missing ROADMAP helper functions return structured missing_deps" {
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  local partial_scripts
+  partial_scripts="$TEST_TEMP_DIR/partial-verify-scripts"
+  mkdir -p "$partial_scripts/lib"
+  cp "$SCRIPTS_DIR/verify-state-consistency.sh" "$partial_scripts/verify-state-consistency.sh"
+  cp "$SCRIPTS_DIR/summary-utils.sh" "$partial_scripts/summary-utils.sh"
+  cp "$SCRIPTS_DIR/uat-utils.sh" "$partial_scripts/uat-utils.sh"
+  cp "$SCRIPTS_DIR/lib/vbw-config-root.sh" "$partial_scripts/lib/vbw-config-root.sh"
+  cat > "$partial_scripts/phase-state-utils.sh" <<'PHASEUTILS'
+list_canonical_phase_dirs() { :; }
+count_phase_plans() { echo "0"; }
+phase_dir_display_name() { echo "Stub"; }
+PHASEUTILS
+
+  run bash "$partial_scripts/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.failed_checks | index("missing_deps")' >/dev/null
+  echo "$output" | jq -r '.reason' | grep -q 'normalize_roadmap_phase_num'
 }
 
 # ============================================================

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1995,6 +1995,48 @@ ROADMAP
   [ "$c2_pass" = "true" ]
 }
 
+@test "roadmap_vs_summaries validates ordinal gapped ROADMAP by sorted phase position" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 3 of 3 (Deploy)
+Plans: 0/1
+Progress: 0%
+Status: ready
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [x] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 3: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/03-build/03-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+}
+
 # ============================================================
 # Bootstrap link-format ROADMAP tests
 # ============================================================

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1984,6 +1984,45 @@ ROADMAP
   [[ "$c2_detail" == *"phase 2"* ]]
 }
 
+@test "roadmap_vs_summaries handles final checklist entry without trailing newline" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 4 (Build)
+Plans: 0/1
+Progress: 0%
+Status: running
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  : > "$root/ROADMAP.md"
+  printf '%s\n' '# Roadmap' '- [x] Phase 1: Setup' '- [ ] Phase 2: Build' '- [ ] Phase 3: Test' >> "$root/ROADMAP.md"
+  printf '%s' '- [ ] Phase 4: Deploy' >> "$root/ROADMAP.md"
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/02-build" "$root/phases/03-test" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/02-build/02-01-PLAN.md"
+  echo '# Plan' > "$root/phases/03-test/03-01-PLAN.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass c4_pass
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c4_pass=$(echo "$output" | jq -r '.checks.state_vs_roadmap.pass')
+  [ "$c2_pass" = "true" ]
+  [ "$c4_pass" = "true" ]
+}
+
 @test "roadmap_vs_summaries detects phase dir missing from roadmap" {
   cd "$TEST_TEMP_DIR"
   scaffold_consistent_workspace
@@ -2141,6 +2180,46 @@ EOF
 ### Phase 02: Duplicate Build
 ### Phase 04: Deploy
 EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/03-build/03-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" == *"duplicate ROADMAP checklist entry for phase 2"* ]]
+}
+
+@test "roadmap_vs_summaries reports final duplicate without trailing newline when scheme is unknown" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  : > "$root/ROADMAP.md"
+  printf '%s\n' '# Roadmap' '- [x] [Phase 01: Setup](#phase-01-setup)' '- [ ] [Phase 02: Build](#phase-02-build)' '- [ ] [Phase 04: Deploy](#phase-04-deploy)' >> "$root/ROADMAP.md"
+  printf '%s' '- [ ] [Phase 02: Duplicate Build](#phase-02-duplicate-build)' >> "$root/ROADMAP.md"
 
   mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
   echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2110,6 +2110,56 @@ EOF
   [[ "$c2_detail" != *"phase directory 4 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
+@test "roadmap_vs_summaries reports duplicates when numbering scheme is unknown" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] [Phase 01: Setup](#phase-01-setup)
+- [ ] [Phase 02: Build](#phase-02-build)
+- [ ] [Phase 02: Duplicate Build](#phase-02-duplicate-build)
+- [ ] [Phase 04: Deploy](#phase-04-deploy)
+
+### Phase 01: Setup
+### Phase 02: Build
+### Phase 02: Duplicate Build
+### Phase 04: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/03-build/03-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" == *"duplicate ROADMAP checklist entry for phase 2"* ]]
+}
+
 @test "missing ROADMAP helper functions return structured missing_deps" {
   cd "$TEST_TEMP_DIR"
   scaffold_consistent_workspace

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1510,6 +1510,30 @@ EOF
   [ "$verdict" = "pass" ] || [ "$verdict" = "fail" ]
 }
 
+@test "roadmap_vs_summaries reports missing entries for headings-only ROADMAP" {
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/ROADMAP.md" <<'EOF'
+# Roadmap
+### Phase 1: Setup
+### Phase 2: Backend API
+### Phase 3: Frontend
+EOF
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  [ "$status" -eq 2 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"phase directory 1 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" != *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+}
+
 @test "state_vs_roadmap handles checklist-only ROADMAP" {
   cd "$TEST_TEMP_DIR"
   scaffold_consistent_workspace

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1210,7 +1210,8 @@ EOF
 
   local c2_detail
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
-  [[ "$c2_detail" == *"no matching phase directory"* ]]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
 }
 
 @test "roadmap references phase with no matching dir fails in advisory mode too" {
@@ -1236,7 +1237,8 @@ EOF
 
   local c2_detail
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
-  [[ "$c2_detail" == *"no matching phase directory"* ]]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -1978,9 +1980,8 @@ ROADMAP
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
   [ "$c2_pass" = "false" ]
-  [[ "$c2_detail" == *"phase"* ]]
-  [[ "$c2_detail" == *"2"* ]]
-  [[ "$c2_detail" == *"no matching ROADMAP"* ]]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" != *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
 @test "roadmap_vs_summaries passes when roadmap and dirs fully aligned" {
@@ -2035,6 +2036,55 @@ EOF
   run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode archive
   if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
   [ "$status" -eq 0 ]
+}
+
+@test "roadmap_vs_summaries reports unknown scheme without guessed phase details" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 1/1
+Progress: 100%
+Status: active
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+
+### Phase 1: Setup
+### Phase 2: Build
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/03-build/03-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
+  [[ "$c2_detail" != *"phase 2 referenced in ROADMAP.md but no matching phase directory"* ]]
+  [[ "$c2_detail" != *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" != *"phase directory 4 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
 # ============================================================


### PR DESCRIPTION
## Linked Issue

Fixes #571

## What

Repairs deterministic ROADMAP checklist state for linked/plain phase entries while preserving the repository's ROADMAP numbering invariant. `scripts/state-updater.sh` now rewrites only the resolved checklist entry for valid prefix or ordinal ROADMAP schemes, `scripts/reconcile-state-md.sh` projects computed completion/UAT state back into existing checklist rows, and duplicate/mixed/unresolvable ROADMAPs remain verifier-owned failures instead of being silently rewritten.

## Why

The root cause was a split contract: `verify-state-consistency.sh` could parse linked ROADMAP checklist entries such as `- [ ] [Phase 02: Name](#anchor)`, but updater/reconcile paths either handled only plain entries or did not repair ROADMAP checkboxes at all. The durable fix centralizes ROADMAP checklist parsing and numbering decisions in shared bash helpers so updater, reconcile, and verifier agree on prefix-numbered, ordinal-gapped, linked, plain, zero-padded, duplicate, and unresolvable ROADMAP shapes.

## How

- `scripts/phase-state-utils.sh`: adds shared ROADMAP checklist parsing/numbering helpers, deterministic prefix-vs-ordinal scheme selection, phase-dir lookup helpers, and duplicate checklist phase-number detection.
- `scripts/state-updater.sh`: uses the shared numbering scheme to update only the checklist row matching the resolved phase number; preserves display text, zero padding, links, and anchors; keeps helperless fallback behavior in parity; and no-ops on duplicate checklist phase numbers.
- `scripts/reconcile-state-md.sh`: projects computed phase completion/UAT state into existing ROADMAP checklist entries using the resolved scheme, with duplicate entries left untouched for verifier reporting.
- `scripts/verify-state-consistency.sh`: validates ROADMAP checklist entries through the shared parser/scheme helpers and reports actionable duplicate, missing, extra, ordinal, and unknown-scheme diagnostics.
- `testing/verify-roadmap-checklist-parser-contract.sh`: enforces shared parser usage and duplicate-guard structure, and fixes misleading missing-function-body failure text.
- `tests/state-updater.bats`, `tests/state-reconcile.bats`, and `tests/verify-state-consistency.bats`: add linked/plain prefix coverage, ordinal-gapped coverage, UAT uncheck coverage, duplicate no-mutation coverage, and verifier diagnostic regressions.

## Acceptance Criteria Verification

1. `scripts/state-updater.sh` checks an existing linked ROADMAP checklist entry when all plans are complete and no current unresolved UAT issues exist — covered by `tests/state-updater.bats` test `summary update checks linked ROADMAP entry and preserves anchor`.
2. `scripts/state-updater.sh` unchecks an existing linked ROADMAP checklist entry when current UAT status is `issues_found` — covered by `tests/state-updater.bats` test `UAT update unchecks linked ROADMAP entry when current UAT has issues`.
3. ROADMAP updates preserve display text, zero padding, links, and anchors — covered by exact-line assertions for linked `Phase 02` entries in `tests/state-updater.bats` and `tests/state-reconcile.bats`.
4. ROADMAP numbering is resolved through one deterministic scheme per ROADMAP — implemented in `roadmap_numbering_scheme()` and covered by prefix, ordinal-gapped, stray-extra, headings-only, duplicate, and unknown-scheme verifier tests.
5. `scripts/state-updater.sh` mutates only the checklist entry for the resolved scheme when ordinal and prefix numbers diverge — covered by `tests/state-updater.bats` test `advance_phase uses sorted phase position for gapped directories`.
6. `scripts/reconcile-state-md.sh` repairs pre-existing linked/plain ROADMAP checklist drift using the resolved scheme — covered by linked, plain, and ordinal reconcile tests.
7. Reconciliation updates only existing ROADMAP checklist entries; missing, duplicate, mixed, or unresolvable entries remain verifier failures — covered by no-insertion implementation, duplicate no-projection tests, unknown-scheme no-op tests, and verifier duplicate/missing diagnostics.
8. `scripts/verify-state-consistency.sh --mode archive` succeeds for complete summaries with linked/plain ROADMAP entries after updater/reconcile runs — covered by archive verifier assertions in the updater and reconcile BATS files.
9. Regression coverage exists in `tests/state-updater.bats`, `tests/state-reconcile.bats`, and `tests/verify-state-consistency.bats` for linked prefix, plain prefix, ordinal-gapped, and UAT `issues_found` uncheck behavior — all three files were extended in this PR.
10. `bash testing/run-all.sh` passes — verified locally and in GitHub Actions on `8fc6af695eeb60d588a2bff6175bb6e3b16859f2`.

## Testing

- [x] `bash testing/verify-roadmap-checklist-parser-contract.sh`
- [x] `bats tests/state-updater.bats`
- [x] `bats tests/state-reconcile.bats`
- [x] `bats tests/verify-state-consistency.bats`
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh`

Final local full suite on macOS:

- Lint checks: `1/1 passed`
- Contract checks: `51/51 passed`
- BATS: `3308 passed, 0 failed`

GitHub Actions on final head `8fc6af695eeb60d588a2bff6175bb6e3b16859f2`:

- `CI_GREEN` — all 18 checks passed.

## QA Summary

- Primary QA: 1 full-contract round, clean. Evidence commit: `cd835544`.
- Cross-model QA: skipped because this session is GPT-class; configured GPT cross-model review would not provide model-family diversity.
- Copilot PR review: 10 fresh reviews total on pushed PR heads.
  - Rounds 1-9 produced 24 legitimate findings; all were fixed.
  - Round 10 was clean: Copilot reviewed 9/9 changed files and generated no new comments.
  - False positives: none.
- Copilot remediation commits:
  - Round 1: `e0dabbfd`
  - Round 2: `587b3184`
  - Round 3: `5ef1d839`
  - Round 4: `4bdd528a`
  - Round 5: `9e0c561`
  - Round 6: `fb88ba1`
  - Round 7: `ce2dc83`
  - Round 8: `30a8869`
  - Round 9: `8fc6af6`
- Final Copilot review state: clean, zero unresolved Copilot-authored threads.
- Post-review main sync: `origin/main` had `0` new commits; no merge or conflict-resolution QA re-run was needed.
