### PR TITLE
fix(verify): handle UAT rounds 08 and 09

### DIFF
--- a/scripts/compile-verify-context.sh
+++ b/scripts/compile-verify-context.sh
@@ -308,7 +308,7 @@ if [ "$REMEDIATION_ONLY" = true ]; then
   fi
 
   if [ -n "$LATEST_ROUND" ]; then
-    rr=$(printf '%02d' "$LATEST_ROUND")
+    rr=$(printf '%02d' "$((10#$LATEST_ROUND))")
     ALL_PLAN_FILES=$(find "$REMED_DIR/round-$rr" -maxdepth 1 \( -name "R${rr}-PLAN.md" -o -name "R${rr}-*-PLAN.md" \) 2>/dev/null | sort)
     SCOPE_HEADER="verify_scope=remediation round=$rr"
     # UAT remediation rounds write round-scoped UAT artifacts; QA remediation

--- a/tests/compile-verify-context-for-uat.bats
+++ b/tests/compile-verify-context-for-uat.bats
@@ -101,6 +101,43 @@ EOF
   [[ "$output" != *"Original feature"* ]]
 }
 
+@test "compile-verify-context-for-uat: active UAT round 09 keeps remediation scope without octal error" {
+  cat > "$PHASE_DIR/03-01-PLAN.md" <<'EOF'
+---
+plan: 01
+title: Original feature
+must_haves:
+  - Feature works
+---
+EOF
+  mkdir -p "$PHASE_DIR/remediation/uat/round-09"
+  printf 'stage=verify\nround=09\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-09/R09-PLAN.md" <<'EOF'
+---
+round: 09
+title: UAT remediation round nine
+must_haves:
+  - Ninth UAT issue fixed
+---
+EOF
+  cat > "$PHASE_DIR/remediation/uat/round-09/R09-SUMMARY.md" <<'EOF'
+---
+status: complete
+---
+## What Was Built
+- Fixed the ninth UAT issue
+EOF
+
+  run bash "$SCRIPT" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"invalid number"* ]]
+  [[ "$output" == *"verify_scope=remediation round=09"* ]]
+  [[ "$output" == *"uat_path=remediation/uat/round-09/R09-UAT.md"* ]]
+  [[ "$output" == *"=== PLAN R09: UAT remediation round nine ==="* ]]
+  [[ "$output" != *"Original feature"* ]]
+}
+
 @test "compile-verify-context-for-uat: legacy UAT remediation marker uses remediation-only scope" {
   cat > "$PHASE_DIR/03-01-PLAN.md" <<'EOF'
 ---

--- a/tests/compile-verify-context.bats
+++ b/tests/compile-verify-context.bats
@@ -671,6 +671,46 @@ EOF
   [[ "$output" == *"uat_path=remediation/uat/round-01/R01-UAT.md"* ]]
 }
 
+@test "compile-verify-context: active UAT round 08 keeps remediation scope without octal error" {
+  cat > "$PHASE_DIR/03-01-PLAN.md" <<'EOF'
+---
+plan: 01
+title: Phase-root plan
+must_haves:
+  - Original feature remains out of remediation scope
+---
+EOF
+
+  mkdir -p "$PHASE_DIR/remediation/uat/round-08"
+  printf 'stage=verify\nround=08\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-08/R08-PLAN.md" <<'EOF'
+---
+round: 08
+title: Round 8 UAT remediation
+must_haves:
+  - Round-eight UAT issue fixed
+---
+EOF
+  cat > "$PHASE_DIR/remediation/uat/round-08/R08-SUMMARY.md" <<'EOF'
+---
+status: complete
+---
+## What Was Built
+- Fixed the round-eight UAT issue
+EOF
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/compile-verify-context.sh" --remediation-only --remediation-kind uat "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"invalid number"* ]]
+  [[ "$output" == *"verify_scope=remediation round=08"* ]]
+  [[ "$output" == *"uat_path=remediation/uat/round-08/R08-UAT.md"* ]]
+  [[ "$output" == *"=== PLAN R08: Round 8 UAT remediation ==="* ]]
+  [[ "$output" != *"Phase-root plan"* ]]
+  [[ "$output" == *"verify_plan_count=1"* ]]
+}
+
 @test "compile-verify-context: legacy remediation layout emits correct uat_path" {
   # Legacy layout: remediation/round-* (no uat/ sublevel)
   mkdir -p "$PHASE_DIR/remediation/round-01"


### PR DESCRIPTION
## Linked Issue

Fixes #597

## What

This fixes the UAT remediation round `08`/`09` Bash octal parsing failure in `scripts/compile-verify-context.sh`. The production change decimal-coerces the already-zero-padded `LATEST_ROUND` value before formatting it back to `RR`, preserving round-scoped verification context instead of falling back or erroring. Regression coverage was added in `tests/compile-verify-context.bats` for direct round `08` compilation and in `tests/compile-verify-context-for-uat.bats` for the wrapper path on round `09`.

## Why

The root cause was an unsafe `printf '%02d' "$LATEST_ROUND"` call in the final remediation scope setup. Bash treats zero-padded `08`/`09` as octal numeric literals, which errors because digits `8` and `9` are invalid octal digits. Reusing the existing `10#` decimal-coercion idiom is the durable fix because it preserves the script’s current normalized output contract while making numeric parsing explicit.

## How

- `scripts/compile-verify-context.sh`: changes the final `LATEST_ROUND` to `rr` conversion to `printf '%02d' "$((10#$LATEST_ROUND))"`, matching the safe pattern already used elsewhere in the file.
- `tests/compile-verify-context.bats`: adds an active UAT round `08` direct regression that asserts no invalid-number error, `verify_scope=remediation round=08`, round-scoped `uat_path`, only the R08 plan, and `verify_plan_count=1`.
- `tests/compile-verify-context-for-uat.bats`: adds an active UAT round `09` wrapper regression that asserts no invalid-number error, `verify_scope=remediation round=09`, round-scoped `uat_path`, and exclusion of the phase-root plan.

## Acceptance criteria verification

Issue #597 does not define a separate numbered acceptance-criteria section, so this maps the stated issue contract into verifiable checks:

1. Rounds `08` and `09` do not emit `printf: 08/09: invalid number`.
   - Satisfied by the decimal coercion in `scripts/compile-verify-context.sh` and covered by both new BATS regressions.
2. Active UAT remediation re-verification remains round-scoped instead of degrading to full scope.
   - Covered by assertions for `verify_scope=remediation round=08` and `verify_scope=remediation round=09`.
3. UAT output uses the round-scoped artifact path instead of the phase-root UAT path.
   - Covered by assertions for `uat_path=remediation/uat/round-08/R08-UAT.md` and `uat_path=remediation/uat/round-09/R09-UAT.md`.
4. The public wrapper path used by `/vbw:vibe` and `/vbw:verify` is covered.
   - Covered by the new `compile-verify-context-for-uat.sh` regression for round `09`.
5. Scope remains limited to the numeric parsing bug and focused tests.
   - Diff is limited to one script line and two BATS files; no docs, command markdown, version, marketplace, or broader UAT behavior changes.

## Testing

- [x] `bats tests/compile-verify-context.bats tests/compile-verify-context-for-uat.bats` — `91 tests, 0 failures`
- [x] `bash testing/run-lint.sh` — passed with no reported errors
- [x] `bash testing/run-all.sh` — `Lint checks: 1/1 passed`, `Contract checks: 51/51 passed`, `BATS: 3491 passed, 0 failed`
- [x] Pre-PR main sync: `origin/main` already up to date, then `bash testing/run-all.sh` passed again with the same totals
- [x] Pre-ready sync: `origin/main` already up to date, then `bash testing/run-all.sh` passed again with the same totals
- [x] CI: `CI_GREEN — all 18 checks passed`
- [x] Post-review main sync: `NEW_COMMITS=0`

## QA summary

- Primary QA: 1 round with `qa-investigator`; 0 findings.
- Cross-model QA: skipped because the current session is not Opus-class, so the workflow’s different-family GPT-5.4 validation gate is not applicable.
- Copilot PR review: 1 review round; Copilot returned `COMMENTED` on head `dcb503969d2c2022bc7dce64b511ff281462adb3` with 0 unresolved Copilot threads and no fixes required.
- False positives: none.
- Findings fixed after QA/Copilot: none; primary QA and Copilot review were clean.
