### PR TITLE
fix(state): preserve phase numbering across roadmap gaps

### DIFF
--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -260,6 +260,26 @@ roadmap_checklist_count() {
   printf '%s\n' "$count"
 }
 
+roadmap_display_numbering_scheme() {
+  local raw_scheme="$1" roadmap_total="${2:-0}"
+
+  case "$raw_scheme" in
+    unknown)
+      printf '%s\n' "unknown"
+      ;;
+    prefix)
+      if [ "${roadmap_total:-0}" -gt 0 ] 2>/dev/null; then
+        printf '%s\n' "prefix"
+      else
+        printf '%s\n' "ordinal"
+      fi
+      ;;
+    *)
+      printf '%s\n' "ordinal"
+      ;;
+  esac
+}
+
 roadmap_numbering_scheme() {
   local roadmap_file="$1" phases_dir="$2"
   local checklist_nums=() prefix_nums=()
@@ -347,6 +367,11 @@ roadmap_numbering_mismatch_details() {
         printf 'legacy ordinal ROADMAP numbering is in use because phase directory prefixes diverge from the Phase 1..N checklist; position %s -> %s (prefix %s)\n' "$first_position" "$first_base" "$first_prefix"
       fi
     fi
+    return 0
+  fi
+
+  if [ "$scheme" = "prefix" ] && [ "$(roadmap_checklist_count "$roadmap_file")" -eq 0 ]; then
+    printf '%s\n' "ROADMAP has no Phase checklist entries; using ordinal display numbering"
     return 0
   fi
 

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -120,6 +120,48 @@ roadmap_phase_dir_prefix_num() {
   normalize_roadmap_phase_num "$num"
 }
 
+roadmap_duplicate_phase_dir_prefix_details() {
+  local phases_dir="$1"
+  local seen="" emitted="" dir num dup_dir dup_num names base
+
+  [ -d "$phases_dir" ] || return 0
+
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    num=$(roadmap_phase_dir_prefix_num "$dir")
+    case " $seen " in
+      *" $num "*)
+        case " $emitted " in
+          *" $num "*) ;;
+          *)
+            names=""
+            while IFS= read -r dup_dir; do
+              [ -n "$dup_dir" ] || continue
+              dup_num=$(roadmap_phase_dir_prefix_num "$dup_dir")
+              [ "$dup_num" = "$num" ] || continue
+              base=$(basename "$dup_dir")
+              names="${names:+$names, }$base"
+            done < <(list_canonical_phase_dirs "$phases_dir")
+            printf 'duplicate phase directory prefix %s is ambiguous across %s; ROADMAP numbering cannot be safely reconciled\n' "$num" "$names"
+            emitted="$emitted $num"
+            ;;
+        esac
+        ;;
+    esac
+    seen="$seen $num"
+  done < <(list_canonical_phase_dirs "$phases_dir")
+}
+
+roadmap_phase_dir_prefixes_have_duplicates() {
+  local detail
+
+  while IFS= read -r detail; do
+    [ -n "$detail" ] && return 0
+  done < <(roadmap_duplicate_phase_dir_prefix_details "$1")
+
+  return 1
+}
+
 _roadmap_index_in_sequence() {
   local wanted="$1" sequence="$2" idx=0 candidate
 
@@ -247,6 +289,10 @@ roadmap_numbering_scheme() {
     printf '%s\n' "unknown"
     return 0
   fi
+  if roadmap_phase_dir_prefixes_have_duplicates "$phases_dir"; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
   if [ "${#checklist_nums[@]}" -eq 0 ]; then
     printf '%s\n' "prefix"
     return 0
@@ -275,6 +321,7 @@ roadmap_numbering_mismatch_details() {
 
   if [ "$scheme" = "unknown" ]; then
     printf '%s\n' "ROADMAP checklist numbering scheme is mixed or unresolvable; skipping numbering-dependent rewrite"
+    roadmap_duplicate_phase_dir_prefix_details "$phases_dir"
     return 0
   fi
 
@@ -372,13 +419,15 @@ roadmap_phase_num_for_dir() {
 
 roadmap_phase_dir_for_num() {
   local scheme="$1" phases_dir="$2" phase_num="$3"
-  local wanted dir idx dir_num
+  local wanted dir idx dir_num match_dir match_count
 
   wanted=$(normalize_roadmap_phase_num "$phase_num")
   [ -n "$wanted" ] || return 1
   [ "$wanted" != "0" ] || return 1
 
   idx=0
+  match_dir=""
+  match_count=0
   while IFS= read -r dir; do
     [ -n "$dir" ] || continue
     idx=$((idx + 1))
@@ -394,10 +443,20 @@ roadmap_phase_dir_for_num() {
         ;;
     esac
     if [ "$dir_num" = "$wanted" ]; then
-      printf '%s\n' "$dir"
-      return 0
+      if [ "$scheme" = "prefix" ]; then
+        match_dir="$dir"
+        match_count=$((match_count + 1))
+      else
+        printf '%s\n' "$dir"
+        return 0
+      fi
     fi
   done < <(list_canonical_phase_dirs "$phases_dir")
+
+  if [ "$scheme" = "prefix" ] && [ "$match_count" -eq 1 ]; then
+    printf '%s\n' "$match_dir"
+    return 0
+  fi
 
   return 1
 }

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -278,6 +278,31 @@ roadmap_numbering_mismatch_details() {
     return 0
   fi
 
+  if [ "$scheme" = "ordinal" ]; then
+    local idx=0 mismatch_count=0 first_position="" first_base="" first_prefix=""
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      idx=$((idx + 1))
+      dir_num=$(roadmap_phase_dir_prefix_num "$dir")
+      if [ "$dir_num" != "$idx" ]; then
+        mismatch_count=$((mismatch_count + 1))
+        if [ -z "$first_position" ]; then
+          first_position="$idx"
+          first_base=$(basename "$dir")
+          first_prefix="$dir_num"
+        fi
+      fi
+    done < <(list_canonical_phase_dirs "$phases_dir")
+    if [ "$mismatch_count" -gt 0 ]; then
+      if [ "$mismatch_count" -gt 1 ]; then
+        printf 'legacy ordinal ROADMAP numbering is in use because phase directory prefixes diverge from the Phase 1..N checklist; position %s -> %s (prefix %s), plus %s more divergent phase dir(s)\n' "$first_position" "$first_base" "$first_prefix" "$((mismatch_count - 1))"
+      else
+        printf 'legacy ordinal ROADMAP numbering is in use because phase directory prefixes diverge from the Phase 1..N checklist; position %s -> %s (prefix %s)\n' "$first_position" "$first_base" "$first_prefix"
+      fi
+    fi
+    return 0
+  fi
+
   while IFS= read -r num; do
     [ -n "$num" ] || continue
     checklist_seen="$checklist_seen $num"

--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -159,10 +159,69 @@ _roadmap_candidate_score() {
   printf '%s\n' "$score"
 }
 
+_roadmap_unique_count() {
+  local sequence="$1" seen="" count=0 num
+
+  while IFS= read -r num; do
+    [ -n "$num" ] || continue
+    case " $seen " in *" $num "*) continue ;; esac
+    seen="$seen $num"
+    count=$((count + 1))
+  done <<< "$sequence"
+
+  printf '%s\n' "$count"
+}
+
+_roadmap_sequence_contains_all_unique_in_order() {
+  local checklist_seq="$1" expected_seq="$2"
+  local expected_count score
+
+  expected_count=$(_roadmap_unique_count "$expected_seq")
+  [ "$expected_count" -gt 0 ] || return 1
+  score=$(_roadmap_candidate_score "$checklist_seq" "$expected_seq")
+  [ "$score" -eq "$expected_count" ]
+}
+
+_roadmap_sequence_is_exact_ordinal() {
+  local checklist_seq="$1" expected_count="$2"
+  local idx=0 num
+
+  [ "$expected_count" -gt 0 ] || return 1
+  while IFS= read -r num; do
+    [ -n "$num" ] || continue
+    idx=$((idx + 1))
+    [ "$num" = "$idx" ] || return 1
+  done <<< "$checklist_seq"
+
+  [ "$idx" -eq "$expected_count" ]
+}
+
+roadmap_checklist_phase_nums() {
+  local roadmap_file="$1" line num
+
+  [ -f "$roadmap_file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    if num=$(roadmap_checklist_phase_num_from_line "$line"); then
+      printf '%s\n' "$num"
+    fi
+  done < "$roadmap_file"
+}
+
+roadmap_checklist_count() {
+  local roadmap_file="$1" count=0 num
+
+  while IFS= read -r num; do
+    [ -n "$num" ] || continue
+    count=$((count + 1))
+  done < <(roadmap_checklist_phase_nums "$roadmap_file")
+
+  printf '%s\n' "$count"
+}
+
 roadmap_numbering_scheme() {
   local roadmap_file="$1" phases_dir="$2"
-  local checklist_nums=() prefix_nums=() ordinal_nums=()
-  local line num dir idx checklist_seq prefix_seq ordinal_seq prefix_score ordinal_score
+  local checklist_nums=() prefix_nums=()
+  local line num dir idx checklist_seq prefix_seq dir_count
 
   [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
   [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
@@ -182,7 +241,6 @@ roadmap_numbering_scheme() {
     [ -n "$dir" ] || continue
     idx=$((idx + 1))
     prefix_nums+=("$(roadmap_phase_dir_prefix_num "$dir")")
-    ordinal_nums+=("$idx")
   done < <(list_canonical_phase_dirs "$phases_dir")
 
   if [ "${#prefix_nums[@]}" -eq 0 ]; then
@@ -196,25 +254,78 @@ roadmap_numbering_scheme() {
 
   checklist_seq=$(printf '%s\n' "${checklist_nums[@]}")
   prefix_seq=$(printf '%s\n' "${prefix_nums[@]}")
-  ordinal_seq=$(printf '%s\n' "${ordinal_nums[@]}")
-  prefix_score=$(_roadmap_candidate_score "$checklist_seq" "$prefix_seq")
-  ordinal_score=$(_roadmap_candidate_score "$checklist_seq" "$ordinal_seq")
 
-  if [ "$prefix_score" -le 0 ] && [ "$ordinal_score" -le 0 ]; then
-    printf '%s\n' "unknown"
-  elif [ "$prefix_seq" = "$ordinal_seq" ]; then
+  dir_count=${#prefix_nums[@]}
+  if _roadmap_sequence_contains_all_unique_in_order "$checklist_seq" "$prefix_seq"; then
     printf '%s\n' "prefix"
-  elif [ "$prefix_score" -gt 0 ] && [ "$ordinal_score" -le 0 ]; then
-    printf '%s\n' "prefix"
-  elif [ "$ordinal_score" -gt 0 ] && [ "$prefix_score" -le 0 ]; then
-    printf '%s\n' "ordinal"
-  elif [ "$prefix_score" -gt "$ordinal_score" ]; then
-    printf '%s\n' "prefix"
-  elif [ "$ordinal_score" -gt "$prefix_score" ]; then
+  elif _roadmap_sequence_is_exact_ordinal "$checklist_seq" "$dir_count"; then
     printf '%s\n' "ordinal"
   else
     printf '%s\n' "unknown"
   fi
+}
+
+roadmap_numbering_mismatch_details() {
+  local roadmap_file="$1" phases_dir="$2" scheme="${3:-}"
+  local checklist_seen="" num dir dir_num base
+
+  [ -f "$roadmap_file" ] || return 0
+  [ -d "$phases_dir" ] || return 0
+  [ -n "$scheme" ] || scheme=$(roadmap_numbering_scheme "$roadmap_file" "$phases_dir")
+
+  if [ "$scheme" = "unknown" ]; then
+    printf '%s\n' "ROADMAP checklist numbering scheme is mixed or unresolvable; skipping numbering-dependent rewrite"
+    return 0
+  fi
+
+  while IFS= read -r num; do
+    [ -n "$num" ] || continue
+    checklist_seen="$checklist_seen $num"
+    if [ "$scheme" = "prefix" ] && ! roadmap_phase_dir_for_num "prefix" "$phases_dir" "$num" >/dev/null 2>&1; then
+      printf 'ROADMAP phase %s has no matching %s-* phase directory; using prefix numbering and preserving missing phase slot\n' "$num" "$num"
+    fi
+  done < <(roadmap_checklist_phase_nums "$roadmap_file")
+
+  if [ "$scheme" = "prefix" ]; then
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      dir_num=$(roadmap_phase_dir_prefix_num "$dir")
+      case " $checklist_seen " in
+        *" $dir_num "*) ;;
+        *)
+          base=$(basename "$dir")
+          printf 'phase directory %s exists on disk but ROADMAP has no matching Phase %s entry; using prefix numbering\n' "$base" "$dir_num"
+          ;;
+      esac
+    done < <(list_canonical_phase_dirs "$phases_dir")
+  fi
+}
+
+phase_state_log_warning() {
+  local planning_root="$1" detail="$2"
+  local log ts lc
+
+  [ -n "$planning_root" ] || return 0
+  [ -d "$planning_root" ] || return 0
+  [ -n "$detail" ] || return 0
+
+  log="$planning_root/.hook-errors.log"
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%s")
+  printf '[%s] state-numbering-warning: %s\n' "$ts" "$detail" >> "$log" 2>/dev/null || return 0
+  if [ -f "$log" ]; then
+    lc=$(wc -l < "$log" 2>/dev/null | tr -d ' ')
+    [ "${lc:-0}" -gt 50 ] && { tail -30 "$log" > "${log}.tmp" && mv "${log}.tmp" "$log"; } 2>/dev/null
+  fi
+}
+
+phase_state_log_numbering_warnings() {
+  local planning_root="$1" roadmap_file="$2" phases_dir="$3" scheme="${4:-}"
+  local detail
+
+  while IFS= read -r detail; do
+    [ -n "$detail" ] || continue
+    phase_state_log_warning "$planning_root" "$detail"
+  done < <(roadmap_numbering_mismatch_details "$roadmap_file" "$phases_dir" "$scheme")
 }
 
 roadmap_phase_num_for_dir() {

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -63,6 +63,7 @@ REQUIRED_FUNCTIONS=(
   roadmap_checklist_phase_num_from_line
   roadmap_phase_dir_prefix_num
   roadmap_numbering_scheme
+  roadmap_display_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
   roadmap_checklist_phase_nums
@@ -388,6 +389,7 @@ fi
 
 ROADMAP_FILE="$PLANNING_DIR/ROADMAP.md"
 numbering_scheme="ordinal"
+display_numbering_scheme="ordinal"
 roadmap_total=0
 if [ -f "$ROADMAP_FILE" ]; then
   numbering_scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
@@ -399,11 +401,12 @@ if [ -f "$ROADMAP_FILE" ]; then
     exit 0
   fi
   roadmap_total=$(roadmap_checklist_count "$ROADMAP_FILE")
+  display_numbering_scheme=$(roadmap_display_numbering_scheme "$numbering_scheme" "$roadmap_total")
 fi
 
 active_display_idx="$active_idx"
 display_total="$TOTAL"
-if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ]; then
+if [ "$display_numbering_scheme" = "prefix" ]; then
   active_display_idx=$(roadmap_phase_num_for_dir "prefix" "${phase_dirs[$array_idx]}" "$PHASES_DIR")
   [ -n "$active_display_idx" ] || active_display_idx="$active_idx"
   display_total="$roadmap_total"
@@ -416,7 +419,7 @@ status_line="Status: ${active_status}"
 
 status_lines_file="${STATE_FILE}.phase-status.$$.${RANDOM:-0}"
 : > "$status_lines_file" 2>/dev/null || exit 0
-if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ]; then
+if [ "$display_numbering_scheme" = "prefix" ]; then
   while IFS= read -r roadmap_phase_num; do
     [ -n "$roadmap_phase_num" ] || continue
     roadmap_phase_dir=$(roadmap_phase_dir_for_num "prefix" "$PHASES_DIR" "$roadmap_phase_num" 2>/dev/null || true)
@@ -430,7 +433,7 @@ else
   idx=0
   for phase_dir in "${phase_dirs[@]}"; do
     idx=$((idx + 1))
-    case "$numbering_scheme" in
+    case "$display_numbering_scheme" in
       prefix)
         display_num=$(roadmap_phase_num_for_dir "prefix" "$phase_dir" "$PHASES_DIR")
         [ -n "$display_num" ] || display_num="$idx"

--- a/scripts/reconcile-state-md.sh
+++ b/scripts/reconcile-state-md.sh
@@ -65,6 +65,8 @@ REQUIRED_FUNCTIONS=(
   roadmap_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
+  roadmap_checklist_phase_nums
+  roadmap_checklist_count
   roadmap_checklist_has_duplicate_phase_nums
 )
 for fn in "${REQUIRED_FUNCTIONS[@]}"; do
@@ -260,6 +262,47 @@ rewrite_roadmap_checklist_projection() {
   [ -s "$tmp" ] && mv "$tmp" "$roadmap_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 }
 
+phase_dir_array_index() {
+  local wanted="$1" idx=0 candidate
+
+  for candidate in "${phase_dirs[@]}"; do
+    if [ "${candidate%/}" = "${wanted%/}" ]; then
+      printf '%s\n' "$idx"
+      return 0
+    fi
+    idx=$((idx + 1))
+  done
+
+  return 1
+}
+
+existing_phase_status_line() {
+  local state_file="$1" phase_num="$2"
+
+  grep -E "^- \*\*Phase 0*${phase_num}([ :]|\()" "$state_file" 2>/dev/null | head -1
+}
+
+append_phase_status_for_dir_index() {
+  local out_file="$1" display_num="$2" dir_index="$3"
+  local name label
+
+  name=${names[$dir_index]}
+  label=${labels[$dir_index]}
+  printf -- '- **Phase %s (%s):** %s\n' "$display_num" "$name" "$label" >> "$out_file" 2>/dev/null || true
+}
+
+append_missing_phase_status() {
+  local out_file="$1" phase_num="$2"
+  local existing
+
+  existing=$(existing_phase_status_line "$STATE_FILE" "$phase_num" || true)
+  if [ -n "$existing" ]; then
+    printf '%s\n' "$existing" >> "$out_file" 2>/dev/null || true
+  else
+    printf -- '- **Phase %s (Missing phase directory):** Unknown (missing phase directory)\n' "$phase_num" >> "$out_file" 2>/dev/null || true
+  fi
+}
+
 PLANNING_DIR=$(resolve_planning_root "$TARGET")
 [ -n "$PLANNING_DIR" ] || { quiet_json "skipped" "planning root not found"; exit 0; }
 
@@ -343,20 +386,62 @@ else
   active_status="ready"
 fi
 
-phase_line="Phase: ${active_idx} of ${TOTAL} (${active_name})"
+ROADMAP_FILE="$PLANNING_DIR/ROADMAP.md"
+numbering_scheme="ordinal"
+roadmap_total=0
+if [ -f "$ROADMAP_FILE" ]; then
+  numbering_scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
+  if type phase_state_log_numbering_warnings >/dev/null 2>&1; then
+    phase_state_log_numbering_warnings "$PLANNING_DIR" "$ROADMAP_FILE" "$PHASES_DIR" "$numbering_scheme"
+  fi
+  if [ "$numbering_scheme" = "unknown" ]; then
+    quiet_json "skipped" "ROADMAP checklist numbering scheme is mixed or unresolvable"
+    exit 0
+  fi
+  roadmap_total=$(roadmap_checklist_count "$ROADMAP_FILE")
+fi
+
+active_display_idx="$active_idx"
+display_total="$TOTAL"
+if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ]; then
+  active_display_idx=$(roadmap_phase_num_for_dir "prefix" "${phase_dirs[$array_idx]}" "$PHASES_DIR")
+  [ -n "$active_display_idx" ] || active_display_idx="$active_idx"
+  display_total="$roadmap_total"
+fi
+
+phase_line="Phase: ${active_display_idx} of ${display_total} (${active_name})"
 plans_line="Plans: ${active_terminal_count}/${active_plan_count}"
 progress_line="Progress: ${progress}%"
 status_line="Status: ${active_status}"
 
 status_lines_file="${STATE_FILE}.phase-status.$$.${RANDOM:-0}"
 : > "$status_lines_file" 2>/dev/null || exit 0
-idx=0
-for phase_dir in "${phase_dirs[@]}"; do
-  idx=$((idx + 1))
-  name=${names[$((idx - 1))]}
-  label=${labels[$((idx - 1))]}
-  printf -- '- **Phase %s (%s):** %s\n' "$idx" "$name" "$label" >> "$status_lines_file" 2>/dev/null || true
-done
+if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ]; then
+  while IFS= read -r roadmap_phase_num; do
+    [ -n "$roadmap_phase_num" ] || continue
+    roadmap_phase_dir=$(roadmap_phase_dir_for_num "prefix" "$PHASES_DIR" "$roadmap_phase_num" 2>/dev/null || true)
+    if [ -n "$roadmap_phase_dir" ] && dir_index=$(phase_dir_array_index "$roadmap_phase_dir"); then
+      append_phase_status_for_dir_index "$status_lines_file" "$roadmap_phase_num" "$dir_index"
+    else
+      append_missing_phase_status "$status_lines_file" "$roadmap_phase_num"
+    fi
+  done < <(roadmap_checklist_phase_nums "$ROADMAP_FILE")
+else
+  idx=0
+  for phase_dir in "${phase_dirs[@]}"; do
+    idx=$((idx + 1))
+    case "$numbering_scheme" in
+      prefix)
+        display_num=$(roadmap_phase_num_for_dir "prefix" "$phase_dir" "$PHASES_DIR")
+        [ -n "$display_num" ] || display_num="$idx"
+        ;;
+      *)
+        display_num="$idx"
+        ;;
+    esac
+    append_phase_status_for_dir_index "$status_lines_file" "$display_num" "$((idx - 1))"
+  done
+fi
 
 rewrite_current_phase_section "$STATE_FILE" "$phase_line" "$plans_line" "$progress_line" "$status_line"
 rewrite_phase_status_section "$STATE_FILE" "$status_lines_file"

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -183,11 +183,54 @@ if ! type _roadmap_candidate_score >/dev/null 2>&1; then
   }
 fi
 
+if ! type _roadmap_unique_count >/dev/null 2>&1; then
+  _roadmap_unique_count() {
+    local sequence="$1" seen="" count=0 num
+
+    while IFS= read -r num; do
+      [ -n "$num" ] || continue
+      case " $seen " in *" $num "*) continue ;; esac
+      seen="$seen $num"
+      count=$((count + 1))
+    done <<< "$sequence"
+
+    printf '%s\n' "$count"
+  }
+fi
+
+if ! type _roadmap_sequence_contains_all_unique_in_order >/dev/null 2>&1; then
+  _roadmap_sequence_contains_all_unique_in_order() {
+    local checklist_seq="$1" expected_seq="$2"
+    local expected_count score
+
+    expected_count=$(_roadmap_unique_count "$expected_seq")
+    [ "$expected_count" -gt 0 ] || return 1
+    score=$(_roadmap_candidate_score "$checklist_seq" "$expected_seq")
+    [ "$score" -eq "$expected_count" ]
+  }
+fi
+
+if ! type _roadmap_sequence_is_exact_ordinal >/dev/null 2>&1; then
+  _roadmap_sequence_is_exact_ordinal() {
+    local checklist_seq="$1" expected_count="$2"
+    local idx=0 num
+
+    [ "$expected_count" -gt 0 ] || return 1
+    while IFS= read -r num; do
+      [ -n "$num" ] || continue
+      idx=$((idx + 1))
+      [ "$num" = "$idx" ] || return 1
+    done <<< "$checklist_seq"
+
+    [ "$idx" -eq "$expected_count" ]
+  }
+fi
+
 if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
   roadmap_numbering_scheme() {
     local roadmap_file="$1" phases_dir="$2"
-    local checklist_nums=() prefix_nums=() ordinal_nums=()
-    local line num dir idx checklist_seq prefix_seq ordinal_seq prefix_score ordinal_score
+    local checklist_nums=() prefix_nums=()
+    local line num dir idx checklist_seq prefix_seq dir_count
 
     [ -f "$roadmap_file" ] || { printf '%s\n' "unknown"; return 0; }
     [ -d "$phases_dir" ] || { printf '%s\n' "unknown"; return 0; }
@@ -207,7 +250,6 @@ if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
       [ -n "$dir" ] || continue
       idx=$((idx + 1))
       prefix_nums+=("$(roadmap_phase_dir_prefix_num "$dir")")
-      ordinal_nums+=("$idx")
     done < <(list_canonical_phase_dirs "$phases_dir")
 
     if [ "${#prefix_nums[@]}" -eq 0 ]; then
@@ -221,21 +263,10 @@ if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
 
     checklist_seq=$(printf '%s\n' "${checklist_nums[@]}")
     prefix_seq=$(printf '%s\n' "${prefix_nums[@]}")
-    ordinal_seq=$(printf '%s\n' "${ordinal_nums[@]}")
-    prefix_score=$(_roadmap_candidate_score "$checklist_seq" "$prefix_seq")
-    ordinal_score=$(_roadmap_candidate_score "$checklist_seq" "$ordinal_seq")
-
-    if [ "$prefix_score" -le 0 ] && [ "$ordinal_score" -le 0 ]; then
-      printf '%s\n' "unknown"
-    elif [ "$prefix_seq" = "$ordinal_seq" ]; then
+    dir_count=${#prefix_nums[@]}
+    if _roadmap_sequence_contains_all_unique_in_order "$checklist_seq" "$prefix_seq"; then
       printf '%s\n' "prefix"
-    elif [ "$prefix_score" -gt 0 ] && [ "$ordinal_score" -le 0 ]; then
-      printf '%s\n' "prefix"
-    elif [ "$ordinal_score" -gt 0 ] && [ "$prefix_score" -le 0 ]; then
-      printf '%s\n' "ordinal"
-    elif [ "$prefix_score" -gt "$ordinal_score" ]; then
-      printf '%s\n' "prefix"
-    elif [ "$ordinal_score" -gt "$prefix_score" ]; then
+    elif _roadmap_sequence_is_exact_ordinal "$checklist_seq" "$dir_count"; then
       printf '%s\n' "ordinal"
     else
       printf '%s\n' "unknown"
@@ -418,15 +449,15 @@ update_roadmap() {
 
   [ -f "$roadmap" ] || return 0
 
-  local dirname ordinal_phase_num table_phase_num checkbox_phase_num checkbox_scheme prefix_phase_num plan_count summary_count status date_str
+  local dirname table_phase_num checkbox_phase_num numbering_scheme prefix_phase_num plan_count summary_count status date_str
   dirname=$(basename "$phase_dir")
   prefix_phase_num=$(echo "$dirname" | sed 's/^\([0-9]*\).*/\1/' | sed 's/^0*//')
-  ordinal_phase_num=$(phase_dir_position "$phase_dir")
-  if [ -z "$ordinal_phase_num" ]; then
-    ordinal_phase_num="$prefix_phase_num"
+  numbering_scheme=$(roadmap_numbering_scheme "$roadmap" "$(dirname "$phase_dir")")
+  if type phase_state_log_numbering_warnings >/dev/null 2>&1; then
+    phase_state_log_numbering_warnings "$planning_root" "$roadmap" "$(dirname "$phase_dir")" "$numbering_scheme"
   fi
-  [ -z "$ordinal_phase_num" ] && return 0
-  table_phase_num="$ordinal_phase_num"
+  table_phase_num=$(roadmap_phase_num_for_dir "$numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
+  [ -z "$table_phase_num" ] && return 0
 
   plan_count=$(count_phase_plans "$phase_dir")
   summary_count=$(count_terminal_summaries "$phase_dir")
@@ -457,7 +488,7 @@ update_roadmap() {
   # Update extended progress table row (| num - name | done | status | date |)
   local existing_name
   existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
-  if [ -z "$existing_name" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$table_phase_num" ]; then
+  if [ -z "$existing_name" ] && [ "$numbering_scheme" != "unknown" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$table_phase_num" ]; then
     table_phase_num="$prefix_phase_num"
     existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
   fi
@@ -484,8 +515,7 @@ update_roadmap() {
       [ -s "$tmp_simple" ] && mv "$tmp_simple" "$tmp" 2>/dev/null || rm -f "$tmp_simple" 2>/dev/null
   fi
 
-  checkbox_scheme=$(roadmap_numbering_scheme "$tmp" "$(dirname "$phase_dir")")
-  checkbox_phase_num=$(roadmap_phase_num_for_dir "$checkbox_scheme" "$phase_dir" "$(dirname "$phase_dir")")
+  checkbox_phase_num=$(roadmap_phase_num_for_dir "$numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
 
   # Check/uncheck checkbox based on status
   if [ -n "$checkbox_phase_num" ]; then

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -244,6 +244,43 @@ if ! type _roadmap_sequence_is_exact_ordinal >/dev/null 2>&1; then
   }
 fi
 
+if ! type roadmap_checklist_count >/dev/null 2>&1; then
+  roadmap_checklist_count() {
+    local roadmap_file="$1" count=0 line
+
+    [ -f "$roadmap_file" ] || { printf '%s\n' "0"; return 0; }
+    while IFS= read -r line || [ -n "$line" ]; do
+      if roadmap_checklist_phase_num_from_line "$line" >/dev/null 2>&1; then
+        count=$((count + 1))
+      fi
+    done < "$roadmap_file"
+
+    printf '%s\n' "$count"
+  }
+fi
+
+if ! type roadmap_display_numbering_scheme >/dev/null 2>&1; then
+  roadmap_display_numbering_scheme() {
+    local raw_scheme="$1" roadmap_total="${2:-0}"
+
+    case "$raw_scheme" in
+      unknown)
+        printf '%s\n' "unknown"
+        ;;
+      prefix)
+        if [ "${roadmap_total:-0}" -gt 0 ] 2>/dev/null; then
+          printf '%s\n' "prefix"
+        else
+          printf '%s\n' "ordinal"
+        fi
+        ;;
+      *)
+        printf '%s\n' "ordinal"
+        ;;
+    esac
+  }
+fi
+
 if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
   roadmap_numbering_scheme() {
     local roadmap_file="$1" phases_dir="$2"
@@ -471,14 +508,16 @@ update_roadmap() {
 
   [ -f "$roadmap" ] || return 0
 
-  local dirname table_phase_num checkbox_phase_num numbering_scheme prefix_phase_num plan_count summary_count status date_str
+  local dirname table_phase_num checkbox_phase_num numbering_scheme display_numbering_scheme roadmap_total prefix_phase_num plan_count summary_count status date_str
   dirname=$(basename "$phase_dir")
   prefix_phase_num=$(echo "$dirname" | sed 's/^\([0-9]*\).*/\1/' | sed 's/^0*//')
   numbering_scheme=$(roadmap_numbering_scheme "$roadmap" "$(dirname "$phase_dir")")
   if type phase_state_log_numbering_warnings >/dev/null 2>&1; then
     phase_state_log_numbering_warnings "$planning_root" "$roadmap" "$(dirname "$phase_dir")" "$numbering_scheme"
   fi
-  table_phase_num=$(roadmap_phase_num_for_dir "$numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
+  roadmap_total=$(roadmap_checklist_count "$roadmap")
+  display_numbering_scheme=$(roadmap_display_numbering_scheme "$numbering_scheme" "$roadmap_total")
+  table_phase_num=$(roadmap_phase_num_for_dir "$display_numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
   [ -z "$table_phase_num" ] && return 0
 
   plan_count=$(count_phase_plans "$phase_dir")
@@ -510,7 +549,7 @@ update_roadmap() {
   # Update extended progress table row (| num - name | done | status | date |)
   local existing_name
   existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
-  if [ -z "$existing_name" ] && [ "$numbering_scheme" != "unknown" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$table_phase_num" ]; then
+  if [ -z "$existing_name" ] && [ "$display_numbering_scheme" = "prefix" ] && [ -n "$prefix_phase_num" ] && [ "$prefix_phase_num" != "$table_phase_num" ]; then
     table_phase_num="$prefix_phase_num"
     existing_name=$(grep -E "^\| *${table_phase_num} - " "$roadmap" | head -1 | sed 's/^| *[0-9]* - //' | sed 's/ *|.*//')
   fi
@@ -537,7 +576,7 @@ update_roadmap() {
       [ -s "$tmp_simple" ] && mv "$tmp_simple" "$tmp" 2>/dev/null || rm -f "$tmp_simple" 2>/dev/null
   fi
 
-  checkbox_phase_num=$(roadmap_phase_num_for_dir "$numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
+  checkbox_phase_num=$(roadmap_phase_num_for_dir "$display_numbering_scheme" "$phase_dir" "$(dirname "$phase_dir")")
 
   # Check/uncheck checkbox based on status
   if [ -n "$checkbox_phase_num" ]; then

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -140,6 +140,24 @@ if ! type roadmap_phase_dir_prefix_num >/dev/null 2>&1; then
   }
 fi
 
+if ! type roadmap_phase_dir_prefixes_have_duplicates >/dev/null 2>&1; then
+  roadmap_phase_dir_prefixes_have_duplicates() {
+    local phases_dir="$1" seen="" dir num
+
+    [ -d "$phases_dir" ] || return 1
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      num=$(roadmap_phase_dir_prefix_num "$dir")
+      case " $seen " in
+        *" $num "*) return 0 ;;
+      esac
+      seen="$seen $num"
+    done < <(list_canonical_phase_dirs "$phases_dir")
+
+    return 1
+  }
+fi
+
 if ! type _roadmap_index_in_sequence >/dev/null 2>&1; then
   _roadmap_index_in_sequence() {
     local wanted="$1" sequence="$2" idx=0 candidate
@@ -253,6 +271,10 @@ if ! type roadmap_numbering_scheme >/dev/null 2>&1; then
     done < <(list_canonical_phase_dirs "$phases_dir")
 
     if [ "${#prefix_nums[@]}" -eq 0 ]; then
+      printf '%s\n' "unknown"
+      return 0
+    fi
+    if roadmap_phase_dir_prefixes_have_duplicates "$phases_dir"; then
       printf '%s\n' "unknown"
       return 0
     fi

--- a/scripts/update-phase-total.sh
+++ b/scripts/update-phase-total.sh
@@ -144,6 +144,7 @@ list_canonical_phase_dirs "$phases_dir" > "$sorted_dirs_file"
 total=$(wc -l < "$sorted_dirs_file" | tr -d ' ')
 roadmap_md="${planning_root}/ROADMAP.md"
 numbering_scheme="ordinal"
+display_numbering_scheme="ordinal"
 roadmap_total=0
 display_total="$total"
 if [ -f "$roadmap_md" ] && type roadmap_numbering_scheme >/dev/null 2>&1 && type roadmap_checklist_count >/dev/null 2>&1; then
@@ -153,10 +154,15 @@ if [ -f "$roadmap_md" ] && type roadmap_numbering_scheme >/dev/null 2>&1 && type
   fi
   if [ "$numbering_scheme" = "prefix" ]; then
     roadmap_total=$(roadmap_checklist_count "$roadmap_md")
-    [ "${roadmap_total:-0}" -gt 0 ] && display_total="$roadmap_total"
   elif [ "$numbering_scheme" = "unknown" ]; then
     rm -f "$sorted_dirs_file" 2>/dev/null
     exit 0
+  fi
+  if type roadmap_display_numbering_scheme >/dev/null 2>&1; then
+    display_numbering_scheme=$(roadmap_display_numbering_scheme "$numbering_scheme" "$roadmap_total")
+  fi
+  if [ "$display_numbering_scheme" = "prefix" ]; then
+    display_total="$roadmap_total"
   fi
 fi
 
@@ -223,7 +229,7 @@ esac
 # F-11: Resolve phase name using the selected display-numbering scheme so
 # the Phase: line and Phase Status bullets always agree on numbering.
 phase_name=""
-case "$numbering_scheme" in
+case "$display_numbering_scheme" in
   prefix)
     phase_dir=""
     if type roadmap_phase_dir_for_num >/dev/null 2>&1; then
@@ -254,7 +260,7 @@ sed "s/^Phase: .*/${replacement}/" "$state_md" > "$tmp" 2>/dev/null && \
 new_status_file="${state_md}.newstatus.$$"
 phase_idx=0
 : > "$new_status_file"
-if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ] && type roadmap_checklist_phase_nums >/dev/null 2>&1 && type roadmap_phase_dir_for_num >/dev/null 2>&1; then
+if [ "$display_numbering_scheme" = "prefix" ] && type roadmap_checklist_phase_nums >/dev/null 2>&1 && type roadmap_phase_dir_for_num >/dev/null 2>&1; then
   while IFS= read -r roadmap_phase_num; do
     [ -n "$roadmap_phase_num" ] || continue
     dir=$(roadmap_phase_dir_for_num "prefix" "$phases_dir" "$roadmap_phase_num" 2>/dev/null || true)

--- a/scripts/update-phase-total.sh
+++ b/scripts/update-phase-total.sh
@@ -121,10 +121,44 @@ if [ -n "$action" ] && ! echo "$position" | grep -qE '^[1-9][0-9]*$'; then
   exit 0
 fi
 
+existing_phase_status_line() {
+  local phase_num="$1"
+  grep -E "^- \*\*Phase 0*${phase_num}([ :]|\()" "$state_md" 2>/dev/null | head -1
+}
+
+append_missing_phase_status() {
+  local out_file="$1" phase_num="$2"
+  local existing
+
+  existing=$(existing_phase_status_line "$phase_num" || true)
+  if [ -n "$existing" ]; then
+    printf '%s\n' "$existing" >> "$out_file"
+  else
+    printf -- '- **Phase %s (Missing phase directory):** Unknown (missing phase directory)\n' "$phase_num" >> "$out_file"
+  fi
+}
+
 sorted_dirs_file="${state_md}.dirs.$$"
 list_canonical_phase_dirs "$phases_dir" > "$sorted_dirs_file"
 
 total=$(wc -l < "$sorted_dirs_file" | tr -d ' ')
+roadmap_md="${planning_root}/ROADMAP.md"
+numbering_scheme="ordinal"
+roadmap_total=0
+display_total="$total"
+if [ -f "$roadmap_md" ] && type roadmap_numbering_scheme >/dev/null 2>&1 && type roadmap_checklist_count >/dev/null 2>&1; then
+  numbering_scheme=$(roadmap_numbering_scheme "$roadmap_md" "$phases_dir")
+  if type phase_state_log_numbering_warnings >/dev/null 2>&1; then
+    phase_state_log_numbering_warnings "$planning_root" "$roadmap_md" "$phases_dir" "$numbering_scheme"
+  fi
+  if [ "$numbering_scheme" = "prefix" ]; then
+    roadmap_total=$(roadmap_checklist_count "$roadmap_md")
+    [ "${roadmap_total:-0}" -gt 0 ] && display_total="$roadmap_total"
+  elif [ "$numbering_scheme" = "unknown" ]; then
+    rm -f "$sorted_dirs_file" 2>/dev/null
+    exit 0
+  fi
+fi
 
 # F-02: handle zero-phase state — remove stale current-phase section and clear
 # stale Phase Status bullets so STATE.md no longer claims an active phase.
@@ -183,22 +217,32 @@ case "$action" in
 esac
 
 # Clamp current to valid range
-[ "$current" -gt "$total" ] && current="$total"
+[ "$current" -gt "$display_total" ] && current="$display_total"
 [ "$current" -lt 1 ] && current=1
 
-# F-11: Resolve phase name from sorted position (not filesystem prefix) so
+# F-11: Resolve phase name using the selected display-numbering scheme so
 # the Phase: line and Phase Status bullets always agree on numbering.
 phase_name=""
-phase_dir=$(sed -n "${current}p" "$sorted_dirs_file")
+case "$numbering_scheme" in
+  prefix)
+    phase_dir=""
+    if type roadmap_phase_dir_for_num >/dev/null 2>&1; then
+      phase_dir=$(roadmap_phase_dir_for_num "prefix" "$phases_dir" "$current" 2>/dev/null || true)
+    fi
+    ;;
+  *)
+    phase_dir=$(sed -n "${current}p" "$sorted_dirs_file")
+    ;;
+esac
 if [ -n "$phase_dir" ]; then
   phase_name=$(basename "$phase_dir" | sed 's/^[0-9]*-//' | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')
 fi
 
 # Build replacement
 if [ -n "$phase_name" ]; then
-  replacement="Phase: ${current} of ${total} (${phase_name})"
+  replacement="Phase: ${current} of ${display_total} (${phase_name})"
 else
-  replacement="Phase: ${current} of ${total}"
+  replacement="Phase: ${current} of ${display_total}"
 fi
 
 # Update STATE.md Phase: line
@@ -210,13 +254,28 @@ sed "s/^Phase: .*/${replacement}/" "$state_md" > "$tmp" 2>/dev/null && \
 new_status_file="${state_md}.newstatus.$$"
 phase_idx=0
 : > "$new_status_file"
-while IFS= read -r dir; do
-  [ -z "$dir" ] && continue
-  phase_idx=$((phase_idx + 1))
-  local_name=$(phase_dir_display_name "$dir")
-  status_text=$(phase_status_label "$dir" "$phase_idx")
-  echo "- **Phase ${phase_idx} (${local_name}):** ${status_text}" >> "$new_status_file"
-done < "$sorted_dirs_file"
+if [ "$numbering_scheme" = "prefix" ] && [ "${roadmap_total:-0}" -gt 0 ] && type roadmap_checklist_phase_nums >/dev/null 2>&1 && type roadmap_phase_dir_for_num >/dev/null 2>&1; then
+  while IFS= read -r roadmap_phase_num; do
+    [ -n "$roadmap_phase_num" ] || continue
+    dir=$(roadmap_phase_dir_for_num "prefix" "$phases_dir" "$roadmap_phase_num" 2>/dev/null || true)
+    if [ -n "$dir" ]; then
+      phase_idx=$((phase_idx + 1))
+      local_name=$(phase_dir_display_name "$dir")
+      status_text=$(phase_status_label "$dir" "$phase_idx")
+      echo "- **Phase ${roadmap_phase_num} (${local_name}):** ${status_text}" >> "$new_status_file"
+    else
+      append_missing_phase_status "$new_status_file" "$roadmap_phase_num"
+    fi
+  done < <(roadmap_checklist_phase_nums "$roadmap_md")
+else
+  while IFS= read -r dir; do
+    [ -z "$dir" ] && continue
+    phase_idx=$((phase_idx + 1))
+    local_name=$(phase_dir_display_name "$dir")
+    status_text=$(phase_status_label "$dir" "$phase_idx")
+    echo "- **Phase ${phase_idx} (${local_name}):** ${status_text}" >> "$new_status_file"
+  done < "$sorted_dirs_file"
+fi
 
 rm -f "$sorted_dirs_file" 2>/dev/null
 

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -291,10 +291,9 @@ find_active_phase_num() {
     prefix_num=${prefix_num:-0}
     plans=$(count_phase_plans "$dir")
     complete=$(count_complete_summaries "$dir")
-    if [ "$plans" -eq 0 ] || [ "$complete" -lt "$plans" ] || phase_has_uat_issues "$dir"; then
+    if [ -z "$active_ordinal" ] && { [ "$plans" -eq 0 ] || [ "$complete" -lt "$plans" ] || phase_has_uat_issues "$dir"; }; then
       active_ordinal="$phase_idx"
       active_prefix="$prefix_num"
-      break
     fi
   done < <(list_canonical_phase_dirs "$phases_dir")
   total_dirs="$phase_idx"

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -59,6 +59,7 @@ REQUIRED_FUNCTIONS=(
   roadmap_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
+  roadmap_checklist_count
   roadmap_checklist_has_duplicate_phase_nums
 )
 MISSING_FUNCTIONS=()
@@ -267,18 +268,21 @@ phase_has_uat_issues() {
 }
 
 # --- Helper: find active phase dir (first incomplete phase) ------------------
-# Uses ordinal position (1-based index in sorted dir list) to match
-# state-updater.sh's Phase: N of M semantics, not directory prefixes.
-# Sets ACTIVE_PHASE_NUM (ordinal position for STATE.md comparison) and
+# Uses the selected ROADMAP display-numbering scheme for STATE.md comparison.
+# Sets ACTIVE_PHASE_NUM (display number for STATE.md comparison),
 # ACTIVE_PHASE_PREFIX (directory prefix number for .execution-state.json comparison).
 find_active_phase_num() {
   local phases_dir="$1"
+  local roadmap_file="${2:-${ROADMAP_FILE:-}}"
   ACTIVE_PHASE_NUM=""
   ACTIVE_PHASE_PREFIX=""
+  ACTIVE_PHASE_TOTAL=""
   [ -d "$phases_dir" ] || return 1
-  local plans complete phase_idx prefix_num
+  local plans complete phase_idx prefix_num active_ordinal active_prefix total_dirs scheme roadmap_total
   local dir=""
   phase_idx=0
+  active_ordinal=""
+  active_prefix=""
   while IFS= read -r dir; do
     [ -n "$dir" ] || continue
     phase_idx=$((phase_idx + 1))
@@ -288,15 +292,29 @@ find_active_phase_num() {
     plans=$(count_phase_plans "$dir")
     complete=$(count_complete_summaries "$dir")
     if [ "$plans" -eq 0 ] || [ "$complete" -lt "$plans" ] || phase_has_uat_issues "$dir"; then
-      ACTIVE_PHASE_NUM="$phase_idx"
-      ACTIVE_PHASE_PREFIX="$prefix_num"
-      return 0
+      active_ordinal="$phase_idx"
+      active_prefix="$prefix_num"
+      break
     fi
   done < <(list_canonical_phase_dirs "$phases_dir")
+  total_dirs="$phase_idx"
   # All phases complete — use the last ordinal position
-  if [ "$phase_idx" -gt 0 ]; then
-    ACTIVE_PHASE_NUM="$phase_idx"
-    ACTIVE_PHASE_PREFIX="$prefix_num"
+  if [ -z "$active_ordinal" ] && [ "$phase_idx" -gt 0 ]; then
+    active_ordinal="$phase_idx"
+    active_prefix="$prefix_num"
+  fi
+
+  ACTIVE_PHASE_NUM="$active_ordinal"
+  ACTIVE_PHASE_PREFIX="$active_prefix"
+  ACTIVE_PHASE_TOTAL="$total_dirs"
+
+  if [ -f "$roadmap_file" ]; then
+    scheme=$(roadmap_numbering_scheme "$roadmap_file" "$phases_dir")
+    if [ "$scheme" = "prefix" ] && [ -n "$active_prefix" ]; then
+      ACTIVE_PHASE_NUM="$active_prefix"
+      roadmap_total=$(roadmap_checklist_count "$roadmap_file")
+      [ "${roadmap_total:-0}" -gt 0 ] && ACTIVE_PHASE_TOTAL="$roadmap_total"
+    fi
   fi
   return 0
 }
@@ -327,18 +345,23 @@ run_check_state_vs_filesystem() {
     return
   fi
 
-  local fs_total
+  local fs_total expected_total
   fs_total=$(list_canonical_phase_dirs "$PHASES_DIR" | wc -l | tr -d ' ')
+  expected_total="$fs_total"
+
+  find_active_phase_num "$PHASES_DIR" "$ROADMAP_FILE"
+  if [ -n "${ACTIVE_PHASE_TOTAL:-}" ]; then
+    expected_total="$ACTIVE_PHASE_TOTAL"
+  fi
 
   local details=""
-  if [ "$STATE_PHASE_TOTAL" != "$fs_total" ]; then
-    details="phase total mismatch: STATE.md says $STATE_PHASE_TOTAL, filesystem has $fs_total"
+  if [ "$STATE_PHASE_TOTAL" != "$expected_total" ]; then
+    details="phase total mismatch: STATE.md says $STATE_PHASE_TOTAL, expected display total is $expected_total"
     check_state_vs_filesystem_pass=false
   fi
 
-  find_active_phase_num "$PHASES_DIR"
   if [ -n "$ACTIVE_PHASE_NUM" ] && [ "$STATE_PHASE_CURRENT" != "$ACTIVE_PHASE_NUM" ]; then
-    local msg="active phase mismatch: STATE.md says phase $STATE_PHASE_CURRENT, filesystem active phase is $ACTIVE_PHASE_NUM"
+    local msg="active phase mismatch: STATE.md says phase $STATE_PHASE_CURRENT, filesystem active display phase is $ACTIVE_PHASE_NUM"
     if [ -n "$details" ]; then
       details="$details; $msg"
     else

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -57,6 +57,7 @@ REQUIRED_FUNCTIONS=(
   roadmap_checklist_phase_num_from_line
   roadmap_phase_dir_prefix_num
   roadmap_numbering_scheme
+  roadmap_display_numbering_scheme
   roadmap_phase_num_for_dir
   roadmap_phase_dir_for_num
   roadmap_checklist_count
@@ -278,7 +279,7 @@ find_active_phase_num() {
   ACTIVE_PHASE_PREFIX=""
   ACTIVE_PHASE_TOTAL=""
   [ -d "$phases_dir" ] || return 1
-  local plans complete phase_idx prefix_num active_ordinal active_prefix total_dirs scheme roadmap_total
+  local plans complete phase_idx prefix_num active_ordinal active_prefix total_dirs scheme display_scheme roadmap_total
   local dir=""
   phase_idx=0
   active_ordinal=""
@@ -309,11 +310,12 @@ find_active_phase_num() {
 
   if [ -f "$roadmap_file" ]; then
     scheme=$(roadmap_numbering_scheme "$roadmap_file" "$phases_dir")
-    case "$scheme" in
+    roadmap_total=$(roadmap_checklist_count "$roadmap_file")
+    display_scheme=$(roadmap_display_numbering_scheme "$scheme" "$roadmap_total")
+    case "$display_scheme" in
       prefix)
         if [ -n "$active_prefix" ]; then
           ACTIVE_PHASE_NUM="$active_prefix"
-          roadmap_total=$(roadmap_checklist_count "$roadmap_file")
           [ "${roadmap_total:-0}" -gt 0 ] && ACTIVE_PHASE_TOTAL="$roadmap_total"
         fi
         ;;
@@ -402,10 +404,12 @@ run_check_roadmap_vs_summaries() {
   fi
 
   local mismatches=""
-  local phase_num checked plans complete phase_dir scheme
+  local phase_num checked plans complete phase_dir scheme display_scheme roadmap_total
   local seen_phases=""
 
   scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
+  roadmap_total=$(roadmap_checklist_count "$ROADMAP_FILE")
+  display_scheme=$(roadmap_display_numbering_scheme "$scheme" "$roadmap_total")
   if [ "$scheme" = "unknown" ]; then
     if type roadmap_numbering_mismatch_details >/dev/null 2>&1; then
       while IFS= read -r detail; do
@@ -484,7 +488,7 @@ run_check_roadmap_vs_summaries() {
   while IFS= read -r rd; do
     [ -n "$rd" ] || continue
     rd_idx=$((rd_idx + 1))
-    case "$scheme" in
+    case "$display_scheme" in
       ordinal)
         rd_num="$rd_idx"
         ;;
@@ -498,7 +502,7 @@ run_check_roadmap_vs_summaries() {
     case " $seen_phases " in
       *" $rd_num "*) ;; # found in roadmap
       *)
-        case "$scheme" in
+        case "$display_scheme" in
           ordinal)
             rd_base=$(basename "$rd")
             rd_prefix=$(roadmap_phase_dir_prefix_num "$rd")

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -407,7 +407,13 @@ run_check_roadmap_vs_summaries() {
 
   scheme=$(roadmap_numbering_scheme "$ROADMAP_FILE" "$PHASES_DIR")
   if [ "$scheme" = "unknown" ]; then
-    mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
+    if type roadmap_numbering_mismatch_details >/dev/null 2>&1; then
+      while IFS= read -r detail; do
+        [ -n "$detail" ] || continue
+        mismatches="${mismatches:+$mismatches, }$detail"
+      done < <(roadmap_numbering_mismatch_details "$ROADMAP_FILE" "$PHASES_DIR" "$scheme")
+    fi
+    [ -n "$mismatches" ] || mismatches="ROADMAP checklist numbering scheme is mixed or unresolvable"
     while IFS= read -r line || [ -n "$line" ]; do
       phase_num=$(roadmap_checklist_phase_num_from_line "$line") || continue
       case " $seen_phases " in

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -309,11 +309,18 @@ find_active_phase_num() {
 
   if [ -f "$roadmap_file" ]; then
     scheme=$(roadmap_numbering_scheme "$roadmap_file" "$phases_dir")
-    if [ "$scheme" = "prefix" ] && [ -n "$active_prefix" ]; then
-      ACTIVE_PHASE_NUM="$active_prefix"
-      roadmap_total=$(roadmap_checklist_count "$roadmap_file")
-      [ "${roadmap_total:-0}" -gt 0 ] && ACTIVE_PHASE_TOTAL="$roadmap_total"
-    fi
+    case "$scheme" in
+      prefix)
+        if [ -n "$active_prefix" ]; then
+          ACTIVE_PHASE_NUM="$active_prefix"
+          roadmap_total=$(roadmap_checklist_count "$roadmap_file")
+          [ "${roadmap_total:-0}" -gt 0 ] && ACTIVE_PHASE_TOTAL="$roadmap_total"
+        fi
+        ;;
+      unknown)
+        ACTIVE_PHASE_NUM=""
+        ;;
+    esac
   fi
   return 0
 }

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -260,6 +260,72 @@ ROADMAP
   [ "$status" -eq 0 ]
 }
 
+@test "reconcile-state preserves prefix numbers when ROADMAP has a missing phase dir" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 4 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Out Of Band):** Complete
+- **Phase 3 (Build):** Planned
+- **Phase 4 (Deploy):** Pending
+
+## Decisions
+- Preserve manual missing phase notes.
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [x] Phase 2: Out Of Band
+- [ ] Phase 3: Build
+- [ ] Phase 4: Deploy
+
+## Phase 1: Setup
+## Phase 2: Out Of Band
+## Phase 3: Build
+## Phase 4: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^Phase: 4 of 4 (Deploy)$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Out Of Band):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Build):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 4 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 2 (Build):\*\*' .vbw-planning/STATE.md
+  grep -q 'Preserve manual missing phase notes' .vbw-planning/STATE.md
+  grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'phase 2 referenced in ROADMAP.md but no matching phase directory'
+  echo "$output" | jq -r '.checks.state_vs_filesystem.detail' | grep -q '^ok$'
+}
+
 @test "reconcile-state repairs ordinal ROADMAP checklist drift by sorted phase position" {
   cat > .vbw-planning/PROJECT.md <<'PROJECT'
 # Test Project

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -378,6 +378,8 @@ ROADMAP
 
   grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
   grep -q '^- \[ \] Phase 3: Deploy$' .vbw-planning/ROADMAP.md
+  grep -q 'legacy ordinal ROADMAP numbering' .vbw-planning/.hook-errors.log
+  grep -q 'position 2 -> 03-build (prefix 3)' .vbw-planning/.hook-errors.log
 
   run bash "$SCRIPTS_DIR/verify-state-consistency.sh" .vbw-planning --mode archive
   if [ "$status" -ne 0 ]; then echo "$output" >&2; fi

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -502,6 +502,63 @@ ROADMAP
   echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
 }
 
+@test "reconcile-state treats duplicate phase directory prefixes as unknown" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Build):** Planned
+- **Phase 3 (Deploy):** Pending
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 3: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/02-build-a .vbw-planning/phases/02-build-b .vbw-planning/phases/03-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/02-build-a/02-01-PLAN.md
+  echo '# Plan' > .vbw-planning/phases/02-build-b/02-02-PLAN.md
+  echo '# Plan' > .vbw-planning/phases/03-deploy/03-01-PLAN.md
+
+  cp .vbw-planning/STATE.md "$TEST_TEMP_DIR/state-before.md"
+  cp .vbw-planning/ROADMAP.md "$TEST_TEMP_DIR/roadmap-before.md"
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  cmp -s "$TEST_TEMP_DIR/state-before.md" .vbw-planning/STATE.md
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.md" .vbw-planning/ROADMAP.md
+  grep -q 'state-numbering-warning' .vbw-planning/.hook-errors.log
+  grep -q 'duplicate phase directory prefix 2' .vbw-planning/.hook-errors.log
+  grep -q '02-build-a' .vbw-planning/.hook-errors.log
+  grep -q '02-build-b' .vbw-planning/.hook-errors.log
+}
+
 @test "reconcile-state skips quietly when ROADMAP helpers are missing" {
   local partial_scripts
   partial_scripts="$TEST_TEMP_DIR/partial-reconcile-scripts"

--- a/tests/state-reconcile.bats
+++ b/tests/state-reconcile.bats
@@ -326,6 +326,56 @@ ROADMAP
   echo "$output" | jq -r '.checks.state_vs_filesystem.detail' | grep -q '^ok$'
 }
 
+@test "reconcile-state uses ordinal display when ROADMAP checklist is empty" {
+  cat > .vbw-planning/PROJECT.md <<'PROJECT'
+# Test Project
+PROJECT
+
+  cat > .vbw-planning/STATE.md <<'STATE'
+# State
+
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Build):** Planned
+- **Phase 3 (Deploy):** Pending
+STATE
+
+  cat > .vbw-planning/ROADMAP.md <<'ROADMAP'
+# Roadmap
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 3: Deploy
+ROADMAP
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  run bash "$SCRIPTS_DIR/reconcile-state-md.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  grep -q '^Phase: 3 of 3 (Deploy)$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 1 (Setup):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Build):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 4 ' .vbw-planning/STATE.md
+  grep -q 'ROADMAP has no Phase checklist entries; using ordinal display numbering' .vbw-planning/.hook-errors.log
+}
+
 @test "reconcile-state repairs ordinal ROADMAP checklist drift by sorted phase position" {
   cat > .vbw-planning/PROJECT.md <<'PROJECT'
 # Test Project

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -753,6 +753,67 @@ EOF
   grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
 }
 
+@test "summary update uses ordinal display when ROADMAP checklist is empty" {
+  cd "$TEST_TEMP_DIR"
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Build):** Planned
+- **Phase 3 (Deploy):** Pending
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+
+| Phase | Progress | Status | Completed |
+|------|----------|--------|-----------|
+| 1 - Setup | 1/1 | complete | 2026-01-01 |
+| 2 - Build | 0/1 | pending | - |
+| 3 - Deploy | 0/1 | pending | - |
+EOF
+
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'phase: 3' 'plan: 1' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/03-build/03-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^Phase: 3 of 3 (Deploy)$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 1 (Setup):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Build):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 4 ' .vbw-planning/STATE.md
+
+  grep -Eq '^\| 2 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+  grep -q '^| 3 - Deploy | 0/1 | pending | - |$' .vbw-planning/ROADMAP.md
+  ! grep -Eq '^\| 4 - ' .vbw-planning/ROADMAP.md
+  grep -q 'ROADMAP has no Phase checklist entries; using ordinal display numbering' .vbw-planning/.hook-errors.log
+}
+
 @test "summary update leaves unknown ROADMAP checklist scheme untouched" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -681,6 +681,8 @@ EOF
   grep -q '^- \[x\] Phase 2: Build$' .vbw-planning/ROADMAP.md
   grep -q '^- \[ \] Phase 3: Deploy$' .vbw-planning/ROADMAP.md
   grep -Eq '^\| 2 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+  grep -q 'legacy ordinal ROADMAP numbering' .vbw-planning/.hook-errors.log
+  grep -q 'position 2 -> 03-build (prefix 3)' .vbw-planning/.hook-errors.log
 }
 
 @test "summary update preserves prefix numbering when ROADMAP has a missing phase dir" {

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -806,6 +806,66 @@ EOF
   echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail' | grep -q 'ROADMAP checklist numbering scheme is mixed or unresolvable'
 }
 
+@test "summary update treats duplicate phase directory prefixes as unknown" {
+  cd "$TEST_TEMP_DIR"
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/02-build-a .vbw-planning/phases/02-build-b .vbw-planning/phases/03-deploy
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Build):** Planned
+- **Phase 3 (Deploy):** Pending
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+| Phase | Progress | Status | Completed |
+|------|----------|--------|-----------|
+| 1 - Setup | 1/1 | complete | 2026-01-01 |
+| 2 - Build | 0/1 | pending | - |
+| 3 - Deploy | 0/1 | pending | - |
+EOF
+
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/02-build-a/02-01-PLAN.md
+  printf '%s\n' '---' 'phase: 2' 'plan: 1' 'status: complete' '---' 'Done.' > .vbw-planning/phases/02-build-a/02-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/02-build-b/02-02-PLAN.md
+  echo '# Plan' > .vbw-planning/phases/03-deploy/03-01-PLAN.md
+
+  cp .vbw-planning/STATE.md "$TEST_TEMP_DIR/state-before.md"
+  cp .vbw-planning/ROADMAP.md "$TEST_TEMP_DIR/roadmap-before.md"
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/02-build-a/02-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  cmp -s "$TEST_TEMP_DIR/state-before.md" .vbw-planning/STATE.md
+  cmp -s "$TEST_TEMP_DIR/roadmap-before.md" .vbw-planning/ROADMAP.md
+  grep -q 'state-numbering-warning' .vbw-planning/.hook-errors.log
+  grep -q 'duplicate phase directory prefix 2' .vbw-planning/.hook-errors.log
+  grep -q '02-build-a' .vbw-planning/.hook-errors.log
+  grep -q '02-build-b' .vbw-planning/.hook-errors.log
+}
+
 @test "summary update repairs resolvable ROADMAP despite stray extra entry" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/state-updater.bats
+++ b/tests/state-updater.bats
@@ -683,6 +683,74 @@ EOF
   grep -Eq '^\| 2 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
 }
 
+@test "summary update preserves prefix numbering when ROADMAP has a missing phase dir" {
+  cd "$TEST_TEMP_DIR"
+
+  mkdir -p .vbw-planning/phases/01-setup .vbw-planning/phases/03-build .vbw-planning/phases/04-deploy
+
+  cat > .vbw-planning/PROJECT.md <<'EOF'
+# Test Project
+EOF
+
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+**Project:** Test Project
+**Milestone:** MVP
+
+## Current Phase
+Phase: 3 of 4 (Build)
+Plans: 0/1
+Progress: 0%
+Status: ready
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Out Of Band):** Complete
+- **Phase 3 (Build):** Planned
+- **Phase 4 (Deploy):** Pending
+EOF
+
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [x] Phase 2: Out Of Band
+- [ ] Phase 3: Build
+- [ ] Phase 4: Deploy
+
+| Phase | Progress | Status | Completed |
+|------|----------|--------|-----------|
+| 1 - Setup | 1/1 | complete | 2026-01-01 |
+| 2 - Out Of Band | 1/1 | complete | 2026-01-01 |
+| 3 - Build | 0/1 | pending | - |
+| 4 - Deploy | 0/1 | pending | - |
+EOF
+
+  echo '# Plan' > .vbw-planning/phases/01-setup/01-01-PLAN.md
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > .vbw-planning/phases/01-setup/01-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/03-build/03-01-PLAN.md
+  printf '%s\n' '---' 'phase: 3' 'plan: 1' 'status: complete' '---' 'Done.' > .vbw-planning/phases/03-build/03-01-SUMMARY.md
+  echo '# Plan' > .vbw-planning/phases/04-deploy/04-01-PLAN.md
+
+  local summary_path input
+  summary_path="$TEST_TEMP_DIR/.vbw-planning/phases/03-build/03-01-SUMMARY.md"
+  input=$(jq -nc --arg p "$summary_path" '{tool_input:{file_path:$p}}')
+
+  run bash -c "cd '$TEST_TEMP_DIR' && printf '%s' '$input' | bash '$SCRIPTS_DIR/state-updater.sh'"
+  [ "$status" -eq 0 ]
+
+  grep -q '^Phase: 4 of 4 (Deploy)$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Out Of Band):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Build):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 4 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 2 (Build):\*\*' .vbw-planning/STATE.md
+
+  grep -q '^- \[x\] Phase 3: Build$' .vbw-planning/ROADMAP.md
+  grep -q '^- \[ \] Phase 4: Deploy$' .vbw-planning/ROADMAP.md
+  grep -Eq '^\| 3 - Build \| 1/1 \| complete \| [0-9]{4}-[0-9]{2}-[0-9]{2} \|$' .vbw-planning/ROADMAP.md
+  grep -q '^| 2 - Out Of Band | 1/1 | complete | 2026-01-01 |$' .vbw-planning/ROADMAP.md
+  grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
+}
+
 @test "summary update leaves unknown ROADMAP checklist scheme untouched" {
   cd "$TEST_TEMP_DIR"
 

--- a/tests/update-phase-total.bats
+++ b/tests/update-phase-total.bats
@@ -581,6 +581,49 @@ EOF
   grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
 }
 
+@test "update-phase-total: uses ordinal name when ROADMAP checklist is empty" {
+  cd "$TEST_TEMP_DIR"
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+## Current Phase
+Phase: 2 of 3 (Old Name)
+Plans: 0/0
+Progress: 0%
+Status: active
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Old Name):** Pending
+- **Phase 3 (Deploy):** Pending
+EOF
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+
+## Phase 1: Setup
+## Phase 2: Build
+## Phase 3: Deploy
+EOF
+  mkdir -p .vbw-planning/phases/01-setup
+  mkdir -p .vbw-planning/phases/03-build
+  mkdir -p .vbw-planning/phases/04-deploy
+  touch .vbw-planning/phases/01-setup/01-PLAN.md
+  printf -- '---\nstatus: complete\n---\n' > .vbw-planning/phases/01-setup/01-SUMMARY.md
+  touch .vbw-planning/phases/03-build/03-PLAN.md
+  touch .vbw-planning/phases/04-deploy/04-PLAN.md
+
+  run bash "$SCRIPTS_DIR/update-phase-total.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+
+  grep -q '^Phase: 2 of 3 (Build)' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 1 (Setup):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Build):\*\* Planned$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 4 ' .vbw-planning/STATE.md
+  ! ls .vbw-planning/STATE.md.* >/dev/null 2>&1
+  grep -q 'ROADMAP has no Phase checklist entries; using ordinal display numbering' .vbw-planning/.hook-errors.log
+}
+
 @test "update-phase-total: treats duplicate phase directory prefixes as unknown" {
   cd "$TEST_TEMP_DIR"
   cat > .vbw-planning/STATE.md <<'EOF'

--- a/tests/update-phase-total.bats
+++ b/tests/update-phase-total.bats
@@ -581,6 +581,50 @@ EOF
   grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
 }
 
+@test "update-phase-total: treats duplicate phase directory prefixes as unknown" {
+  cd "$TEST_TEMP_DIR"
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+## Current Phase
+Phase: 2 of 3 (Build)
+Plans: 0/0
+Progress: 0%
+Status: active
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Build):** Planned
+- **Phase 3 (Deploy):** Pending
+EOF
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+EOF
+  mkdir -p .vbw-planning/phases/01-setup
+  mkdir -p .vbw-planning/phases/02-build-a
+  mkdir -p .vbw-planning/phases/02-build-b
+  mkdir -p .vbw-planning/phases/03-deploy
+  touch .vbw-planning/phases/01-setup/01-PLAN.md
+  printf -- '---\nstatus: complete\n---\n' > .vbw-planning/phases/01-setup/01-SUMMARY.md
+  touch .vbw-planning/phases/02-build-a/02-PLAN.md
+  touch .vbw-planning/phases/02-build-b/02-PLAN.md
+  touch .vbw-planning/phases/03-deploy/03-PLAN.md
+  cp .vbw-planning/STATE.md "$TEST_TEMP_DIR/state-before.md"
+
+  run bash "$SCRIPTS_DIR/update-phase-total.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+
+  cmp -s "$TEST_TEMP_DIR/state-before.md" .vbw-planning/STATE.md
+  ! ls .vbw-planning/STATE.md.* >/dev/null 2>&1
+  grep -q 'state-numbering-warning' .vbw-planning/.hook-errors.log
+  grep -q 'duplicate phase directory prefix 2' .vbw-planning/.hook-errors.log
+  grep -q '02-build-a' .vbw-planning/.hook-errors.log
+  grep -q '02-build-b' .vbw-planning/.hook-errors.log
+}
+
 # --- F-12: blank line before next heading after empty Phase Status ---
 
 @test "update-phase-total: emits blank line before next heading after Phase Status" {

--- a/tests/update-phase-total.bats
+++ b/tests/update-phase-total.bats
@@ -519,6 +519,12 @@ Status: active
 - **Phase 2:** Pending
 - **Phase 3:** Pending
 EOF
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+EOF
   # Create dirs with a gap: 01, 03, 04 (no 02)
   mkdir -p .vbw-planning/phases/01-setup
   mkdir -p .vbw-planning/phases/03-build
@@ -529,6 +535,8 @@ EOF
   grep -q '^Phase: 2 of 3 (Build)' .vbw-planning/STATE.md
   # Bullet 2 should also say Build
   grep -q '^\- \*\*Phase 2 (Build):\*\*' .vbw-planning/STATE.md
+  grep -q 'legacy ordinal ROADMAP numbering' .vbw-planning/.hook-errors.log
+  grep -q 'position 2 -> 03-build (prefix 3)' .vbw-planning/.hook-errors.log
 }
 
 @test "update-phase-total: preserves ROADMAP prefix numbers with missing phase dir" {

--- a/tests/update-phase-total.bats
+++ b/tests/update-phase-total.bats
@@ -531,6 +531,48 @@ EOF
   grep -q '^\- \*\*Phase 2 (Build):\*\*' .vbw-planning/STATE.md
 }
 
+@test "update-phase-total: preserves ROADMAP prefix numbers with missing phase dir" {
+  cd "$TEST_TEMP_DIR"
+  cat > .vbw-planning/STATE.md <<'EOF'
+# State
+
+## Current Phase
+Phase: 3 of 4 (Build)
+Plans: 0/0
+Progress: 0%
+Status: active
+
+## Phase Status
+- **Phase 1 (Setup):** Complete
+- **Phase 2 (Out Of Band):** Complete
+- **Phase 3 (Build):** Pending
+- **Phase 4 (Deploy):** Pending
+EOF
+  cat > .vbw-planning/ROADMAP.md <<'EOF'
+# Roadmap
+- [x] Phase 1: Setup
+- [x] Phase 2: Out Of Band
+- [ ] Phase 3: Build
+- [ ] Phase 4: Deploy
+EOF
+  mkdir -p .vbw-planning/phases/01-setup
+  mkdir -p .vbw-planning/phases/03-build
+  mkdir -p .vbw-planning/phases/04-deploy
+  touch .vbw-planning/phases/01-setup/01-PLAN.md
+  printf -- '---\nstatus: complete\n---\n' > .vbw-planning/phases/01-setup/01-SUMMARY.md
+  touch .vbw-planning/phases/03-build/03-PLAN.md
+  touch .vbw-planning/phases/04-deploy/04-PLAN.md
+
+  run bash "$SCRIPTS_DIR/update-phase-total.sh" .vbw-planning
+  [ "$status" -eq 0 ]
+  grep -q '^Phase: 3 of 4 (Build)' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 2 (Out Of Band):\*\* Complete$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 3 (Build):\*\* Planned$' .vbw-planning/STATE.md
+  grep -q '^- \*\*Phase 4 (Deploy):\*\* Planned$' .vbw-planning/STATE.md
+  ! grep -q '^- \*\*Phase 2 (Build):\*\*' .vbw-planning/STATE.md
+  grep -q 'ROADMAP phase 2 has no matching 2-\* phase directory' .vbw-planning/.hook-errors.log
+}
+
 # --- F-12: blank line before next heading after empty Phase Status ---
 
 @test "update-phase-total: emits blank line before next heading after Phase Status" {

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -57,6 +57,49 @@ SUMMARY
   mkdir -p "$root/phases/03-frontend"
 }
 
+write_legacy_ordinal_active_middle_fixture() {
+  local state_total="$1"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<EOF
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of ${state_total} (Build)
+Plans: 0/1
+Progress: 0%
+Status: running
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+Core value proposition for testing.
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 3: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo "# Plan" > "$root/phases/01-setup/01-01-PLAN.md"
+  cat > "$root/phases/01-setup/01-01-SUMMARY.md" <<'SUMMARY'
+---
+status: complete
+---
+# Summary
+SUMMARY
+  echo "# Plan" > "$root/phases/03-build/03-01-PLAN.md"
+  echo "# Plan" > "$root/phases/04-deploy/04-01-PLAN.md"
+}
+
 # ============================================================
 # Happy path
 # ============================================================
@@ -553,6 +596,29 @@ SUMMARY
   local phase_pass
   phase_pass=$(echo "$output" | jq -r '.checks.state_vs_filesystem.pass')
   [ "$phase_pass" = "true" ]
+}
+
+@test "state_vs_filesystem passes legacy ordinal active phase before final dir" {
+  cd "$TEST_TEMP_DIR"
+  write_legacy_ordinal_active_middle_fixture 3
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  if [ "$status" -ne 0 ]; then echo "$output" >&2; fi
+  [ "$status" -eq 0 ]
+
+  echo "$output" | jq -e '.verdict == "pass"' >/dev/null
+  echo "$output" | jq -e '.checks.state_vs_filesystem.pass == true' >/dev/null
+}
+
+@test "state_vs_filesystem rejects truncated legacy ordinal total" {
+  cd "$TEST_TEMP_DIR"
+  write_legacy_ordinal_active_middle_fixture 2
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  [ "$status" -eq 2 ]
+
+  echo "$output" | jq -e '.checks.state_vs_filesystem.pass == false' >/dev/null
+  echo "$output" | jq -r '.checks.state_vs_filesystem.detail' | grep -q 'expected display total is 3'
 }
 
 @test "exec_state plan with only generic SUMMARY.md fails" {

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -501,12 +501,13 @@ EOF
   [ "$mode" = "advisory" ]
 }
 
-@test "state_vs_filesystem passes with non-contiguous phase dirs" {
+@test "state_vs_filesystem passes with legacy ordinal non-contiguous phase dirs" {
   cd "$TEST_TEMP_DIR"
   local root="$TEST_TEMP_DIR/.vbw-planning"
 
-  # STATE says Phase 2 of 2 — only 2 phase dirs but numbered 01 and 03
-  # Verifier uses ordinal position (2nd dir = phase 2), not prefix (03)
+  # STATE says Phase 2 of 2 — only 2 phase dirs but numbered 01 and 03.
+  # ROADMAP uses the exact legacy ordinal signature (Phase 1, Phase 2), so the
+  # verifier uses sorted position (2nd dir = phase 2), not prefix (03).
   cat > "$root/STATE.md" <<'EOF'
 # State
 **Project:** My Test Project
@@ -526,10 +527,10 @@ EOF
 # Roadmap
 
 - [x] Phase 1: Setup
-- [ ] Phase 3: Build
+- [ ] Phase 2: Build
 
 ### Phase 1: Setup
-### Phase 3: Build
+### Phase 2: Build
 EOF
 
   # Non-contiguous: 01 and 03 (no 02)
@@ -548,7 +549,7 @@ SUMMARY
   run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
   [ "$status" -eq 0 ]
 
-  # Active phase is ordinal 2 (second dir), STATE says phase 2 — should match
+  # Active phase is ordinal 2 (second dir), STATE says phase 2 — should match.
   local phase_pass
   phase_pass=$(echo "$output" | jq -r '.checks.state_vs_filesystem.pass')
   [ "$phase_pass" = "true" ]
@@ -2023,7 +2024,7 @@ EOF
   [ "$c4_pass" = "true" ]
 }
 
-@test "roadmap_vs_summaries detects phase dir missing from roadmap" {
+@test "roadmap_vs_summaries treats phase dir missing from roadmap as unknown scheme" {
   cd "$TEST_TEMP_DIR"
   scaffold_consistent_workspace
 
@@ -2041,10 +2042,10 @@ ROADMAP
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
   [ "$c2_pass" = "false" ]
-  [[ "$c2_detail" == *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
 }
 
-@test "roadmap_vs_summaries describes missing ordinal checklist entry with actual dir" {
+@test "roadmap_vs_summaries does not guess ordinal mapping for mixed checklist gaps" {
   cd "$TEST_TEMP_DIR"
   local root="$TEST_TEMP_DIR/.vbw-planning"
 
@@ -2084,10 +2085,9 @@ EOF
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
   [ "$c2_pass" = "false" ]
-  [[ "$c2_detail" == *"ordinal phase position 2"* ]]
-  [[ "$c2_detail" == *"03-build"* ]]
-  [[ "$c2_detail" == *"prefix 3"* ]]
-  [[ "$c2_detail" == *"no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" != *"ordinal phase position 2"* ]]
+  [[ "$c2_detail" != *"03-build"* ]]
   [[ "$c2_detail" != *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2251,11 +2251,19 @@ EOF
   run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
   [ "$status" -eq 0 ]
 
-  local c2_pass c2_detail
+  local c1_pass c1_detail c2_pass c2_detail failed_state
+  c1_pass=$(echo "$output" | jq -r '.checks.state_vs_filesystem.pass')
+  c1_detail=$(echo "$output" | jq -r '.checks.state_vs_filesystem.detail')
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  failed_state=$(echo "$output" | jq -r '.failed_checks | index("state_vs_filesystem") // empty')
+  [ "$c1_pass" = "true" ]
+  [ "$c1_detail" = "ok" ]
+  [ -z "$failed_state" ]
   [ "$c2_pass" = "false" ]
   [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c1_detail" != *"active phase mismatch"* ]]
+  [[ "$c1_detail" != *"filesystem active display phase is 3"* ]]
   [[ "$c2_detail" != *"phase 1 referenced in ROADMAP.md but no matching phase directory"* ]]
   [[ "$c2_detail" != *"phase 2 referenced in ROADMAP.md but no matching phase directory"* ]]
   [[ "$c2_detail" != *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -1595,9 +1595,9 @@ EOF
   c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
   c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
   [ "$c2_pass" = "false" ]
-  [[ "$c2_detail" == *"phase directory 1 exists on disk but no matching ROADMAP checklist entry"* ]]
-  [[ "$c2_detail" == *"phase directory 2 exists on disk but no matching ROADMAP checklist entry"* ]]
-  [[ "$c2_detail" == *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]
+  [[ "$c2_detail" == *"ordinal phase position 1 maps to phase directory 01-setup"* ]]
+  [[ "$c2_detail" == *"ordinal phase position 2 maps to phase directory 02-backend-api"* ]]
+  [[ "$c2_detail" == *"ordinal phase position 3 maps to phase directory 03-frontend"* ]]
   [[ "$c2_detail" != *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
 }
 
@@ -2268,6 +2268,54 @@ EOF
   [[ "$c2_detail" != *"phase 2 referenced in ROADMAP.md but no matching phase directory"* ]]
   [[ "$c2_detail" != *"phase directory 3 exists on disk but no matching ROADMAP checklist entry"* ]]
   [[ "$c2_detail" != *"phase directory 4 exists on disk but no matching ROADMAP checklist entry"* ]]
+}
+
+@test "state_vs_filesystem uses ordinal display when ROADMAP checklist is empty" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: running
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 3: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/03-build" "$root/phases/04-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/03-build/03-01-PLAN.md"
+  echo '# Plan' > "$root/phases/04-deploy/04-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c1_pass c1_detail c2_pass c2_detail
+  c1_pass=$(echo "$output" | jq -r '.checks.state_vs_filesystem.pass')
+  c1_detail=$(echo "$output" | jq -r '.checks.state_vs_filesystem.detail')
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c1_pass" = "true" ]
+  [ "$c1_detail" = "ok" ]
+  [ "$c2_pass" = "false" ]
+  [[ "$c2_detail" == *"no matching ROADMAP checklist entry"* ]]
+  [[ "$c1_detail" != *"active phase mismatch"* ]]
+  [[ "$c1_detail" != *"filesystem active display phase is 3"* ]]
 }
 
 @test "roadmap_vs_summaries treats duplicate phase directory prefixes as unknown" {

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2270,6 +2270,57 @@ EOF
   [[ "$c2_detail" != *"phase directory 4 exists on disk but no matching ROADMAP checklist entry"* ]]
 }
 
+@test "roadmap_vs_summaries treats duplicate phase directory prefixes as unknown" {
+  cd "$TEST_TEMP_DIR"
+  local root="$TEST_TEMP_DIR/.vbw-planning"
+
+  cat > "$root/STATE.md" <<'EOF'
+# State
+**Project:** My Test Project
+**Milestone:** MVP
+Phase: 2 of 3 (Build)
+Plans: 0/1
+Progress: 0%
+Status: running
+EOF
+
+  cat > "$root/PROJECT.md" <<'EOF'
+# My Test Project
+EOF
+
+  cat > "$root/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] Phase 1: Setup
+- [ ] Phase 2: Build
+- [ ] Phase 3: Deploy
+
+### Phase 1: Setup
+### Phase 2: Build
+### Phase 3: Deploy
+EOF
+
+  mkdir -p "$root/phases/01-setup" "$root/phases/02-build-a" "$root/phases/02-build-b" "$root/phases/03-deploy"
+  echo '# Plan' > "$root/phases/01-setup/01-01-PLAN.md"
+  printf '%s\n' '---' 'status: complete' '---' 'Done.' > "$root/phases/01-setup/01-01-SUMMARY.md"
+  echo '# Plan' > "$root/phases/02-build-a/02-01-PLAN.md"
+  echo '# Plan' > "$root/phases/02-build-b/02-02-PLAN.md"
+  echo '# Plan' > "$root/phases/03-deploy/03-01-PLAN.md"
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$root" --mode archive
+  [ "$status" -eq 2 ]
+
+  local c2_pass c2_detail
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  c2_detail=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.detail')
+  [ "$c2_pass" = "false" ]
+  echo "$output" | jq -e '.failed_checks | index("roadmap_vs_summaries")' >/dev/null
+  [[ "$c2_detail" == *"ROADMAP checklist numbering scheme is mixed or unresolvable"* ]]
+  [[ "$c2_detail" == *"duplicate phase directory prefix 2"* ]]
+  [[ "$c2_detail" == *"02-build-a"* ]]
+  [[ "$c2_detail" == *"02-build-b"* ]]
+}
+
 @test "roadmap_vs_summaries reports duplicates when numbering scheme is unknown" {
   cd "$TEST_TEMP_DIR"
   local root="$TEST_TEMP_DIR/.vbw-planning"


### PR DESCRIPTION
## Linked Issue

Fixes #598

## What

This fixes silent `STATE.md`/`ROADMAP.md` phase-number drift when ROADMAP checklist numbers and on-disk phase directory prefixes diverge. The change centralizes ROADMAP/display-numbering selection in `scripts/phase-state-utils.sh`, then has `state-updater.sh`, `reconcile-state-md.sh`, `update-phase-total.sh`, and `verify-state-consistency.sh` all use that shared invariant.

## Why

The root cause was that VBW could infer sorted-position/ordinal numbering when prefix numbering was still the safe representation, which compacted phases after a missing ROADMAP slot and rewrote authoritative planning state with off-by-one labels. The durable fix is to make the numbering scheme explicit and shared: unique prefix-aligned dirs preserve prefix numbers and missing slots; only exact legacy `Phase 1..N` ROADMAPs use ordinal numbering; mixed or ambiguous states fail open with warnings instead of guessed rewrites.

## How

- `scripts/phase-state-utils.sh`: adds shared ROADMAP checklist parsing/numbering helpers, raw/effective display scheme selection, mismatch diagnostics, fail-open `.hook-errors.log` warning support, and defensive duplicate-prefix handling.
- `scripts/state-updater.sh`: routes ROADMAP mutation through the shared scheme, uses ordinal display for empty-checklist ROADMAPs, and skips numbering-dependent rewrites when the scheme is unknown.
- `scripts/reconcile-state-md.sh`: rebuilds `STATE.md` current phase and `## Phase Status` with the shared effective display scheme so prefix gaps preserve missing slots while headings-only ROADMAPs stay ordinal-consistent.
- `scripts/update-phase-total.sh`: recalculates display totals/status bullets with the shared effective display scheme and exits fail-open on unknown numbering after logging.
- `scripts/verify-state-consistency.sh`: verifies active phase and ROADMAP/SUMMARY consistency against the same shared scheme and reports unknown/ambiguous numbering as verifier failures.
- `tests/state-updater.bats`, `tests/state-reconcile.bats`, `tests/update-phase-total.bats`, `tests/verify-state-consistency.bats`: add regressions for prefix gaps, exact legacy ordinal support, empty-checklist ROADMAP display, mixed unknown states, duplicate ROADMAP entries, and duplicate phase-directory prefixes.

## Acceptance criteria verification

1. Missing `N-*` dirs do not compact later phases: satisfied by prefix-mode scheme selection in `phase-state-utils.sh` and regressions covering PostToolUse SUMMARY, direct reconciliation, verifier behavior, and phase-total rebuild.
2. `state-updater.sh` remains fail-open and logs warnings: satisfied by `phase_state_log_numbering_warnings`/`.hook-errors.log` coverage and hook-path tests asserting exit `0` with warnings.
3. Legacy ordinal numbering is constrained to exact `Phase 1..N`: satisfied by `_roadmap_sequence_is_exact_ordinal` usage plus legacy ordinal and mixed/unknown regressions.
4. Reconciliation, verification, and phase-total rebuild share the invariant: satisfied by moving the numbering policy to `phase-state-utils.sh` and updating all deterministic state paths to consume it.
5. Regression coverage includes all required paths: satisfied by BATS coverage in the four touched test suites.

## Testing

- [x] `bats tests/state-updater.bats tests/state-reconcile.bats tests/update-phase-total.bats tests/verify-state-consistency.bats` — 170 passed, 0 failed after Copilot remediation
- [x] `bash testing/verify-bash-scripts-contract.sh`
- [x] `bash testing/verify-roadmap-checklist-parser-contract.sh`
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh` — lint 1/1, contracts 51/51, BATS 3504 passed / 0 failed after Copilot remediation
- [x] GitHub Actions on `3dad70717095af1fabca40c77c6f22dec418c3f1` — all 18 checks passed

## QA summary

- Primary QA rounds: 4 total
  - Round 1: fixed 1 high contract finding (legacy ordinal active-phase verifier total)
  - Round 2: fixed 2 medium contract findings (ordinal warning detail and unknown-scheme active display guessing)
  - Round 3: fixed 1 medium contract finding (duplicate phase-directory prefixes treated as ambiguous)
  - Round 4: clean, zero legitimate findings
- Cross-model QA: skipped by workflow gate because this is a GPT-class Copilot session and no different-family cross-model reviewer is eligible.
- Copilot PR review rounds: 2 total
  - Round 1: fixed 2 comments about empty-checklist ROADMAPs mixing prefix and ordinal display in reconciliation/phase-total paths (`3dad7071`)
  - Round 2: clean, no new comments; zero unresolved Copilot threads
- CI/CD: green, all required checks passed.
- Post-review main sync: no new commits on `origin/main`; no conflict-resolution QA rerun required.

## Notes

GitNexus symbol impact lookups did not resolve the bash helper symbols in the indexed worktree, so blast radius was treated as unknown/high caution. Practical touched surface is limited to deterministic state-numbering helpers and their direct state updater/reconciler/verifier call sites.