### PR TITLE
fix(verify): show deviation context in UAT prompt

### DIFF
--- a/commands/verify.md
+++ b/commands/verify.md
@@ -597,9 +597,13 @@ options:
 
 The tool automatically provides a freeform "Other" option for the user to describe issues.
 
-**Summary-deviation checkpoint prompt:** When the current checkpoint is a prefilled `D{NN}` summary-deviation review, present the deviation text and source metadata instead of a product scenario. Ask whether the documented deviation is acceptable for this phase. Use the same two visible options, but interpret them as:
-- `Pass` → accept the deviation as a non-blocking process exception for this phase.
-- `Skip` → skip review for now without recording acceptance.
+**Summary-deviation checkpoint prompt:** When the current checkpoint is a prefilled `D{NN}` summary-deviation review, present the deviation text and source metadata instead of a product scenario.
+- The CHECKPOINT display must be self-contained: include a compact `Deviation: {text}` line from the entry's `**Deviation:**` field and `Source: {source_path} ({source_plan})` from `**Source Summary:**` and `**Source Plan:**`. Include `Deviation Signature: {signature}` only when it helps distinguish similar deviations.
+- The AskUserQuestion `question` value MUST also be self-contained. Include the same compact `Deviation: {text}` and `Source: {source_path} ({source_plan})` lines in the tool question, then ask: `Accept this documented deviation as non-blocking for this phase?`
+- The generic artifact expectation, `Expected: Human confirms whether this documented deviation is acceptable for this phase.`, is not enough by itself. It must not be the only visible AskUserQuestion question for a prefilled `D{NN}` summary-deviation checkpoint.
+- Use the same two visible option labels, but override their descriptions for this checkpoint type:
+  - `Pass` → `Accept this deviation as non-blocking for this phase`
+  - `Skip` → `Leave this deviation unaccepted for now`
 - freeform/Other → record the text as a real UAT issue if it describes why the deviation is unacceptable or exposes a product defect.
 
 **AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, JSON, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the checkpoint will not be presented to the user and the session will end prematurely.

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -949,9 +949,13 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
 
    The tool automatically provides a freeform "Other" option for the user to describe issues.
 
-  **Summary-deviation checkpoint prompt:** If the current checkpoint is a prefilled `D{NN}` summary-deviation review, show the deviation text and source metadata instead of a product scenario. Ask whether the documented deviation is acceptable for this phase. Interpret responses as:
-  - `Pass` → accept the deviation as a non-blocking process exception for this phase.
-  - `Skip` → skip review for now; do not record acceptance.
+  **Summary-deviation checkpoint prompt:** If the current checkpoint is a prefilled `D{NN}` summary-deviation review, show the deviation text and source metadata instead of a product scenario.
+  - The CHECKPOINT display must be self-contained: include a compact `Deviation: {text}` line from the entry's `**Deviation:**` field and `Source: {source_path} ({source_plan})` from `**Source Summary:**` and `**Source Plan:**`. Include `Deviation Signature: {signature}` only when it helps distinguish similar deviations.
+  - The AskUserQuestion `question` value MUST also be self-contained. Include the same compact `Deviation: {text}` and `Source: {source_path} ({source_plan})` lines in the tool question, then ask: `Accept this documented deviation as non-blocking for this phase?`
+  - The generic artifact expectation, `Expected: Human confirms whether this documented deviation is acceptable for this phase.`, is not enough by itself. It must not be the only visible AskUserQuestion question for a prefilled `D{NN}` summary-deviation checkpoint.
+  - Use the same two visible option labels, but override their descriptions for this checkpoint type:
+    - `Pass` → `Accept this deviation as non-blocking for this phase`
+    - `Skip` → `Leave this deviation unaccepted for now`
   - Freeform/Other → record the response as a UAT issue if it explains why the deviation is unacceptable or reveals a product defect.
 
    **STOP HERE.** Wait for the AskUserQuestion response. Do NOT continue to the next test or to Step 5.

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -25,10 +25,12 @@ REFERENCES_DIR="$ROOT/references"
 
 ASK_USER_QUESTION_REF="$REFERENCES_DIR/ask-user-question.md"
 VIBE_COMMAND_FILE="$COMMANDS_DIR/vibe.md"
+VERIFY_COMMAND_FILE="$COMMANDS_DIR/verify.md"
 INIT_COMMAND_FILE="$COMMANDS_DIR/init.md"
 LIST_TODOS_COMMAND_FILE="$COMMANDS_DIR/list-todos.md"
 CONFIG_COMMAND_FILE="$COMMANDS_DIR/config.md"
 SKILLS_COMMAND_FILE="$COMMANDS_DIR/skills.md"
+EXECUTE_PROTOCOL_FILE="$REFERENCES_DIR/execute-protocol.md"
 
 tracked_command_markdown_files() {
   local rel
@@ -447,6 +449,43 @@ if grep -Eq '2[-–]4 options|1[-–]4 questions|high-cardinality' <<< "$VIBE_CO
 else
   pass "vibe: confirmation gate does not duplicate generic AskUserQuestion guidance"
 fi
+
+# --------------------------------------------------------------------------
+# Check 4b: Summary-deviation UAT prompts are self-contained in AskUserQuestion
+# --------------------------------------------------------------------------
+
+echo ""
+echo "--- Check 4b: Summary-deviation UAT prompt context ---"
+
+VERIFY_DEVIATION_PROMPT_BLOCK="$(extract_regex_block "$VERIFY_COMMAND_FILE" 'Summary-deviation checkpoint prompt' 'AskUserQuestion is a tool call' || true)"
+EXECUTE_DEVIATION_PROMPT_BLOCK="$(extract_regex_block "$EXECUTE_PROTOCOL_FILE" 'Summary-deviation checkpoint prompt' 'STOP HERE' || true)"
+
+if [ -n "$VERIFY_DEVIATION_PROMPT_BLOCK" ]; then
+  pass "verify: summary-deviation prompt block extracted"
+else
+  fail "verify: summary-deviation prompt block extracted"
+fi
+
+if [ -n "$EXECUTE_DEVIATION_PROMPT_BLOCK" ]; then
+  pass "execute-protocol: summary-deviation prompt block extracted"
+else
+  fail "execute-protocol: summary-deviation prompt block extracted"
+fi
+
+for prompt_target in \
+  "verify:$VERIFY_DEVIATION_PROMPT_BLOCK" \
+  "execute-protocol:$EXECUTE_DEVIATION_PROMPT_BLOCK"; do
+  prompt_label="${prompt_target%%:*}"
+  prompt_block="${prompt_target#*:}"
+
+  require_text_literal "$prompt_label: DNN modal question includes deviation line" 'Deviation: {text}' "$prompt_block"
+  require_text_literal "$prompt_label: DNN modal question includes source metadata" 'Source: {source_path} ({source_plan})' "$prompt_block"
+  require_text_literal "$prompt_label: DNN modal question names AskUserQuestion question value" 'AskUserQuestion `question` value MUST also be self-contained' "$prompt_block"
+  require_text_literal "$prompt_label: DNN modal asks non-blocking acceptance question" 'Accept this documented deviation as non-blocking for this phase?' "$prompt_block"
+  require_text_literal "$prompt_label: DNN modal forbids generic expected-only question" 'must not be the only visible AskUserQuestion question' "$prompt_block"
+  require_text_literal "$prompt_label: DNN Pass option accepts non-blocking deviation" 'Accept this deviation as non-blocking for this phase' "$prompt_block"
+  require_text_literal "$prompt_label: DNN Skip option leaves deviation unaccepted" 'Leave this deviation unaccepted for now' "$prompt_block"
+done
 
 # --------------------------------------------------------------------------
 # Check 5: /vbw:list-todos intentional plain-text/freeform handoff

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -138,6 +138,27 @@ extract_regex_block() {
   ' "$file"
 }
 
+extract_bullet_block_from_text() {
+  local text="$1"
+  local start_regex="$2"
+
+  awk -v start_re="$start_regex" '
+    $0 ~ start_re {
+      found=1
+      print
+      next
+    }
+
+    found && $0 ~ /^[[:space:]]*-[[:space:]]+/ {
+      exit
+    }
+
+    found {
+      print
+    }
+  ' <<< "$text"
+}
+
 count_text_occurrences() {
   local text="$1"
   local needle="$2"
@@ -477,11 +498,27 @@ for prompt_target in \
   "execute-protocol:$EXECUTE_DEVIATION_PROMPT_BLOCK"; do
   prompt_label="${prompt_target%%:*}"
   prompt_block="${prompt_target#*:}"
+  checkpoint_display_block="$(extract_bullet_block_from_text "$prompt_block" 'CHECKPOINT display must be self-contained' || true)"
+  modal_question_block="$(extract_bullet_block_from_text "$prompt_block" 'AskUserQuestion `question` value MUST also be self-contained' || true)"
 
-  require_text_literal "$prompt_label: DNN modal question includes deviation line" 'Deviation: {text}' "$prompt_block"
-  require_text_literal "$prompt_label: DNN modal question includes source metadata" 'Source: {source_path} ({source_plan})' "$prompt_block"
-  require_text_literal "$prompt_label: DNN modal question names AskUserQuestion question value" 'AskUserQuestion `question` value MUST also be self-contained' "$prompt_block"
-  require_text_literal "$prompt_label: DNN modal asks non-blocking acceptance question" 'Accept this documented deviation as non-blocking for this phase?' "$prompt_block"
+  if [ -n "$checkpoint_display_block" ]; then
+    pass "$prompt_label: DNN checkpoint display sub-block extracted"
+  else
+    fail "$prompt_label: DNN checkpoint display sub-block extracted"
+  fi
+
+  if [ -n "$modal_question_block" ]; then
+    pass "$prompt_label: DNN modal question sub-block extracted"
+  else
+    fail "$prompt_label: DNN modal question sub-block extracted"
+  fi
+
+  require_text_literal "$prompt_label: DNN checkpoint display includes deviation line" 'Deviation: {text}' "$checkpoint_display_block"
+  require_text_literal "$prompt_label: DNN checkpoint display includes source metadata" 'Source: {source_path} ({source_plan})' "$checkpoint_display_block"
+  require_text_literal "$prompt_label: DNN modal question names AskUserQuestion question value" 'AskUserQuestion `question` value MUST also be self-contained' "$modal_question_block"
+  require_text_literal "$prompt_label: DNN modal question includes deviation line" 'Deviation: {text}' "$modal_question_block"
+  require_text_literal "$prompt_label: DNN modal question includes source metadata" 'Source: {source_path} ({source_plan})' "$modal_question_block"
+  require_text_literal "$prompt_label: DNN modal asks non-blocking acceptance question" 'Accept this documented deviation as non-blocking for this phase?' "$modal_question_block"
   require_text_literal "$prompt_label: DNN modal forbids generic expected-only question" 'must not be the only visible AskUserQuestion question' "$prompt_block"
   require_text_literal "$prompt_label: DNN Pass option accepts non-blocking deviation" 'Accept this deviation as non-blocking for this phase' "$prompt_block"
   require_text_literal "$prompt_label: DNN Skip option leaves deviation unaccepted" 'Leave this deviation unaccepted for now' "$prompt_block"


### PR DESCRIPTION
Fixes #605

## What

Makes prefilled `DNN` summary-deviation UAT checkpoints self-contained in the visible AskUserQuestion modal. The change updates `commands/verify.md` and `references/execute-protocol.md` so the modal question itself includes the deviation text and source metadata, and tightens `testing/verify-askuserquestion-contract.sh` to protect that invariant.

## Why

The root cause was an instruction contract gap: VBW already writes rich `Deviation`, `Source Plan`, and `Source Summary` fields into UAT entries, but the checkpoint prompt could still use only the generic expected text as the AskUserQuestion question. For a human approval checkpoint, the thing being approved must be visible in the approval prompt itself. This fixes the prompt contract at the source instead of adding runtime scans, helper scripts, or state migration.

## How

- `commands/verify.md`: requires `DNN` summary-deviation checkpoint displays and AskUserQuestion `question` values to include compact `Deviation: {text}` and `Source: {source_path} ({source_plan})` lines, asks whether the deviation is accepted as non-blocking, and clarifies `Pass`/`Skip` option semantics for this checkpoint type.
- `references/execute-protocol.md`: mirrors the same self-contained modal contract for execute-mode UAT while leaving response mapping, disposition fields, and accepted-deviation persistence unchanged.
- `testing/verify-askuserquestion-contract.sh`: adds summary-deviation prompt coverage and then tightens it so the modal-question sub-block itself must include `Deviation:` and source metadata, not merely the broader prompt block.

## Acceptance criteria verification

1. Satisfied by `commands/verify.md` requiring `DNN` CHECKPOINT displays to include `Deviation: {text}` plus `Source: {source_path} ({source_plan})`.
2. Satisfied by `commands/verify.md` requiring the AskUserQuestion `question` value itself to include the same deviation and source lines.
3. Satisfied by the `commands/verify.md` prompt asking `Accept this documented deviation as non-blocking for this phase?`.
4. Satisfied by `commands/verify.md` overriding `Pass` as accepting the deviation as non-blocking and `Skip` as leaving it unaccepted for now.
5. Satisfied by `commands/verify.md` explicitly forbidding the generic expected text as the only visible AskUserQuestion question for `DNN` summary-deviation checkpoints.
6. Satisfied because the normal non-deviation AskUserQuestion YAML and option semantics remain unchanged; the new behavior is isolated to the summary-deviation special case.
7. Satisfied because the new instructions use fields already present in the current UAT entry and add no helper scripts, runtime scans, persistent state, or per-checkpoint summary reads.
8. Satisfied by `references/execute-protocol.md` mirroring the same `DNN` modal contract without changing response mapping or accepted-deviation persistence.
9. Satisfied: `commands/vibe.md` was inspected and only delegates Verify mode to `commands/verify.md`; no duplicate summary-deviation wording was added.
10. Satisfied by `testing/verify-askuserquestion-contract.sh` asserting both `commands/verify.md` and `references/execute-protocol.md` require `Deviation:` and source metadata inside the extracted AskUserQuestion modal-question sub-block.
11. Satisfied by `testing/verify-askuserquestion-contract.sh` asserting the generic expected text must not be the sole visible AskUserQuestion question.
12. Satisfied locally by targeted checks, full suite, and remote CI listed below.

## Testing

- [x] `bash testing/verify-askuserquestion-contract.sh` — 131 PASS, 0 FAIL
- [x] `bash testing/verify-commands-contract.sh` — 508 PASS, 0 FAIL
- [x] `bash testing/run-lint.sh` — passed
- [x] `bash testing/run-all.sh` — lint 1/1, contracts 51/51, BATS 3504 passed / 0 failed
- [x] GitHub Actions — `CI_GREEN`, all 18 checks passed on `d5dfd2b9`

## QA summary

- Primary QA round 1 (`qa-investigator`): 1 medium contract finding fixed in `49f54d7f` by tightening modal-question test coverage.
- Primary QA round 2 (`qa-investigator`): clean; evidence commit `d5dfd2b9`.
- Cross-model QA: skipped per workflow gate because this is a GPT-class session; no more-expensive different-family reviewer is available.
- Copilot PR review round 1: fresh `COMMENTED` review on `d5dfd2b9`, generated no inline comments; unresolved Copilot thread count was 0.
- CI/CD: all 18 GitHub Actions checks passed on `d5dfd2b9`.
- Post-review main sync: `origin/main` had 0 new commits; no merge or conflict-resolution QA rerun needed.
