### PR TITLE
docs(contributing): clarify PR automation gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Summary of the approach. Mention affected commands, agents, hooks, or scripts.
 - [ ] Tested affected commands against a real project (not the VBW repo)
 - [ ] No errors on plugin load
 - [ ] Existing commands still work
-- [ ] Ran QA review (2–4 separate AI sessions acting as devil's advocate on the diff)
+- [ ] Ran QA review (at least 3 separate QA rounds acting as devil's advocate on the diff)
 
 ## QA Review Evidence
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Linked Issue
 
 <!-- REQUIRED: Every PR must reference a tracking issue. CI will fail without one. -->
-<!-- Accepted: Fixes/Closes/Resolves #N, full GitHub issue URL, bare #N, or sidebar link -->
+<!-- Accepted: Fixes/Closes/Resolves #N, full GitHub issue URL, bare #N, or sidebar link. Use an issue number, not a PR number. -->
 
 Fixes #
 
@@ -27,13 +27,15 @@ Summary of the approach. Mention affected commands, agents, hooks, or scripts.
 
 ## QA Review Evidence
 
-Paste each QA round's report as a separate comment on this PR. Each round should have a corresponding fix commit (e.g., `fix(scope): address QA round 1`). Reviewers will verify the commit history matches the reported rounds.
+Paste each QA round's report as a separate comment on this PR. QA-relevant changes require 3 QA evidence commits whose first line matches `fix(scope): address QA round N`. Clean rounds still need an evidence commit; use an empty commit when there are no fixes to make. Reviewers will verify the commit history matches the reported rounds.
 
 QA must be run on a top-tier model: **Claude Opus 4.6**, **GPT-5.3 Codex high/xhigh**, or **Gemini 3.1 Pro**.
 
 - **Rounds completed:** (number)
 - **Model used:** (e.g., Claude Opus 4.6)
 - **Fix commits:** (list commit SHAs or titles)
+- [ ] QA-relevant changes have 3 QA evidence commits using `fix(scope): address QA round N`
+- [ ] Clean rounds still have an evidence commit
 
 ## Notes
 

--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -6,8 +6,9 @@ name: QA Review
 on:
   pull_request:
 
-# Paths that contain plugin logic — QA review is only required for PRs touching these.
-# Docs-only or config-only changes skip the QA round commit requirement automatically.
+# Paths that contain plugin logic or automation — QA review is only required for PRs touching these.
+# Docs-only or repo-metadata-only changes skip the QA round commit requirement automatically;
+# .github/workflows/ and config/ are QA-relevant.
 # Maintainer-authored PRs by @dpearson2699 also skip this evidence gate.
 env:
   QA_PATHS: .github/workflows/ agents/ commands/ config/ hooks/ references/ scripts/ templates/ testing/ tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,20 @@ Less good candidates:
 
 ## Pull Request Process
 
+### What PR automation enforces
+
+Ordinary contributor PRs are checked by several separate workflows. If one fails, fix the named status check rather than guessing at the aggregate result:
+
+- `Linked Issue Check` — every ordinary contributor PR must link an actual issue, not just another PR. PR-only references are ignored for traceability.
+- `Lint` — runs `bash testing/run-lint.sh`.
+- `Contract Tests` — discovers contract checks through `testing/list-contract-tests.sh`.
+- `Bats Tests (shard 0)` through `Bats Tests (shard 7)` — run shardable BATS files through the shared shard helper.
+- `Bats Tests (serial)` — runs BATS files that must not be sharded.
+- aggregate `Test` — fails if lint, contract tests, shardable BATS, or serial BATS fail.
+- `QA Review Evidence` — applies when the PR touches QA-relevant paths.
+
+Docs-only and repo-metadata-only PRs skip QA evidence. `.github/workflows/` and `config/` changes are QA-relevant because they affect the automation or plugin behavior that contributors rely on.
+
 1. **Every PR must link a tracking issue.** Open an issue first (bug report or feature request), then reference it in the PR body. CI will fail if no linked issue is found. Accepted formats:
    - Closing keywords: `Fixes #N`, `Closes #N`, `Resolves #N`
    - Full GitHub issue URLs: `https://github.com/owner/repo/issues/N`
@@ -196,9 +210,9 @@ Less good candidates:
 2. Describe what changed and why. Include before/after if relevant.
 3. Ensure `claude-vbw` or `claude --plugin-dir "<path-to-vbw-clone>"` loads without errors.
 4. Test your changes against at least one real project (not the VBW repo itself).
-5. **Run QA review before marking ready.** Repeat this cycle at least 3 times (or until the latest report contains no confirmed critical/major issues):
+5. **Run QA review before marking ready.** QA-relevant contributor PRs need at least 3 QA evidence commits before the gate passes. The first line of each evidence commit must match `fix(scope): address QA round N`, where `N` is the round number. Clean QA rounds still need an empty evidence commit in that exact format so reviewers and automation can count the round.
 
-   > **Docs-only or trivial PRs:** The QA round requirement only applies when the PR touches plugin logic paths (`agents/`, `commands/`, `config/`, `hooks/`, `references/`, `scripts/`, `templates/`, `testing/`, `tests/`). PRs that only change docs, CI config, or repo metadata skip the check automatically.
+   > **QA-relevant paths:** The QA evidence gate applies when the PR touches plugin logic or automation paths (`.github/workflows/`, `agents/`, `commands/`, `config/`, `hooks/`, `references/`, `scripts/`, `templates/`, `testing/`, `tests/`). Docs-only and repo-metadata-only PRs skip QA evidence.
 
    **Step A — Run the QA prompt.** Open a **new** Claude Code (or other AI) session using a top-tier model — **Claude Opus 4.6**, **GPT-5.3 Codex high/xhigh**, or **Gemini 3.1 Pro**. Smaller models (Haiku, Sonnet, etc.) don't produce thorough enough reviews. Paste the prompt below (fill in the placeholders):
 
@@ -223,7 +237,7 @@ Less good candidates:
    - Confirmed vs hypothetical
    ````
 
-   **Step B — Fix the findings.** Copy the QA report and paste it into your original working session (or a new session on the same branch). Tell it to fix the issues found. Each QA round's fixes must be a **separate commit** — do not amend previous commits. Use the format `fix(scope): address QA round N`.
+   **Step B — Fix the findings.** Copy the QA report and paste it into your original working session (or a new session on the same branch). Tell it to fix the issues found. Each QA round's fixes must be a **separate commit** — do not amend previous commits. Use the format `fix(scope): address QA round N`. If the round is clean, create an empty commit with that same format.
 
    **Step C — Repeat.** Go back to Step A with a fresh session. The new QA round will see the fix commits from Step B and look for anything still missed. Continue until a round comes back clean or only has hypothetical/minor findings.
 

--- a/testing/verify-github-fix-workflow-contract.sh
+++ b/testing/verify-github-fix-workflow-contract.sh
@@ -270,6 +270,18 @@ test_pr_template_documents_qa_evidence_commit_gate() {
 }
 test_pr_template_documents_qa_evidence_commit_gate
 
+test_public_docs_reject_lower_minimum_qa_guidance() {
+  local stale_guidance
+  stale_guidance=$(grep -nEi '2[–-]4|2 to 4|two to four|at least 2[[:space:]]+QA|minimum 2[[:space:]]+QA|2[[:space:]]+QA[[:space:]]+(review|round|evidence)' \
+    "$CONTRIBUTING_DOC" "$PR_TEMPLATE" || true)
+  if [ -z "$stale_guidance" ]; then
+    pass "public docs do not contain stale lower-minimum QA guidance"
+  else
+    fail "public docs should not contain stale lower-minimum QA guidance: $stale_guidance"
+  fi
+}
+test_public_docs_reject_lower_minimum_qa_guidance
+
 test_wait_github_fails_fast_on_gh_errors() {
   setup_tmpdir
   cat > "$TMPDIR_BASE/gh" <<'EOF'

--- a/testing/verify-github-fix-workflow-contract.sh
+++ b/testing/verify-github-fix-workflow-contract.sh
@@ -195,23 +195,19 @@ test_qa_review_workflow_has_explicit_maintainer_skip_notice() {
 }
 test_qa_review_workflow_has_explicit_maintainer_skip_notice
 
-test_contributing_docs_do_not_advertise_maintainer_qa_exception() {
-  if ! grep -q '@dpearson2699' "$CONTRIBUTING_DOC"; then
-    pass "CONTRIBUTING.md does not advertise the maintainer QA exception"
+test_public_docs_do_not_advertise_private_author_qa_exception() {
+  local private_actor_terms exception_terms advertised_exceptions
+  private_actor_terms='(maintainer|author|owner|member|collaborator|admin|user|login|actor|dpearson2699|@[[:alnum:]_-]+)'
+  exception_terms='(skip|skips|skipping|exempt|exempted|bypass|bypasses|exception|not required|do not require|without QA evidence)'
+  advertised_exceptions=$(grep -nEi "(${private_actor_terms}.{0,80}${exception_terms}|${exception_terms}.{0,80}${private_actor_terms})" \
+    "$CONTRIBUTING_DOC" "$PR_TEMPLATE" || true)
+  if [ -z "$advertised_exceptions" ]; then
+    pass "public docs do not advertise private author-based QA exceptions"
   else
-    fail "CONTRIBUTING.md should not publicly advertise the maintainer QA exception"
+    fail "public contributor docs must not advertise private author/identity-based QA evidence exceptions: $advertised_exceptions"
   fi
 }
-test_contributing_docs_do_not_advertise_maintainer_qa_exception
-
-test_pr_template_does_not_advertise_maintainer_qa_exception() {
-  if ! grep -q '@dpearson2699' "$PR_TEMPLATE"; then
-    pass "PR template does not advertise the maintainer QA exception"
-  else
-    fail "PR template should not publicly advertise the maintainer QA exception"
-  fi
-}
-test_pr_template_does_not_advertise_maintainer_qa_exception
+test_public_docs_do_not_advertise_private_author_qa_exception
 
 test_contributing_docs_document_public_pr_automation_statuses() {
   if grep -qF 'What PR automation enforces' "$CONTRIBUTING_DOC" \

--- a/testing/verify-github-fix-workflow-contract.sh
+++ b/testing/verify-github-fix-workflow-contract.sh
@@ -213,6 +213,63 @@ test_pr_template_does_not_advertise_maintainer_qa_exception() {
 }
 test_pr_template_does_not_advertise_maintainer_qa_exception
 
+test_contributing_docs_document_public_pr_automation_statuses() {
+  if grep -qF 'What PR automation enforces' "$CONTRIBUTING_DOC" \
+    && grep -qF '`Linked Issue Check`' "$CONTRIBUTING_DOC" \
+    && grep -qF '`Lint`' "$CONTRIBUTING_DOC" \
+    && grep -qF '`Contract Tests`' "$CONTRIBUTING_DOC" \
+    && grep -qF '`Bats Tests (shard 0)` through `Bats Tests (shard 7)`' "$CONTRIBUTING_DOC" \
+    && grep -qF '`Bats Tests (serial)`' "$CONTRIBUTING_DOC" \
+    && grep -qF 'aggregate `Test`' "$CONTRIBUTING_DOC" \
+    && grep -qF '`QA Review Evidence`' "$CONTRIBUTING_DOC"; then
+    pass "CONTRIBUTING.md documents public PR automation status checks"
+  else
+    fail "CONTRIBUTING.md should document the public PR automation status checks"
+  fi
+}
+test_contributing_docs_document_public_pr_automation_statuses
+
+test_contributing_docs_document_issue_not_pr_requirement() {
+  if grep -qF 'link an actual issue, not just another PR' "$CONTRIBUTING_DOC"; then
+    pass "CONTRIBUTING.md distinguishes issue links from PR-only references"
+  else
+    fail "CONTRIBUTING.md should state that ordinary PRs must link an actual issue, not just another PR"
+  fi
+}
+test_contributing_docs_document_issue_not_pr_requirement
+
+test_contributing_docs_document_qa_evidence_path_rule() {
+  if grep -qF 'Docs-only and repo-metadata-only PRs skip QA evidence' "$CONTRIBUTING_DOC" \
+    && grep -qF '`.github/workflows/` and `config/` changes are QA-relevant' "$CONTRIBUTING_DOC"; then
+    pass "CONTRIBUTING.md documents QA evidence path relevance"
+  else
+    fail "CONTRIBUTING.md should document docs/repo-metadata skips and workflow/config QA relevance"
+  fi
+}
+test_contributing_docs_document_qa_evidence_path_rule
+
+test_contributing_docs_document_qa_evidence_commit_gate() {
+  if grep -qF 'at least 3 QA evidence commits' "$CONTRIBUTING_DOC" \
+    && grep -qF 'fix(scope): address QA round N' "$CONTRIBUTING_DOC" \
+    && grep -qF 'Clean QA rounds still need an empty evidence commit' "$CONTRIBUTING_DOC"; then
+    pass "CONTRIBUTING.md documents the three-commit QA evidence gate"
+  else
+    fail "CONTRIBUTING.md should document three QA evidence commits, exact pattern, and clean-round empty commits"
+  fi
+}
+test_contributing_docs_document_qa_evidence_commit_gate
+
+test_pr_template_documents_qa_evidence_commit_gate() {
+  if grep -qF '3 QA evidence commits' "$PR_TEMPLATE" \
+    && grep -qF 'fix(scope): address QA round N' "$PR_TEMPLATE" \
+    && grep -qF 'Clean rounds still need an evidence commit' "$PR_TEMPLATE"; then
+    pass "PR template documents the three-commit QA evidence gate"
+  else
+    fail "PR template should document three QA evidence commits, exact pattern, and clean-round evidence commits"
+  fi
+}
+test_pr_template_documents_qa_evidence_commit_gate
+
 test_wait_github_fails_fast_on_gh_errors() {
   setup_tmpdir
   cat > "$TMPDIR_BASE/gh" <<'EOF'


### PR DESCRIPTION
## Linked Issue

Fixes #602

## What

Clarifies the contributor-facing PR automation rules so the public docs match the checks ordinary PRs actually hit. This updates `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/qa-review.yml`, and `testing/verify-github-fix-workflow-contract.sh`.

## Why

The root cause was documentation drift: the workflows already enforce issue links, CI matrix checks, and a three-commit QA evidence gate, but contributor docs did not name those checks precisely and still contained stale lower-minimum QA wording. The fix keeps automation unchanged and strengthens docs plus contract tests so future public guidance cannot drift from the existing workflow policy.

## How

- `CONTRIBUTING.md` — adds a concise “What PR automation enforces” section naming the actual status checks, clarifies issue-vs-PR references, documents QA-relevant paths, and states the three QA evidence commit rule including clean-round empty commits.
- `.github/PULL_REQUEST_TEMPLATE.md` — clarifies that linked references must be issue numbers, not PR numbers, and aligns QA evidence checklist text with the three-commit gate.
- `.github/workflows/qa-review.yml` — corrects the stale comment so it no longer claims config/CI changes skip QA evidence; workflow logic is unchanged.
- `testing/verify-github-fix-workflow-contract.sh` — adds public-doc contract assertions for status names, issue-not-PR wording, QA path relevance, three-commit evidence wording, stale lower-minimum QA wording, and generic author/identity-based private skip wording.

## Acceptance criteria verification

1. `CONTRIBUTING.md` names `Linked Issue Check`, `Lint`, `Contract Tests`, `Bats Tests (shard 0)` through `Bats Tests (shard 7)`, `Bats Tests (serial)`, aggregate `Test`, and `QA Review Evidence` — satisfied by the new PR automation section and guarded by `testing/verify-github-fix-workflow-contract.sh`.
2. `CONTRIBUTING.md` states ordinary PRs must link an actual issue, not just another PR — satisfied in the same section and guarded by the issue-not-PR contract assertion.
3. `CONTRIBUTING.md` documents docs/repo-metadata skips and `.github/workflows/` / `config/` QA relevance — satisfied in the PR process section and guarded by the QA path relevance assertion.
4. `CONTRIBUTING.md` documents at least three `fix(scope): address QA round N` evidence commits, including empty commits for clean rounds — satisfied in the QA review process and guarded by the three-commit assertion.
5. `.github/PULL_REQUEST_TEMPLATE.md` mirrors the QA evidence gate and keeps linked issue issue-focused — satisfied by the linked issue comment plus QA evidence checklist and guarded by template assertions.
6. Public contributor docs do not advertise private author-based exceptions or maintainer logins — satisfied by current docs and guarded by the new identity-based exception scan.
7. `testing/verify-github-fix-workflow-contract.sh` asserts the strengthened public-doc contract and continues to guard private-skip visibility — satisfied by the added positive and negative public-doc checks.
8. Required verification commands pass — see Testing.

## Testing

- [x] `bash testing/verify-run-all-execution-contract.sh`
- [x] `bash testing/verify-github-fix-workflow-contract.sh`
- [x] `bash testing/run-all.sh` — latest full run passed with lint `1/1`, contract checks `51/51`, and BATS `3491 passed, 0 failed`
- [x] Branch synced with `origin/main` before PR creation and before marking ready
- [x] GitHub Actions CI green — all 18 checks passed on `4589b5d6363b825679545b38e742644700990a5a`
- [ ] Loaded plugin locally (`claude-vbw` or `claude --plugin-dir "<path-to-vbw-clone>"`) — not applicable; docs/contract-only change
- [ ] Tested affected commands against a real project — not applicable; docs/contract-only change

## QA summary

- Primary QA: 3 rounds completed.
  - Round 1: medium findings F-01/F-02 fixed in `57500212`.
  - Round 2: medium finding F-01 fixed in `3329720d`.
  - Round 3: clean; evidence commit `4589b5d`.
- Cross-model QA: skipped because this is a GitHub Copilot/GPT-class session; no different model-family reviewer is available under the workflow gate.
- Copilot PR review: 1 round completed on `4589b5d6363b825679545b38e742644700990a5a`; fresh review was `COMMENTED` with zero inline comments/unresolved threads.
- CI/CD: green; all 18 required checks passed.
- False positives: none from primary QA or Copilot review.

## Notes

Workflow behavior was intentionally not loosened. This PR aligns public contributor guidance and contract tests with the existing automation policy.
