### PR TITLE
Fix product UAT modal context

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Autonomy interacts with effort profiles. At `cautious`, plan approval expands to
 | Plan approval (Balanced) | Required | Off | Off | Off |
 | UAT after QA | Run | Run | Skip | Skip |
 
-**`auto_uat`** — When `true`, VBW automatically runs UAT verification after QA passes during the `/vbw:vibe` execution flow, regardless of autonomy level. Normally, UAT only runs at `cautious` and `standard` autonomy. With `auto_uat` enabled, UAT runs inline at every level, including `confident` and `pure-vibe`. If completed summaries document implementation deviations, UAT preloads them as review checkpoints so you can accept them as process exceptions, accept them while adding a VBW todo for follow-up, skip them, or reject them as real issues.
+**`auto_uat`** — When `true`, VBW automatically runs UAT verification after QA passes during the `/vbw:vibe` execution flow, regardless of autonomy level. Normally, UAT only runs at `cautious` and `standard` autonomy. With `auto_uat` enabled, UAT runs inline at every level, including `confident` and `pure-vibe`. Product UAT checkpoint modals include both the scenario and expected result so the prompt is answerable even if the modal covers surrounding terminal text. If completed summaries document implementation deviations, UAT preloads them as review checkpoints so you can accept them as process exceptions, accept them while adding a VBW todo for follow-up, skip them, or reject them as real issues.
 
 ```text
 /vbw:config auto_uat true

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -595,9 +595,9 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
    {scenario description}
    ```
 
-   Then call AskUserQuestion:
+  Then call AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
    ```yaml
-   question: "Expected: {expected result}"
+  question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
    header: "UAT"
    multiSelect: false
    options:

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -595,16 +595,16 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
    {scenario description}
    ```
 
-  Then call AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
+    Then call AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
    ```yaml
-  question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
-   header: "UAT"
-   multiSelect: false
-   options:
-     - label: "Pass"
-       description: "Behavior matches expected result"
-     - label: "Skip"
-       description: "Cannot test right now — skip this checkpoint"
+    question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
+    header: "UAT"
+    multiSelect: false
+    options:
+      - label: "Pass"
+        description: "Behavior matches expected result"
+      - label: "Skip"
+        description: "Cannot test right now — skip this checkpoint"
    ```
 
    **AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, YAML, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the checkpoint will not be presented to the user and the session will end prematurely. **STOP HERE and wait for the user to respond.** Process one checkpoint at a time.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -587,16 +587,16 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 2. Present checkpoints one at a time using CHECKPOINT + AskUserQuestion:
 
    Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
-   ```text
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-     CHECKPOINT {NN}/{total} — Debug Fix Verification
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ```text
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      CHECKPOINT {NN}/{total} — Debug Fix Verification
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-   {scenario description}
-   ```
+    {scenario description}
+    ```
 
     Then call AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
-   ```yaml
+    ```yaml
     question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
     header: "UAT"
     multiSelect: false
@@ -605,7 +605,7 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
         description: "Behavior matches expected result"
       - label: "Skip"
         description: "Cannot test right now — skip this checkpoint"
-   ```
+    ```
 
    **AskUserQuestion is a tool call (NON-NEGOTIABLE):** You MUST invoke AskUserQuestion via the tool_use mechanism — never emit the question parameters as text, YAML, or any other inline format in your response body. If AskUserQuestion appears in your text output instead of as a tool call, the checkpoint will not be presented to the user and the session will end prematurely. **STOP HERE and wait for the user to respond.** Process one checkpoint at a time.
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -493,8 +493,9 @@ When routed here, skip the standard phase-resolution Steps entirely. Instead:
 - Use UAT resume metadata for the active target phase (the pre-computed auto-detected block, the target-specific refresh from Step 1, or the refreshed metadata from Step 2 for re-verification):
   - `uat_resume=none`: no existing UAT session — proceed to Step 4 (generate tests)
   - `uat_resume=all_done uat_completed=N uat_total=N`: all tests already have results — display the summary, STOP
-  - `uat_resume=<test-id> uat_completed=N uat_total=N`: resume at `<test-id>`. Display: `Resuming UAT session -- {completed}/{total} tests done`. Read the UAT.md once to load checkpoint text, then jump to the CHECKPOINT loop at the resume point.
-- Do NOT scan-parse the UAT file to find the resume point — the pre-computed metadata already identifies it.
+  - `uat_resume=<test-id> uat_completed=N uat_total=N`: resume at `<test-id>` only when `<test-id>` is a valid checkpoint ID (`P...`, `PR...`, or `D...`). Display: `Resuming UAT session -- {completed}/{total} tests done`. Use the following `uat_resume_*` lines as the authoritative prompt context for the first resumed checkpoint: normal product checkpoints use `uat_resume_scenario` + `uat_resume_expected`; summary-deviation checkpoints use `uat_resume_deviation`, `uat_resume_source_plan`, `uat_resume_source_summary`, and `uat_resume_deviation_signature`.
+- Treat `uat_resume=unavailable`, `uat_resume=error`, and `uat_resume=pending_archive` as compact wrapper sentinels, not checkpoint IDs.
+- Do NOT scan-parse the UAT file to find the resume point — the pre-computed metadata already identifies it. If the required `uat_resume_*` fields for the active checkpoint type are absent or incomplete, read the UAT.md once as a recoverable legacy/malformed-artifact fallback, then jump to the CHECKPOINT loop at the resume point.
 
 ### 4. Generate test scenarios from pre-computed verify context
 
@@ -582,10 +583,10 @@ For the FIRST test without a result, display a CHECKPOINT followed by AskUserQue
 {scenario description}
 ```
 
-Then call the `AskUserQuestion` tool (this MUST be a tool_use call, NOT text output):
+Then call the `AskUserQuestion` tool (this MUST be a tool_use call, NOT text output). The modal question must be self-contained because it may cover the surrounding prose:
 
 ```yaml
-question: "Expected: {expected result}"
+question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
 header: "UAT"
 multiSelect: false
 options:
@@ -612,7 +613,7 @@ The tool automatically provides a freeform "Other" option for the user to descri
 
 **STOP HERE.** Wait for the AskUserQuestion response. Do NOT continue to the next test, do NOT skip to Step 6, and do NOT end the turn. The tool call blocks until the user responds.
 
-**After the user responds:** process the response (Step 6), persist to disk (Step 8), then present the NEXT test using the same CHECKPOINT + AskUserQuestion format. **STOP and wait again.** Repeat until all tests are done, then go to Step 9.
+**After the user responds:** process the response (Step 6), persist to disk (Step 8), then re-run `bash "{plugin-root}/scripts/extract-uat-resume.sh" "{phase-dir}"` to fetch the next incomplete checkpoint and its deterministic `uat_resume_*` prompt context. If the refreshed output is `uat_resume=all_done`, proceed to Step 9. If it returns another valid product checkpoint with `uat_resume_scenario` + `uat_resume_expected`, present that next checkpoint using those emitted fields. If it returns a valid summary-deviation checkpoint, use the emitted deviation/source fields. If required fields are missing for the checkpoint type, read the UAT file once as a fallback for that next checkpoint instead of guessing. **STOP and wait again.** Repeat until all tests are done, then go to Step 9.
 
 ### 6. Response mapping
 

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -347,9 +347,9 @@ else
       echo "uat_resume=pending_archive"
     elif [ "$STATE" = "needs_verification" ]; then
       if [ -d "$PDIR" ] && [ -L "$L" ] && [ -f "$L/scripts/extract-uat-resume.sh" ]; then
-        bash "$L/scripts/extract-uat-resume.sh" "$PDIR" 2>/dev/null || echo "uat_resume=none"
+        bash "$L/scripts/extract-uat-resume.sh" "$PDIR" 2>/dev/null || echo "uat_resume=error"
       else
-        echo "uat_resume=none"
+        echo "uat_resume=unavailable"
       fi
     elif [ -d "$PDIR" ] && [ -L "$L" ] && [ -f "$L/scripts/extract-uat-resume.sh" ]; then
       bash "$L/scripts/extract-uat-resume.sh" "$PDIR" 2>/dev/null || echo "uat_resume=error"
@@ -1522,7 +1522,7 @@ No SUMMARY.md: STOP "Phase {NN} has no completed plans. Run /vbw:vibe first."
 
 **Steps:**
 1. Read `/tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/commands/verify.md` protocol. When entering from `needs_reverification` or `auto_uat` routing, the pre-computed verify context (verify_scope, uat_path, uat_resume) is already available from the Context section above — use it unless the `needs_reverification` flow above just refreshed verify context and resume metadata after `prepare-reverification.sh`, in which case use that refreshed output instead. **Error guard:** If the active verify block contains `verify_context_error=true` or `verify_context=unavailable`, display: "⚠ Verify context compilation failed. Run `bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/compile-verify-context.sh .vbw-planning/phases/{NN}-{slug}` manually to debug." STOP. Do NOT improvise by scanning PLAN/SUMMARY files manually in this routed path.
-2. Execute the verify.md steps inline in this conversation. Specifically: generate test scenarios (verify.md Step 4), then run the CHECKPOINT loop (verify.md Step 5) presenting one test at a time via AskUserQuestion and waiting for the user's response before proceeding to the next test. Use the pre-computed "Verify context" block from this command's Context section — it contains the PLAN/SUMMARY aggregation and UAT resume metadata for the target phase. Pass this data through to the verify protocol steps so they do NOT read individual PLAN/SUMMARY files or scan-parse UAT.md for resume state.
+2. Execute the verify.md steps inline in this conversation. Specifically: generate test scenarios (verify.md Step 4), then run the CHECKPOINT loop (verify.md Step 5) presenting one test at a time via AskUserQuestion and waiting for the user's response before proceeding to the next test. Use the pre-computed "Verify context" block from this command's Context section — it contains the PLAN/SUMMARY aggregation and UAT resume metadata for the target phase. Pass the full UAT resume metadata through to the verify protocol, including `uat_resume_scenario`, `uat_resume_expected`, and summary-deviation source fields when present, so verify.md can ask the first resumed checkpoint without re-reading the UAT file. After each persisted answer, verify.md re-runs `extract-uat-resume.sh` and uses the refreshed deterministic fields for the next checkpoint. Do NOT read individual PLAN/SUMMARY files or scan-parse UAT.md for resume state.
 3. Display results per verify.md output format.
 4. **UAT Remediation Auto-Continuation:** This step only applies when verify.md emitted `remediation_continue=true` (which happens when `verify_scope=remediation` AND `status=issues_found` AND running in orchestrated mode from vibe.md). If `remediation_continue` was not set (first-time UAT, complete result, or standalone verify), skip this step entirely — the command ends after step 3.
 

--- a/references/ask-user-question.md
+++ b/references/ask-user-question.md
@@ -12,6 +12,7 @@ Last reviewed: 2026-04-18
 - When options exist, Claude Code still exposes an `Other` path. Treat it as the built-in escape hatch instead of pretending freeform input does not exist.
 - Mark the preferred option with `isRecommended` when one option is genuinely better.
 - Leave 3–4 blank lines before the tool call so the dialog does not cover the last line of prose.
+- When a modal choice depends on nearby explanatory context, include the minimal answer-critical context in the `question` itself; the modal may cover or displace preceding prose.
 
 ### Batch vs. sequence
 

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -934,17 +934,17 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
    {scenario description}
    ```
 
-  Then use AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
+    Then use AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
 
    ```yaml
-  question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
-   header: "UAT"
-   multiSelect: false
-   options:
-     - label: "Pass"
-       description: "Behavior matches expected result"
-     - label: "Skip"
-       description: "Cannot test right now — skip this checkpoint"
+    question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
+    header: "UAT"
+    multiSelect: false
+    options:
+      - label: "Pass"
+        description: "Behavior matches expected result"
+      - label: "Skip"
+        description: "Cannot test right now — skip this checkpoint"
    ```
 
    The tool automatically provides a freeform "Other" option for the user to describe issues.

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -926,17 +926,17 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
 
    For the FIRST test without a result, display a CHECKPOINT followed by AskUserQuestion:
 
-   ```text
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   CHECKPOINT {NN}/{total} — {plan-id}: {plan-title}
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ```text
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    CHECKPOINT {NN}/{total} — {plan-id}: {plan-title}
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-   {scenario description}
-   ```
+    {scenario description}
+    ```
 
     Then use AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
 
-   ```yaml
+    ```yaml
     question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
     header: "UAT"
     multiSelect: false
@@ -945,7 +945,7 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
         description: "Behavior matches expected result"
       - label: "Skip"
         description: "Cannot test right now — skip this checkpoint"
-   ```
+    ```
 
    The tool automatically provides a freeform "Other" option for the user to describe issues.
 

--- a/references/execute-protocol.md
+++ b/references/execute-protocol.md
@@ -934,10 +934,10 @@ UAT_NAME=$(bash "${VBW_PLUGIN_ROOT}/scripts/resolve-artifact-path.sh" uat "{phas
    {scenario description}
    ```
 
-   Then use AskUserQuestion:
+  Then use AskUserQuestion. Keep the modal question self-contained because it may cover the surrounding checkpoint prose:
 
    ```yaml
-   question: "Expected: {expected result}"
+  question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"
    header: "UAT"
    multiSelect: false
    options:

--- a/scripts/extract-uat-resume.sh
+++ b/scripts/extract-uat-resume.sh
@@ -126,6 +126,31 @@ awk '
     return flatten(line)
   }
 
+  function normalize_result(raw,    val, upper, lower, i, c, pos, lval) {
+    val = trim(raw)
+    # Strip common decorators while preserving the literal template placeholder
+    # {pass|skip|issue}, which must remain incomplete.
+    gsub(/^[^a-zA-Z{]+/, "", val)
+    gsub(/[^a-zA-Z}]+$/, "", val)
+
+    upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    lower = "abcdefghijklmnopqrstuvwxyz"
+    lval = ""
+    for (i = 1; i <= length(val); i++) {
+      c = substr(val, i, 1)
+      pos = index(upper, c)
+      if (pos > 0) c = substr(lower, pos, 1)
+      lval = lval c
+    }
+    val = lval
+
+    if (val == "" || val == "{pass|skip|issue}") return ""
+    if (val ~ /^pass/) return "pass"
+    if (val ~ /^skip/) return "skip"
+    if (val ~ /^issue/ || val ~ /^fail/ || val ~ /^partial/) return "issue"
+    return ""
+  }
+
   function reset_current() {
     cur_scenario=""
     cur_expected=""
@@ -177,40 +202,46 @@ awk '
     next
   }
   /^- \*\*Scenario:\*\*/ {
+    if (cur_id == "") next
     cur_scenario = field_value($0)
     last_field = "scenario"
     next
   }
   /^- \*\*Expected:\*\*/ {
+    if (cur_id == "") next
     cur_expected = field_value($0)
     last_field = "expected"
     next
   }
   /^- \*\*Deviation:\*\*/ {
+    if (cur_id == "") next
     cur_deviation = field_value($0)
     last_field = "deviation"
     next
   }
   /^- \*\*Source Plan:\*\*/ {
+    if (cur_id == "") next
     cur_source_plan = field_value($0)
     last_field = "source_plan"
     next
   }
   /^- \*\*Source Summary:\*\*/ {
+    if (cur_id == "") next
     cur_source_summary = field_value($0)
     last_field = "source_summary"
     next
   }
   /^- \*\*Deviation Signature:\*\*/ {
+    if (cur_id == "") next
     cur_deviation_signature = field_value($0)
     last_field = "deviation_signature"
     next
   }
   /^- \*\*Result:\*\*/ {
+    if (cur_id == "") next
     val = $0
     sub(/^- \*\*Result:\*\*[[:space:]]*/, "", val)
-    gsub(/[[:space:]]+$/, "", val)
-    if (val != "") {
+    if (normalize_result(val) != "") {
       cur_has_result = 1
       completed++
     }
@@ -224,6 +255,9 @@ awk '
   /^## / {
     # End of tests section — check last test
     check_prev()
+    cur_id = ""
+    cur_has_result = 0
+    reset_current()
     last_field = ""
     next
   }
@@ -232,6 +266,7 @@ awk '
     next
   }
   {
+    if (cur_id == "") next
     append_to_last($0)
   }
   END {

--- a/scripts/extract-uat-resume.sh
+++ b/scripts/extract-uat-resume.sh
@@ -9,6 +9,12 @@
 #   uat_resume=none                           — no UAT file exists
 #   uat_resume=all_done uat_completed=N uat_total=N — all tests have results
 #   uat_resume=<test-id> uat_completed=N uat_total=N — resume at <test-id>
+#     uat_resume_scenario=...                 — active product checkpoint scenario, when present
+#     uat_resume_expected=...                 — active product checkpoint expected result, when present
+#     uat_resume_deviation=...                — active summary-deviation review text, when present
+#     uat_resume_source_plan=...              — active summary-deviation source plan, when present
+#     uat_resume_source_summary=...           — active summary-deviation source summary, when present
+#     uat_resume_deviation_signature=...      — active summary-deviation identity, when present
 
 set -euo pipefail
 
@@ -90,13 +96,72 @@ if [ -z "$UAT_FILE" ] || [ ! -f "$UAT_FILE" ]; then
   exit 0
 fi
 
-# Parse all test entries: count total, find first without a result
+# Parse all test entries: count total, find first without a result, and emit
+# deterministic prompt-critical context for the active checkpoint.
 awk '
-  BEGIN { total=0; completed=0; first_incomplete=""; cur_id=""; cur_has_result=0 }
+  BEGIN {
+    total=0
+    completed=0
+    first_incomplete=""
+    cur_id=""
+    cur_has_result=0
+    last_field=""
+  }
+
+  function trim(v) {
+    gsub(/\r/, "", v)
+    sub(/^[[:space:]]+/, "", v)
+    sub(/[[:space:]]+$/, "", v)
+    return v
+  }
+
+  function flatten(v) {
+    v = trim(v)
+    gsub(/[[:space:]][[:space:]]+/, " ", v)
+    return v
+  }
+
+  function field_value(line) {
+    sub(/^- \*\*[^*]+:\*\*[[:space:]]*/, "", line)
+    return flatten(line)
+  }
+
+  function reset_current() {
+    cur_scenario=""
+    cur_expected=""
+    cur_deviation=""
+    cur_source_plan=""
+    cur_source_summary=""
+    cur_deviation_signature=""
+    last_field=""
+  }
+
+  function append_to_last(line) {
+    line = flatten(line)
+    if (line == "" || last_field == "") {
+      return
+    }
+    if (last_field == "scenario") cur_scenario = flatten(cur_scenario " " line)
+    else if (last_field == "expected") cur_expected = flatten(cur_expected " " line)
+    else if (last_field == "deviation") cur_deviation = flatten(cur_deviation " " line)
+    else if (last_field == "source_plan") cur_source_plan = flatten(cur_source_plan " " line)
+    else if (last_field == "source_summary") cur_source_summary = flatten(cur_source_summary " " line)
+    else if (last_field == "deviation_signature") cur_deviation_signature = flatten(cur_deviation_signature " " line)
+  }
+
+  function snapshot_first_incomplete() {
+    first_scenario = cur_scenario
+    first_expected = cur_expected
+    first_deviation = cur_deviation
+    first_source_plan = cur_source_plan
+    first_source_summary = cur_source_summary
+    first_deviation_signature = cur_deviation_signature
+  }
 
   function check_prev() {
     if (cur_id != "" && cur_has_result == 0 && first_incomplete == "") {
       first_incomplete = cur_id
+      snapshot_first_incomplete()
     }
   }
 
@@ -108,6 +173,37 @@ awk '
     sub(/:$/, "", cur_id)
     total++
     cur_has_result = 0
+    reset_current()
+    next
+  }
+  /^- \*\*Scenario:\*\*/ {
+    cur_scenario = field_value($0)
+    last_field = "scenario"
+    next
+  }
+  /^- \*\*Expected:\*\*/ {
+    cur_expected = field_value($0)
+    last_field = "expected"
+    next
+  }
+  /^- \*\*Deviation:\*\*/ {
+    cur_deviation = field_value($0)
+    last_field = "deviation"
+    next
+  }
+  /^- \*\*Source Plan:\*\*/ {
+    cur_source_plan = field_value($0)
+    last_field = "source_plan"
+    next
+  }
+  /^- \*\*Source Summary:\*\*/ {
+    cur_source_summary = field_value($0)
+    last_field = "source_summary"
+    next
+  }
+  /^- \*\*Deviation Signature:\*\*/ {
+    cur_deviation_signature = field_value($0)
+    last_field = "deviation_signature"
     next
   }
   /^- \*\*Result:\*\*/ {
@@ -118,11 +214,25 @@ awk '
       cur_has_result = 1
       completed++
     }
+    last_field = ""
+    next
+  }
+  /^- \*\*/ {
+    last_field = ""
     next
   }
   /^## / {
     # End of tests section — check last test
     check_prev()
+    last_field = ""
+    next
+  }
+  /^[[:space:]]*$/ {
+    last_field = ""
+    next
+  }
+  {
+    append_to_last($0)
   }
   END {
     # Check last test if file ends without ## section
@@ -133,6 +243,15 @@ awk '
       printf "uat_resume=all_done uat_completed=%d uat_total=%d\n", completed, total
     } else if (first_incomplete != "") {
       printf "uat_resume=%s uat_completed=%d uat_total=%d\n", first_incomplete, completed, total
+      if (first_deviation != "" || first_source_plan != "" || first_source_summary != "" || first_deviation_signature != "") {
+        if (first_deviation != "") printf "uat_resume_deviation=%s\n", first_deviation
+        if (first_source_plan != "") printf "uat_resume_source_plan=%s\n", first_source_plan
+        if (first_source_summary != "") printf "uat_resume_source_summary=%s\n", first_source_summary
+        if (first_deviation_signature != "") printf "uat_resume_deviation_signature=%s\n", first_deviation_signature
+      } else {
+        if (first_scenario != "") printf "uat_resume_scenario=%s\n", first_scenario
+        if (first_expected != "") printf "uat_resume_expected=%s\n", first_expected
+      }
     } else {
       printf "uat_resume=all_done uat_completed=%d uat_total=%d\n", completed, total
     }

--- a/testing/verify-askuserquestion-contract.sh
+++ b/testing/verify-askuserquestion-contract.sh
@@ -423,6 +423,7 @@ require_file_literal "ask-user-question: documents short-header guidance" "Keep 
 require_file_regex "ask-user-question: documents 2-4 option sweet spot" '2[-–]4 options' "$ASK_USER_QUESTION_REF"
 require_file_regex "ask-user-question: documents 1-4 question guidance" '1[-–]4 questions' "$ASK_USER_QUESTION_REF"
 require_file_literal "ask-user-question: documents built-in Other path" '`Other` path' "$ASK_USER_QUESTION_REF"
+require_file_literal "ask-user-question: documents self-contained modal context" 'minimal answer-critical context in the `question` itself' "$ASK_USER_QUESTION_REF"
 require_file_literal "ask-user-question: documents intentional freeform boundary" "high-cardinality or unbounded" "$ASK_USER_QUESTION_REF"
 require_file_literal "ask-user-question: documents freeform handoff heading" "### Freeform handoff" "$ASK_USER_QUESTION_REF"
 require_file_literal "ask-user-question: documents freeform handoff behavior" "stop using AskUserQuestion" "$ASK_USER_QUESTION_REF"
@@ -566,6 +567,45 @@ for mapping_target in \
 done
 
 require_text_literal "execute-protocol: DNN todo intent rejects smart-apostrophe contraction blocker" "can’t continue, track this" "$EXECUTE_RESPONSE_MAPPING_BLOCK"
+
+# --------------------------------------------------------------------------
+# Check 4c: Normal product UAT prompts are self-contained in AskUserQuestion
+# --------------------------------------------------------------------------
+
+echo ""
+echo "--- Check 4c: Product UAT prompt context ---"
+
+PRODUCT_UAT_MODAL='question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"'
+EXPECTED_ONLY_MODAL='question: "Expected: {expected result}"'
+
+require_file_literal "verify: product UAT modal includes Scenario and Expected" "$PRODUCT_UAT_MODAL" "$VERIFY_COMMAND_FILE"
+require_file_literal "execute-protocol: product UAT modal includes Scenario and Expected" "$PRODUCT_UAT_MODAL" "$EXECUTE_PROTOCOL_FILE"
+require_file_literal "debug: product UAT modal includes Scenario and Expected" "$PRODUCT_UAT_MODAL" "$COMMANDS_DIR/debug.md"
+
+if grep -Fq "$EXPECTED_ONLY_MODAL" "$VERIFY_COMMAND_FILE"; then
+  fail "verify: product UAT modal no longer uses expected-only question"
+else
+  pass "verify: product UAT modal no longer uses expected-only question"
+fi
+
+if grep -Fq "$EXPECTED_ONLY_MODAL" "$EXECUTE_PROTOCOL_FILE"; then
+  fail "execute-protocol: product UAT modal no longer uses expected-only question"
+else
+  pass "execute-protocol: product UAT modal no longer uses expected-only question"
+fi
+
+if grep -Fq "$EXPECTED_ONLY_MODAL" "$COMMANDS_DIR/debug.md"; then
+  fail "debug: product UAT modal no longer uses expected-only question"
+else
+  pass "debug: product UAT modal no longer uses expected-only question"
+fi
+
+require_file_literal "verify: resumed product UAT consumes uat_resume_scenario" 'uat_resume_scenario' "$VERIFY_COMMAND_FILE"
+require_file_literal "verify: resumed product UAT consumes uat_resume_expected" 'uat_resume_expected' "$VERIFY_COMMAND_FILE"
+require_file_literal "vibe: passes resumed product UAT scenario field" 'uat_resume_scenario' "$VIBE_COMMAND_FILE"
+require_file_literal "vibe: passes resumed product UAT expected field" 'uat_resume_expected' "$VIBE_COMMAND_FILE"
+require_file_literal "vibe: extractor failure uses error sentinel" '|| echo "uat_resume=error"' "$VIBE_COMMAND_FILE"
+require_file_literal "vibe: extractor unavailable uses unavailable sentinel" 'echo "uat_resume=unavailable"' "$VIBE_COMMAND_FILE"
 
 # --------------------------------------------------------------------------
 # Check 5: /vbw:list-todos intentional plain-text/freeform handoff

--- a/testing/verify-commands-contract.sh
+++ b/testing/verify-commands-contract.sh
@@ -901,6 +901,15 @@ else
   fail "vibe: needs_reverification missing refreshed round-scoped uat_path validation"
 fi
 
+if grep -q 'uat_resume_scenario' "$VIBE_FILE" \
+  && grep -q 'uat_resume_expected' "$VIBE_FILE" \
+  && grep -q 'bash "$L/scripts/extract-uat-resume.sh" "$PDIR" 2>/dev/null || echo "uat_resume=error"' "$VIBE_FILE" \
+  && grep -q 'echo "uat_resume=unavailable"' "$VIBE_FILE"; then
+  pass "vibe: Verify mode passes deterministic UAT resume fields and preserves wrapper sentinels"
+else
+  fail "vibe: Verify mode missing deterministic UAT resume fields or wrapper sentinels"
+fi
+
 if grep -q 'compile-verify-context.sh --remediation-only {phase-dir}' "$ROOT/references/execute-protocol.md"; then
   pass "execute-protocol: QA remediation verify uses remediation-only verify context"
 else
@@ -946,6 +955,15 @@ if grep -Eq 'uat-remediation-state\.sh"? get-or-init "{phase-dir}" major' "$VERI
   pass "verify: remediation re-verification refreshes and validates round-scoped uat_path for round-dir and legacy layouts"
 else
   fail "verify: remediation re-verification missing refreshed round-scoped uat_path validation"
+fi
+
+if grep -q 'uat_resume_scenario' "$VERIFY_FILE" \
+  && grep -q 'uat_resume_expected' "$VERIFY_FILE" \
+  && grep -q 'summary-deviation checkpoints use `uat_resume_deviation`' "$VERIFY_FILE" \
+  && grep -q 're-run `bash "{plugin-root}/scripts/extract-uat-resume.sh" "{phase-dir}"`' "$VERIFY_FILE"; then
+  pass "verify: resumed UAT uses deterministic checkpoint fields and refreshes after each answer"
+else
+  fail "verify: resumed UAT missing deterministic checkpoint field usage or refresh loop"
 fi
 
 if grep -q 'ignore the pre-computed verify context, `next_phase_state`, `qa_status`, and UAT resume metadata' "$VERIFY_FILE" \

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -664,6 +664,18 @@ else
   fail "debug.md frontmatter missing AskUserQuestion tool"
 fi
 
+if grep -Fq 'question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"' "$ROOT/commands/debug.md" 2>/dev/null; then
+  pass "debug.md inline UAT modal question includes Scenario and Expected"
+else
+  fail "debug.md inline UAT modal question missing Scenario and Expected"
+fi
+
+if grep -Fq 'question: "Expected: {expected result}"' "$ROOT/commands/debug.md" 2>/dev/null; then
+  fail "debug.md inline UAT modal still uses expected-only question"
+else
+  pass "debug.md inline UAT modal avoids expected-only question"
+fi
+
 if grep -q '\-\-session.*Run UAT on the debug fix' "$ROOT/commands/qa.md" 2>/dev/null; then
   pass "qa.md next-step for PASS includes --session"
 else

--- a/testing/verify-human-only-uat-contract.sh
+++ b/testing/verify-human-only-uat-contract.sh
@@ -151,6 +151,24 @@ require_all "$VERIFY_FILE" \
   "rather than asking them to run automated checks"
 
 require_all "$EXEC_PROTO" \
+  "execute-protocol: product UAT modal is self-contained" \
+  'question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"' \
+  "Keep the modal question self-contained"
+
+require_all "$VERIFY_FILE" \
+  "verify: product UAT modal is self-contained" \
+  'question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"' \
+  "The modal question must be self-contained"
+
+require_absent "$EXEC_PROTO" \
+  "execute-protocol: product UAT modal avoids expected-only anti-pattern" \
+  'question: "Expected: {expected result}"'
+
+require_absent "$VERIFY_FILE" \
+  "verify: product UAT modal avoids expected-only anti-pattern" \
+  'question: "Expected: {expected result}"'
+
+require_all "$EXEC_PROTO" \
   "execute-protocol: synthesizes UAT issue descriptions" \
   'synthesize an actionable persisted `Description`' \
   "checkpoint expectation" \

--- a/tests/extract-uat-resume.bats
+++ b/tests/extract-uat-resume.bats
@@ -25,7 +25,22 @@ assert_output_has_line() {
 
 assert_output_lacks_prefix() {
   local prefix="$1"
-  ! grep -Eq "^${prefix}" <<< "$output"
+  local line
+
+  while IFS= read -r line; do
+    case "$line" in
+      "$prefix"*) return 1 ;;
+    esac
+  done <<< "$output"
+
+  return 0
+}
+
+@test "assert_output_lacks_prefix treats regex metacharacters literally" {
+  output='uat_resume_scenario=Literal scenario field'
+
+  assert_output_lacks_prefix 'uat_resume.scenario'
+  ! assert_output_lacks_prefix 'uat_resume_scenario'
 }
 
 @test "extract-uat-resume: no UAT file returns none" {

--- a/tests/extract-uat-resume.bats
+++ b/tests/extract-uat-resume.bats
@@ -99,6 +99,118 @@ passed: 3
   [[ "$output" == "uat_resume=all_done uat_completed=3 uat_total=3" ]]
 }
 
+@test "extract-uat-resume: template result placeholder remains incomplete" {
+  create_uat_file '---
+phase: 03
+status: in_progress
+total_tests: 1
+---
+
+## Tests
+
+### P01-T1: Placeholder test
+
+- **Scenario:** Check placeholder
+- **Expected:** Result placeholder does not count
+- **Result:** {pass|skip|issue}
+
+## Summary'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  assert_output_has_line "uat_resume=P01-T1 uat_completed=0 uat_total=1"
+  assert_output_has_line "uat_resume_scenario=Check placeholder"
+  assert_output_has_line "uat_resume_expected=Result placeholder does not count"
+}
+
+@test "extract-uat-resume: unrecognized non-empty result remains incomplete" {
+  create_uat_file '---
+phase: 03
+status: in_progress
+total_tests: 1
+---
+
+## Tests
+
+### P01-T1: Unrecognized result
+
+- **Scenario:** Check freeform value
+- **Expected:** Freeform value does not count
+- **Result:** not checked yet
+
+## Summary'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  assert_output_has_line "uat_resume=P01-T1 uat_completed=0 uat_total=1"
+}
+
+@test "extract-uat-resume: result outside checkpoint does not complete test" {
+  create_uat_file '---
+phase: 03
+status: in_progress
+total_tests: 1
+---
+
+## Tests
+
+### P01-T1: Blank result
+
+- **Scenario:** Check summary leakage
+- **Expected:** Summary result does not count
+- **Result:**
+
+## Summary
+
+- **Result:** pass'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  assert_output_has_line "uat_resume=P01-T1 uat_completed=0 uat_total=1"
+}
+
+@test "extract-uat-resume: decorated canonical results count complete" {
+  create_uat_file '---
+phase: 03
+status: complete
+total_tests: 3
+---
+
+## Tests
+
+### P01-T1: Decorated pass
+
+- **Scenario:** Check pass
+- **Expected:** Decorated pass counts
+- **Result:** ✅ PASS
+
+### P01-T2: Decorated skip
+
+- **Scenario:** Check skip
+- **Expected:** Decorated skip counts
+- **Result:** **Skipped**
+
+### P01-T3: Decorated issue
+
+- **Scenario:** Check issue
+- **Expected:** Decorated issue counts
+- **Result:** Partial — user found an issue
+
+## Summary'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "uat_resume=all_done uat_completed=3 uat_total=3" ]]
+}
+
 @test "extract-uat-resume: partial completion returns resume ID" {
   create_uat_file '---
 phase: 03

--- a/tests/extract-uat-resume.bats
+++ b/tests/extract-uat-resume.bats
@@ -18,6 +18,16 @@ create_uat_file() {
   printf '%s\n' "$content" > "$PHASE_DIR/03-UAT.md"
 }
 
+assert_output_has_line() {
+  local expected="$1"
+  grep -Fxq "$expected" <<< "$output"
+}
+
+assert_output_lacks_prefix() {
+  local prefix="$1"
+  ! grep -Eq "^${prefix}" <<< "$output"
+}
+
 @test "extract-uat-resume: no UAT file returns none" {
   cd "$TEST_TEMP_DIR"
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
@@ -117,7 +127,11 @@ total_tests: 4
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=P02-T1 uat_completed=2 uat_total=4" ]]
+  assert_output_has_line "uat_resume=P02-T1 uat_completed=2 uat_total=4"
+  assert_output_has_line "uat_resume_scenario=Check third"
+  assert_output_has_line "uat_resume_expected=It works"
+  assert_output_lacks_prefix "uat_resume_title="
+  assert_output_lacks_prefix "uat_resume_plan="
 }
 
 @test "extract-uat-resume: first test incomplete" {
@@ -149,7 +163,9 @@ total_tests: 2
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=P01-T1 uat_completed=0 uat_total=2" ]]
+  assert_output_has_line "uat_resume=P01-T1 uat_completed=0 uat_total=2"
+  assert_output_has_line "uat_resume_scenario=Check something"
+  assert_output_has_line "uat_resume_expected=It works"
 }
 
 @test "extract-uat-resume: discovered issue entry counted" {
@@ -188,10 +204,12 @@ total_tests: 3
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=P02-T1 uat_completed=2 uat_total=3" ]]
+  assert_output_has_line "uat_resume=P02-T1 uat_completed=2 uat_total=3"
+  assert_output_has_line "uat_resume_scenario=Check third"
+  assert_output_has_line "uat_resume_expected=It works"
 }
 
-@test "extract-uat-resume: prefilled D checkpoint resumes before PR checkpoint" {
+@test "extract-uat-resume: summary-deviation checkpoint emits deviation metadata only" {
   create_uat_file '---
 phase: 03
 status: in_progress
@@ -203,6 +221,12 @@ total_tests: 3
 ### D01: Review summary deviation
 
 - **Source:** Summary deviation review
+- **Deviation Signature:** abc123
+- **Source Plan:** 03-02
+- **Source Summary:** remediation/uat/round-06/R06-SUMMARY.md
+- **Deviation:** Summary documented a different refresh path than the plan.
+- **Scenario:** Generic scenario that must be suppressed for summary-deviation prompts
+- **Expected:** Generic expected value that must be suppressed for summary-deviation prompts
 - **Result:**
 
 ### PR03-T01: Verify LCID behavior
@@ -219,7 +243,44 @@ total_tests: 3
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=D01 uat_completed=0 uat_total=3" ]]
+  assert_output_has_line "uat_resume=D01 uat_completed=0 uat_total=3"
+  assert_output_has_line "uat_resume_deviation=Summary documented a different refresh path than the plan."
+  assert_output_has_line "uat_resume_source_plan=03-02"
+  assert_output_has_line "uat_resume_source_summary=remediation/uat/round-06/R06-SUMMARY.md"
+  assert_output_has_line "uat_resume_deviation_signature=abc123"
+  assert_output_lacks_prefix "uat_resume_scenario="
+  assert_output_lacks_prefix "uat_resume_expected="
+}
+
+@test "extract-uat-resume: D-prefixed checkpoint without deviation metadata is not summary-deviation" {
+  create_uat_file '---
+phase: 03
+status: in_progress
+total_tests: 1
+---
+
+## Tests
+
+### D02: Discovered issue follow-up
+
+- **Plan:** (discovered during P01-T1)
+- **Scenario:** User observation needs human review
+- **Expected:** The discovered issue is no longer visible
+- **Result:**
+
+## Summary'
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  assert_output_has_line "uat_resume=D02 uat_completed=0 uat_total=1"
+  assert_output_has_line "uat_resume_scenario=User observation needs human review"
+  assert_output_has_line "uat_resume_expected=The discovered issue is no longer visible"
+  assert_output_lacks_prefix "uat_resume_deviation="
+  assert_output_lacks_prefix "uat_resume_source_plan="
+  assert_output_lacks_prefix "uat_resume_source_summary="
+  assert_output_lacks_prefix "uat_resume_deviation_signature="
 }
 
 @test "extract-uat-resume: PR-prefixed checkpoint is parsed after accepted deviation" {
@@ -240,13 +301,17 @@ total_tests: 2
 ### PR03-T01: Verify LCID behavior
 
 - **Plan:** R03
+- **Scenario:** Open LCID after remediation
+- **Expected:** LCID remains visible as an active wheel
 - **Result:**'
 
   cd "$TEST_TEMP_DIR"
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=PR03-T01 uat_completed=1 uat_total=2" ]]
+  assert_output_has_line "uat_resume=PR03-T01 uat_completed=1 uat_total=2"
+  assert_output_has_line "uat_resume_scenario=Open LCID after remediation"
+  assert_output_has_line "uat_resume_expected=LCID remains visible as an active wheel"
 }
 
 @test "extract-uat-resume: excludes SOURCE-UAT.md" {
@@ -402,7 +467,7 @@ EOF
   [[ "$output" == "uat_resume=P01-T2 uat_completed=1 uat_total=3" ]]
 }
 
-@test "extract-uat-resume: active round 06 resumes at first blank remediation checkpoint" {
+@test "extract-uat-resume: active round 06 emits product checkpoint scenario and expected" {
   mkdir -p "$PHASE_DIR/remediation/uat/round-06"
   printf 'stage=verify\nround=06\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
 
@@ -421,10 +486,14 @@ total_tests: 3
 
 ### PR06-T02: Second remediation checkpoint
 
-- **Result:** issue
+- **Scenario:** In the Robinhood Roth IRA account after the same clear/full-resync and two refreshes, navigate to Wheels and open/review LCID.
+- **Expected:** LCID remains visible as one active/open wheel after repeated refresh.
+- **Result:**
 
 ### PR06-T03: Third remediation checkpoint
 
+- **Scenario:** Reopen TSLA after completing the LCID check.
+- **Expected:** TSLA remains available for review.
 - **Result:**
 
 ## Summary
@@ -434,7 +503,52 @@ EOF
   run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == "uat_resume=PR06-T03 uat_completed=2 uat_total=3" ]]
+  assert_output_has_line "uat_resume=PR06-T02 uat_completed=1 uat_total=3"
+  assert_output_has_line "uat_resume_scenario=In the Robinhood Roth IRA account after the same clear/full-resync and two refreshes, navigate to Wheels and open/review LCID."
+  assert_output_has_line "uat_resume_expected=LCID remains visible as one active/open wheel after repeated refresh."
+  assert_output_lacks_prefix "uat_resume_title="
+  assert_output_lacks_prefix "uat_resume_plan="
+}
+
+@test "extract-uat-resume: refreshed default output advances to next checkpoint context" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-06"
+  printf 'stage=verify\nround=06\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+
+  cat > "$PHASE_DIR/remediation/uat/round-06/R06-UAT.md" <<'EOF'
+---
+phase: 03
+status: in_progress
+total_tests: 3
+---
+
+## Tests
+
+### PR06-T01: First remediation checkpoint
+
+- **Result:** pass
+
+### PR06-T02: Second remediation checkpoint
+
+- **Scenario:** Review LCID after the second refresh.
+- **Expected:** LCID remains visible as one active/open wheel.
+- **Result:** pass
+
+### PR06-T03: Third remediation checkpoint
+
+- **Scenario:** Reopen TSLA after completing the LCID check.
+- **Expected:** TSLA remains available for review.
+- **Result:**
+
+## Summary
+EOF
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/extract-uat-resume.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  assert_output_has_line "uat_resume=PR06-T03 uat_completed=2 uat_total=3"
+  assert_output_has_line "uat_resume_scenario=Reopen TSLA after completing the LCID check."
+  assert_output_has_line "uat_resume_expected=TSLA remains available for review."
 }
 
 @test "extract-uat-resume: round-dir current round UAT all_done returns correct counts" {


### PR DESCRIPTION
## Linked Issue

Fixes #616

Related: #617 tracks a separate local/pre-existing full-suite hang observed in `tests/qa-result-gate.bats`; it is not part of this PR's scope.

## What

Makes product UAT checkpoint prompts self-contained by putting both `Scenario:` and `Expected:` inside the `AskUserQuestion.question` text in `commands/verify.md`, `references/execute-protocol.md`, and `commands/debug.md`. It also makes `scripts/extract-uat-resume.sh` emit deterministic prompt-critical context fields for active checkpoints and tightens resume completion semantics so placeholders or freeform Result text do not incorrectly mark checkpoints complete.

## Why

The root cause was a split prompt contract: the scenario lived in surrounding prose while the modal asked only about the expected result. Claude Code modals can cover or displace nearby conversation text, so the modal itself must carry the minimal answer-critical context. The durable fix is to make the resume metadata and modal contract typed and self-contained rather than patching one prompt string in isolation.

Copilot review also identified a related invariant in the touched extractor: a UAT checkpoint should count complete only when its own Result field contains a canonical completed UAT result. This PR now preserves that invariant too.

## How

- `scripts/extract-uat-resume.sh`: preserves the leading `uat_resume=<id> uat_completed=N uat_total=N` status line, appends typed context fields for active checkpoints, validates Result values before counting completion, and ignores Result bullets outside active checkpoint blocks.
- `tests/extract-uat-resume.bats`: covers product checkpoint scenario/expected output, refresh progression, metadata-based summary-deviation classification, D-prefixed non-deviation handling, compact terminal states, literal prefix assertions, placeholder/freeform Result handling, outside-section Result leakage, and decorated canonical Result values.
- `commands/verify.md`: consumes deterministic `uat_resume_*` fields, treats wrapper sentinel states as non-checkpoints, refreshes extractor output after every persisted answer, and asks product checkpoint modals with Scenario + Expected.
- `commands/vibe.md`: passes full deterministic resume metadata into verify mode and uses `uat_resume=error` / `uat_resume=unavailable` sentinels for helper failure/unavailability.
- `references/execute-protocol.md` and `commands/debug.md`: align product UAT modal wording with the self-contained Scenario + Expected contract and normalize snippet indentation for stable markdown rendering.
- `references/ask-user-question.md`: adds a narrow guideline to include answer-critical modal context in the `question` itself.
- Contract tests in `testing/verify-askuserquestion-contract.sh`, `testing/verify-commands-contract.sh`, `testing/verify-human-only-uat-contract.sh`, and `testing/verify-debug-session-contract.sh`: lock in the modal and deterministic-resume behavior.
- `README.md`: documents that `auto_uat` checkpoint modals include both scenario and expected result.

## Acceptance criteria verification

1. `extract-uat-resume.sh` keeps the leading active-checkpoint status line and emits deterministic context lines: implemented in `scripts/extract-uat-resume.sh`, covered by `tests/extract-uat-resume.bats`.
2. Product checkpoints emit `uat_resume_scenario` and `uat_resume_expected` only: covered by product resume BATS assertions and contract checks.
3. Summary-deviation checkpoints are metadata-classified and emit deviation/source fields while suppressing generic scenario/expected fields: covered by `tests/extract-uat-resume.bats`.
4. D-prefixed non-deviation checkpoints are not treated as summary-deviation reviews: covered by `tests/extract-uat-resume.bats`.
5. Terminal/wrapper states remain compact and are not checkpoint ids: covered by extractor tests plus verify/vibe contract checks.
6. `commands/vibe.md` uses `uat_resume=error` / `uat_resume=unavailable` for helper failure/unavailability: covered by `testing/verify-commands-contract.sh` and `testing/verify-askuserquestion-contract.sh`.
7. `commands/verify.md` consumes deterministic fields and refreshes extractor output after persisted answers: covered by `testing/verify-commands-contract.sh`.
8. Product UAT modal questions in verify, execute protocol, and debug include both Scenario and Expected: covered by ask-user-question, human-only UAT, and debug-session contracts.
9. The expected-only markdown anti-pattern is removed: verified with direct search and contract tests.
10. Summary-deviation modal behavior remains self-contained: existing summary-deviation contract checks still pass.
11. Automated coverage was added/updated for all required product/deviation/sentinel/modal paths, plus Copilot-identified Result normalization and literal-prefix helper cases.
12. `bash testing/run-all.sh` passed locally from the feature worktree on the same code tree before empty QA evidence; GitHub CI later passed all required checks on final head `05612fe76c6d1c85739bda88bd99ec8bd9d2d15b`.

## Testing

Local targeted verification:

- `bash -n scripts/extract-uat-resume.sh && bats tests/extract-uat-resume.bats` — passed (`23 tests, 0 failures` after Copilot remediation).
- `bash testing/verify-askuserquestion-contract.sh` — passed (`191 PASS, 0 FAIL`).
- `bash testing/verify-human-only-uat-contract.sh` — passed (`31 PASS, 0 FAIL`).
- `bash testing/verify-debug-session-contract.sh` — passed (`124 passed, 0 failed`).
- `bash testing/verify-commands-contract.sh` — passed (`514 PASS, 0 FAIL`).
- `bash testing/run-lint.sh` — passed.
- Earlier `bash testing/run-all.sh` — passed on the feature worktree code tree (`Lint checks: 1/1 passed`, `Contract checks: 51/51 passed`, `BATS: 3552 passed, 0 failed`).

CI/CD:

- `CI_GREEN — all 18 checks passed` on `05612fe76c6d1c85739bda88bd99ec8bd9d2d15b`.

Note: a redundant local post-QA `run-all.sh` rerun was stopped after it appeared to hang in a pre-existing large-registry `qa-result-gate` BATS case; #617 tracks that separately. Remote CI completed successfully on the final commit.

## QA summary

- Primary QA: 1 round with `qa-investigator`, clean; no findings. Evidence commit: `ddc1c65e15bce9d8bb821ca233ac8154c2570da3`.
- Cross-model QA: skipped because this is a GPT-class Copilot session, so the configured GPT cross-model reviewer would not provide a different model-family perspective under the workflow gate.
- Copilot PR review:
  - Round 1: 2 low indentation findings fixed in `653ee6dac9758a6a9ed714dba2f98140ec416fa8`.
  - Round 2: 3 findings fixed in `5e07615b5601f484c81a0d9599cceaf2528647f9` (indentation follow-up plus literal-prefix BATS helper bug).
  - Round 3: 1 extractor Result-normalization finding fixed in `05612fe76c6d1c85739bda88bd99ec8bd9d2d15b`.
  - Round 4: clean; no new comments, zero unresolved Copilot threads.
- False positives: none.
- Post-review main sync: no new commits on `origin/main`; no conflict-resolution QA rerun needed.

## Checklist

- [x] Root-cause fix implemented
- [x] Tests/contracts updated
- [x] Local verification completed
- [x] Issue linked
- [x] Copilot PR review clean
- [x] CI green
