### PR TITLE
fix(hooks): scope agent-spawn-guard named-agent block to active VBW workflows only

### DIFF
--- a/scripts/agent-spawn-guard.sh
+++ b/scripts/agent-spawn-guard.sh
@@ -127,7 +127,7 @@ if is_teammate_spawn_tool; then
     echo "Blocked: teammate spawn requested a VBW worktree path as a spawn working directory. Omit cwd/working_dir/workingDirectory/workdir fields; VBW worktree targeting is task prompt/state metadata, not a spawn cwd." >&2
     exit 2
   fi
-  if [ -n "$AGENT_NAME" ] && [ "$TRUE_LIVE_TEAM_MODE" != "true" ]; then
+  if [ -n "$AGENT_NAME" ] && [ "$TRUE_LIVE_TEAM_MODE" != "true" ] && { [ "$MARKER_LIVE" = "true" ] || [ "$EXEC_ACTIVE" = "true" ]; }; then
     echo "Blocked: named non-team teammate spawns are unsupported. Omit name for sequential non-team calls; name is only valid with team_name in true team mode." >&2
     exit 2
   fi

--- a/testing/verify-agent-spawn-guard.sh
+++ b/testing/verify-agent-spawn-guard.sh
@@ -357,53 +357,53 @@ test_strip_preserves_non_stripped_fields() {
 }
 test_strip_preserves_non_stripped_fields
 
-test_named_non_team_with_isolation_blocks() {
+test_named_non_team_with_isolation_strips_when_no_active_workflow() {
   setup_project
 
   local tool output rc
   for tool in Agent TaskCreate; do
     output=$(run_guard "$PROJECT" "" false "dev-01" "$PROJECT" "$tool" "" "worktree" 2>&1) && rc=$? || rc=$?
-    if [ "$rc" -eq 2 ] && echo "$output" | grep -q 'named non-team teammate spawns are unsupported'; then
-      pass "Named non-team + isolation: ${tool} blocked (named check fires before strip)"
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q 'VBW stripped isolation:worktree'; then
+      pass "Named non-team + isolation: ${tool} stripped (no active workflow)"
     else
-      fail "Named non-team + isolation should block for ${tool} (rc=$rc, output=$output)"
+      fail "Named non-team + isolation should strip for ${tool} when no active workflow (rc=$rc, output=$output)"
     fi
   done
   cleanup
 }
-test_named_non_team_with_isolation_blocks
+test_named_non_team_with_isolation_strips_when_no_active_workflow
 
-test_named_non_team_with_sidechain_cwd_blocks() {
+test_named_non_team_with_sidechain_cwd_strips_when_no_active_workflow() {
   setup_project
 
   local tool output rc
   for tool in Agent TaskCreate; do
     output=$(run_guard "$PROJECT" "" false "dev-01" "$PROJECT" "$tool" "" "" "$PROJECT/.claude/worktrees/agent-123" "cwd" 2>&1) && rc=$? || rc=$?
-    if [ "$rc" -eq 2 ] && echo "$output" | grep -q 'named non-team teammate spawns are unsupported'; then
-      pass "Named non-team + sidechain cwd: ${tool} blocked (named check fires before strip)"
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q 'VBW stripped sidechain cwd fields'; then
+      pass "Named non-team + sidechain cwd: ${tool} stripped (no active workflow)"
     else
-      fail "Named non-team + sidechain cwd should block for ${tool} (rc=$rc, output=$output)"
+      fail "Named non-team + sidechain cwd should strip for ${tool} when no active workflow (rc=$rc, output=$output)"
     fi
   done
   cleanup
 }
-test_named_non_team_with_sidechain_cwd_blocks
+test_named_non_team_with_sidechain_cwd_strips_when_no_active_workflow
 
-test_no_marker_blocks_named_non_team_spawns() {
+test_no_marker_allows_named_non_team_spawns() {
   setup_project
 
   local tool output rc
   for tool in Agent TaskCreate; do
     output=$(run_guard "$PROJECT" "" false "dev-01" "$PROJECT" "$tool" 2>&1) && rc=$? || rc=$?
-    if [ "$rc" -eq 2 ] && echo "$output" | grep -q 'named non-team teammate spawns are unsupported'; then
-      pass "No marker: named non-team ${tool} blocked"
+    if [ "$rc" -eq 0 ]; then
+      pass "No marker: named non-team ${tool} allowed (no active workflow)"
     else
-      fail "No-marker named non-team ${tool} should block (rc=$rc, output=$output)"
+      fail "No-marker named non-team ${tool} should allow when no active workflow (rc=$rc, output=$output)"
     fi
   done
   cleanup
 }
-test_no_marker_blocks_named_non_team_spawns
+test_no_marker_allows_named_non_team_spawns
 
 test_no_marker_allows_non_agent_worktree_cwd_when_config_off() {
   setup_project
@@ -752,7 +752,7 @@ test_non_team_mode_blocks_named_non_team_spawns() {
 }
 test_non_team_mode_blocks_named_non_team_spawns
 
-test_stale_team_marker_blocks_named_non_team_spawns() {
+test_stale_team_marker_allows_named_spawns() {
   setup_project
   write_marker execute team "vbw-phase-01" "corr-123"
 
@@ -761,16 +761,16 @@ test_stale_team_marker_blocks_named_non_team_spawns() {
     for team_name in "" "vbw-phase-01"; do
       output=$(run_guard "$PROJECT" "$team_name" false "dev-01" "$PROJECT" "$tool" 2>&1) && rc=$? || rc=$?
       label="${team_name:-without-team-name}"
-      if [ "$rc" -eq 2 ] && echo "$output" | grep -q 'named non-team teammate spawns are unsupported'; then
-        pass "Stale team marker blocks named ${tool} ${label}"
+      if [ "$rc" -eq 0 ]; then
+        pass "Stale team marker allows named ${tool} ${label} (no active workflow)"
       else
-        fail "Stale team marker should block named ${tool} ${label} (rc=$rc, output=$output)"
+        fail "Stale team marker should allow named ${tool} ${label} when no active workflow (rc=$rc, output=$output)"
       fi
     done
   done
   cleanup
 }
-test_stale_team_marker_blocks_named_non_team_spawns
+test_stale_team_marker_allows_named_spawns
 
 test_fix_marker_is_ignored() {
   setup_project


### PR DESCRIPTION
Fixes #589

## What

Narrows the `agent-spawn-guard.sh` named-agent block to only fire when VBW is actively executing a workflow. Previously it blocked ALL named agent spawns in any project with `.vbw-planning/phases/`, even during regular Claude Code usage.

**Files modified:**
- `scripts/agent-spawn-guard.sh` — added `MARKER_LIVE`/`EXEC_ACTIVE` gate to the named-agent block condition (line 131)
- `testing/verify-agent-spawn-guard.sh` — updated 4 tests from expecting block (exit 2) to expecting allow (exit 0) for no-active-workflow scenarios

## Why

Root cause: `delegated-workflow.sh status-json` always returns non-empty JSON (even `{"live":false,"reason":"missing_marker"}`), so the early-exit on line 59 never triggered. The named-agent block on line 131 then applied unconditionally to any project with `.vbw-planning/phases/` — regardless of whether VBW was actively running.

The fix gates the block on workflow activity (`MARKER_LIVE = "true"` OR `EXEC_ACTIVE = "true"`) because the guard's purpose is to protect active VBW execute workflows from faux-team launches, not to interfere with regular Claude Code usage.

## How

- `scripts/agent-spawn-guard.sh`: Changed condition from `if [ -n \"$AGENT_NAME\" ] && [ \"$TRUE_LIVE_TEAM_MODE\" != \"true\" ]` to also require `{ [ \"$MARKER_LIVE\" = \"true\" ] || [ \"$EXEC_ACTIVE\" = \"true\" ]; }` — only blocks when VBW is actively managing an execute workflow.
- `testing/verify-agent-spawn-guard.sh`: 4 tests renamed and updated to reflect that without an active VBW workflow, named agents pass through (isolation/sidechain still gets stripped; plain named spawns simply allowed).

## Acceptance criteria verification

1. **Exits 0 when no VBW workflow active** — satisfied by the new gate condition; covered by `test_no_marker_allows_named_non_team_spawns` and `test_stale_team_marker_allows_named_spawns`
2. **Still exits 2 when VBW IS active** — satisfied; covered by `test_non_team_mode_blocks_named_non_team_spawns` (writes execution state + marker)
3. **debug.md Path A** — investigation confirmed no actual contradiction; no change needed
4. **`bash testing/run-all.sh` passes** — 3430 BATS tests, 51 contract checks, lint clean
5. **Tests updated** — 4 tests updated to reflect new gate behavior

## Testing

- [x] `bash testing/run-all.sh` — all pass (3430 BATS, 51 contracts, lint clean)
- [x] `bash testing/verify-agent-spawn-guard.sh` — 101 PASS, 0 FAIL
- [x] ShellCheck clean on `scripts/agent-spawn-guard.sh`

## QA summary

- Primary QA: 1 round (Claude Opus 4), zero findings
- Cross-model QA: 1 round (GPT-5.4), zero findings
- Total findings: 0 (no false positives)