### PR TITLE
Fix active UAT finalization before remediation advance

### DIFF
--- a/.github/agents/fix-issue.agent.md
+++ b/.github/agents/fix-issue.agent.md
@@ -322,11 +322,20 @@ Start with cross-model round M = 1. **Repeat the following steps, incrementing M
 
 <main_sync_procedure>
 **Standard main-sync procedure.** Used at designated merge points (steps 22, 24):
-1. `cd <worktree-absolute-path> && git fetch origin && git merge origin/main`
-2. If merge produced conflicts, resolve them first
-3. Run `cd <worktree-absolute-path> && bash testing/run-all.sh` to verify
-4. Push normally (no `--force`)
-5. If conflicts are too complex, abort (`git merge --abort`) and report to the user
+1. `cd <worktree-absolute-path> && git fetch origin`
+2. Check whether `origin/main` has commits not in the branch:
+    ```bash
+    NEW_COMMITS=$(git rev-list HEAD..origin/main --count)
+    echo "Commits behind main: $NEW_COMMITS"
+    ```
+3. If `NEW_COMMITS` is `0`, skip the merge, tests, and push. No code changed at this sync checkpoint, so a full `testing/run-all.sh` run would be redundant; continue to the next workflow step.
+4. If `NEW_COMMITS` is greater than `0`, merge `origin/main`.
+5. If merge produced conflicts, resolve them first.
+6. Run `cd <worktree-absolute-path> && bash testing/run-all.sh` only after the merge, conflict resolution, or another sync step changed the branch/worktree.
+7. Push normally (no `--force`) only when there is a merge commit or other sync change to publish.
+8. If conflicts are too complex, abort (`git merge --abort`) and report to the user.
+
+This no-op skip applies only to main-sync checkpoints. After implementation, QA remediation, conflict resolution, or CI fixes, keep the explicit test requirements for the step that changed code.
 
 **Do NOT merge main outside these designated sync points.** In particular, do not merge main mid-round (between spawning a QA sub-agent and processing its findings), and do not merge main after a Copilot review request is already being processed until that review's findings have been handled — merging changes the code under review and can invalidate findings.
 </main_sync_procedure>

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1526,19 +1526,26 @@ No SUMMARY.md: STOP "Phase {NN} has no completed plans. Run /vbw:vibe first."
 3. Display results per verify.md output format.
 4. **UAT Remediation Auto-Continuation:** This step only applies when verify.md emitted `remediation_continue=true` (which happens when `verify_scope=remediation` AND `status=issues_found` AND running in orchestrated mode from vibe.md). If `remediation_continue` was not set (first-time UAT, complete result, or standalone verify), skip this step entirely — the command ends after step 3.
 
-   **Check the UAT remediation round cap, then advance state:** Read the current round number (read-only, no state mutation) and compare against the configured maximum before advancing:
+   **Prepare the next remediation round through the safe transition helper:** Run `prepare-reverification.sh` exactly once for this transition. This helper finalizes and validates the active UAT before state mutation, applies the UAT remediation round cap, and then performs the next-round transition when allowed. A direct `needs-round` call is not the transition path here because it can mutate `.uat-remediation-stage` before the current UAT is terminal.
 
    ```bash
-   _current_round=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh current-round "{phase-dir}")
-   _cap_decision=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/resolve-uat-remediation-round-limit.sh --next-round-decision .vbw-planning/config.json "${_current_round}" 2>/dev/null)
-   _next_round=$(printf '%s\n' "$_cap_decision" | awk -F= '/^next_round=/{print $2; exit}')
-   _max_rounds=$(printf '%s\n' "$_cap_decision" | awk -F= '/^max_rounds=/{print $2; exit}')
-   _cap_reached=$(printf '%s\n' "$_cap_decision" | awk -F= '/^cap_reached=/{print $2; exit}')
+   _prepare_output=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/prepare-reverification.sh "{phase-dir}" 2>&1)
+   _prepare_status=$?
    ```
 
-   **If `_cap_reached` is empty or `_cap_decision` is empty:** The round-cap helper failed or returned malformed output. Display: "⚠ Could not determine UAT remediation round cap. Re-run the same verify command for this phase (for example, `/vbw:vibe --verify {N}`) to retry." STOP. Do NOT call `needs-round` — no state mutation on error paths.
+   **If `prepare-reverification.sh` exits nonzero:** Display the helper output and STOP. Do not re-enter remediation with stale state.
 
-   **If `_cap_reached=true`:** Display the cap-reached banner and STOP. Do NOT call `needs-round` — no state mutation occurs:
+   **If `_prepare_output` is empty or malformed:** STOP. Required recognized keys are one of `archived=...` or `skipped=...`; valid `skipped` values are `already_archived`, `ready_for_verify`, or `cap_reached`. Malformed prepare output means the transition could not be proven safe.
+
+   Parse the helper output:
+   ```bash
+   _archived=$(printf '%s\n' "$_prepare_output" | awk -F= '/^archived=/{print $2; exit}')
+   _skipped=$(printf '%s\n' "$_prepare_output" | awk -F= '/^skipped=/{print $2; exit}')
+   _round=$(printf '%s\n' "$_prepare_output" | awk -F= '/^round=/{print $2; exit}')
+   _max_rounds=$(printf '%s\n' "$_prepare_output" | awk -F= '/^max_rounds=/{print $2; exit}')
+   ```
+
+   **If `_skipped=cap_reached`:** Display the cap-reached banner and STOP. Use `max_rounds={N}` from the helper output:
    ```text
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
      Reached maximum UAT remediation rounds ({_max_rounds}).
@@ -1548,20 +1555,22 @@ No SUMMARY.md: STOP "Phase {NN} has no completed plans. Run /vbw:vibe first."
    ```
    Do NOT re-enter remediation. STOP.
 
-   **If `_cap_reached` is not true:** The UAT remediation round cap is either unlimited or still under the configured limit. Advance state by calling `needs-round`:
+   **Resolve the new round:** Prefer `round=` from `prepare-reverification.sh` when present. If `round=` is absent after a successful prepare, read the current round as a read-only fallback:
    ```bash
-   bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh needs-round "{phase-dir}"
+   if [ -z "$_round" ]; then
+     _round=$(bash /tmp/.vbw-plugin-root-link-${CLAUDE_SESSION_ID:-default}/scripts/uat-remediation-state.sh current-round "{phase-dir}" 2>/dev/null)
+   fi
    ```
-   Parse `round={next-round}` from the script output (the script outputs `research`, `round={next-round}`, `round_dir={path}` on separate lines — match by key name, not line position).
+   If `_round` is empty after both attempts, treat the prepare output as malformed and STOP.
 
    Display the transition banner and re-enter UAT Remediation mode inline:
    ```text
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-     Re-verification found {N} issue(s). Continuing to Round {next-round}.
+     Re-verification found {N} issue(s). Continuing to Round {_round}.
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ```
    Where `{N}` is the issue count from the `remediation_continue` signal (`issues={N}`).
-   Re-enter UAT Remediation mode (above) for the same `PHASE_DIR`. The `needs-round` call above set the remediation state to `research` for the new round. The UAT Remediation mode's step 4 (`get-or-init`) will resume correctly from the `research` stage.
+   Re-enter UAT Remediation mode (above) for the same `PHASE_DIR`. The prepare helper set the remediation state to `research` for the new round. The UAT Remediation mode's step 4 (`get-or-init`) will resume correctly from the `research` stage.
 
   **Continuation loop behavior:** The re-entered UAT Remediation mode chains into Verify mode after its execute stage completes (existing behavior). If that verification again finds issues, verify.md emits `remediation_continue=true` again, and this step 4 re-checks the UAT remediation round cap. This creates the auto-continuation loop, bounded only when `max_uat_remediation_rounds` resolves to a positive integer. The fallback remediation summary section remains the escape hatch when context window limits prevent continuation mid-loop.
 

--- a/scripts/finalize-uat-status.sh
+++ b/scripts/finalize-uat-status.sh
@@ -29,6 +29,22 @@ if [ ! -f "$UAT_FILE" ]; then
   exit 1
 fi
 
+# The rewrite below only operates inside an existing YAML frontmatter block.
+# Fail closed before parsing/reporting status so callers are not told a
+# frontmatter-less UAT was finalized when no file mutation can occur.
+if ! awk '
+  NR == 1 {
+    if ($0 !~ /^---[[:space:]]*$/) exit 1
+    in_fm = 1
+    next
+  }
+  in_fm && /^---[[:space:]]*$/ { found = 1; exit 0 }
+  END { if (!found) exit 1 }
+' "$UAT_FILE"; then
+  echo "finalize-uat-status: missing YAML frontmatter block" >&2
+  exit 1
+fi
+
 # Parse all **Result:** values from test entries.
 # Returns one token per line: pass, skip, issue, empty, __missing__, or
 # __unknown__:<raw>.

--- a/scripts/finalize-uat-status.sh
+++ b/scripts/finalize-uat-status.sh
@@ -139,29 +139,57 @@ fi
 # Preserves all other frontmatter fields, only updates the target fields
 awk -v status="$STATUS" -v completed="$TODAY" -v passed="$PASSED" \
     -v skipped="$SKIPPED" -v issues="$ISSUES" -v total="$TOTAL" '
-  BEGIN { in_fm = 0; fm_done = 0; saw_completed = 0 }
+  BEGIN {
+    in_fm = 0; fm_done = 0
+    saw_status = 0; saw_completed = 0; saw_passed = 0
+    saw_skipped = 0; saw_issues = 0; saw_total = 0
+  }
   NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; print; next }
   in_fm && /^---[[:space:]]*$/ {
-    # Inject completed field if it was missing from frontmatter
+    # Inject canonical UAT status/count fields if missing. A successful
+    # finalizer rewrite must leave downstream readers with a complete schema,
+    # even for brownfield UAT files that omitted count keys.
+    if (!saw_status) {
+      printf "status: %s\n", status
+    }
     if (!saw_completed && completed != "") {
       printf "completed: %s\n", completed
+    } else if (!saw_completed) {
+      printf "completed:\n"
+    }
+    if (!saw_passed) {
+      printf "passed: %s\n", passed
+    }
+    if (!saw_skipped) {
+      printf "skipped: %s\n", skipped
+    }
+    if (!saw_issues) {
+      printf "issues: %s\n", issues
+    }
+    if (!saw_total) {
+      printf "total_tests: %s\n", total
     }
     in_fm = 0; fm_done = 1; print; next
   }
   in_fm {
     if ($0 ~ /^status[[:space:]]*:/) {
+      saw_status = 1
       printf "status: %s\n", status
     } else if ($0 ~ /^completed[[:space:]]*:/) {
       saw_completed = 1
       if (completed != "") printf "completed: %s\n", completed
       else printf "completed:\n"  # clear stale date for in_progress
     } else if ($0 ~ /^passed[[:space:]]*:/) {
+      saw_passed = 1
       printf "passed: %s\n", passed
     } else if ($0 ~ /^skipped[[:space:]]*:/) {
+      saw_skipped = 1
       printf "skipped: %s\n", skipped
     } else if ($0 ~ /^issues[[:space:]]*:/) {
+      saw_issues = 1
       printf "issues: %s\n", issues
     } else if ($0 ~ /^total_tests[[:space:]]*:/) {
+      saw_total = 1
       printf "total_tests: %s\n", total
     } else {
       print

--- a/scripts/prepare-reverification.sh
+++ b/scripts/prepare-reverification.sh
@@ -65,6 +65,27 @@ resolve_config_path() {
   esac
 }
 
+uat_has_required_finalized_frontmatter() {
+  local file="$1"
+
+  awk '
+    BEGIN {
+      in_fm = 0; saw_fm = 0
+      status = 0; completed = 0; passed = 0
+      skipped = 0; issues = 0; total = 0
+    }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; saw_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm = 0; next }
+    in_fm && /^status[[:space:]]*:[[:space:]]*issues_found[[:space:]]*$/ { status = 1; next }
+    in_fm && /^completed[[:space:]]*:[[:space:]]*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][[:space:]]*$/ { completed = 1; next }
+    in_fm && /^passed[[:space:]]*:[[:space:]]*[0-9][0-9]*[[:space:]]*$/ { passed = 1; next }
+    in_fm && /^skipped[[:space:]]*:[[:space:]]*[0-9][0-9]*[[:space:]]*$/ { skipped = 1; next }
+    in_fm && /^issues[[:space:]]*:[[:space:]]*[0-9][0-9]*[[:space:]]*$/ { issues = 1; next }
+    in_fm && /^total_tests[[:space:]]*:[[:space:]]*[0-9][0-9]*[[:space:]]*$/ { total = 1; next }
+    END { exit !(saw_fm && status && completed && passed && skipped && issues && total) }
+  ' "$file"
+}
+
 # Find the UAT file
 UAT_FILE=$(current_uat "$PHASE_DIR")
 
@@ -80,6 +101,7 @@ fi
 # in_progress; the deterministic finalizer is the source of truth for counts.
 UAT_STATUS=$(extract_status_value "$UAT_FILE")
 UAT_CLASS=$(uat_file_status_class "$UAT_FILE")
+_finalized_active_uat=false
 if [ "$UAT_CLASS" = "active" ]; then
   _finalize_output=""
   if ! _finalize_output=$(bash "$_SCRIPT_DIR_PR/finalize-uat-status.sh" "$UAT_FILE" 2>&1); then
@@ -89,10 +111,16 @@ if [ "$UAT_CLASS" = "active" ]; then
   fi
   UAT_STATUS=$(extract_status_value "$UAT_FILE")
   UAT_CLASS=$(uat_file_status_class "$UAT_FILE")
+  _finalized_active_uat=true
 fi
 
 if [ "$UAT_CLASS" != "issues_found" ]; then
   echo "Error: current UAT is not 'issues_found' and not finalized as 'issues_found' (status='${UAT_STATUS:-empty}', class='${UAT_CLASS:-none}') — refusing to advance" >&2
+  exit 1
+fi
+
+if [ "$_finalized_active_uat" = true ] && ! uat_has_required_finalized_frontmatter "$UAT_FILE"; then
+  echo "Error: current UAT finalization did not produce required 'issues_found' frontmatter keys — refusing to advance" >&2
   exit 1
 fi
 

--- a/scripts/prepare-reverification.sh
+++ b/scripts/prepare-reverification.sh
@@ -75,10 +75,24 @@ if [ -z "$UAT_FILE" ] || [ ! -f "$UAT_FILE" ]; then
   exit 0
 fi
 
-# Check UAT status — only archive issues_found
+# Check and, when safe, finalize UAT status before any stage/round mutation.
+# Active UAT artifacts are often fully answered while frontmatter still says
+# in_progress; the deterministic finalizer is the source of truth for counts.
 UAT_STATUS=$(extract_status_value "$UAT_FILE")
-if [ "$UAT_STATUS" != "issues_found" ]; then
-  echo "Error: UAT status is '${UAT_STATUS:-empty}', not 'issues_found' — refusing to archive" >&2
+UAT_CLASS=$(uat_file_status_class "$UAT_FILE")
+if [ "$UAT_CLASS" = "active" ]; then
+  _finalize_output=""
+  if ! _finalize_output=$(bash "$_SCRIPT_DIR_PR/finalize-uat-status.sh" "$UAT_FILE" 2>&1); then
+    printf '%s\n' "$_finalize_output" >&2
+    echo "Error: current UAT is not finalized as 'issues_found' — refusing to advance" >&2
+    exit 1
+  fi
+  UAT_STATUS=$(extract_status_value "$UAT_FILE")
+  UAT_CLASS=$(uat_file_status_class "$UAT_FILE")
+fi
+
+if [ "$UAT_CLASS" != "issues_found" ]; then
+  echo "Error: current UAT is not 'issues_found' and not finalized as 'issues_found' (status='${UAT_STATUS:-empty}', class='${UAT_CLASS:-none}') — refusing to advance" >&2
   exit 1
 fi
 
@@ -183,6 +197,7 @@ case "$UAT_FILE" in
       echo "round_file=$UAT_BASENAME"
       echo "phase=$PHASE_NUM"
       echo "layout=$_LAYOUT"
+      bash "$_SCRIPT_DIR_PR/uat-remediation-state.sh" current-round "${PHASE_DIR%/}" 2>/dev/null | awk '{ print "round=" $0; exit }' || true
     else
       # Stale UAT from a previous round — current round has no UAT yet.
       # Don't archive or advance rounds; move stage to verify so the
@@ -282,5 +297,6 @@ echo "archived=$UAT_BASENAME"
 echo "round_file=$ROUND_FILE"
 echo "phase=$PHASE_NUM"
 echo "layout=$_LAYOUT"
+bash "$_SCRIPT_DIR_PR/uat-remediation-state.sh" current-round "${PHASE_DIR%/}" 2>/dev/null | awk '{ print "round=" $0; exit }' || true
 
 exit 0

--- a/scripts/uat-remediation-state.sh
+++ b/scripts/uat-remediation-state.sh
@@ -212,8 +212,41 @@ reconcile_uat_state() {
   fi
 }
 
-# Auto-migrate: if old-location state file exists but new doesn't, migrate
-if [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ]; then
+read_state_stage_value() {
+  local file="$1" _val=""
+
+  if grep -q '^stage=' "$file" 2>/dev/null; then
+    _val=$(grep '^stage=' "$file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
+  else
+    _val=$(tr -d '[:space:]' < "$file")
+  fi
+  printf '%s\n' "${_val:-none}"
+}
+
+read_state_round_value() {
+  local file="$1" _val=""
+
+  _val=$(grep '^round=' "$file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]' || true)
+  printf '%s\n' "${_val:-01}"
+}
+
+normalize_round_padded_value() {
+  local raw="$1" num
+
+  num=$(printf '%s\n' "$raw" | sed 's/^0*//')
+  num="${num:-0}"
+  case "$num" in
+    *[!0-9]*|"")
+      echo "Error: invalid UAT remediation round value: $raw" >&2
+      return 1
+      ;;
+  esac
+  printf '%02d\n' "$num"
+}
+
+migrate_legacy_remediation_state_if_needed() {
+  [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ] || return 0
+
   mkdir -p "$PHASE_DIR/remediation/uat"
   cp "$LEGACY_REMED_STATE_FILE" "$STATE_FILE"
   # Migrate existing round dirs
@@ -226,6 +259,44 @@ if [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ]; then
   done
   rm -f "$LEGACY_REMED_STATE_FILE"
   reconcile_uat_state "$STATE_FILE"
+}
+
+preflight_legacy_remediation_needs_round() {
+  local legacy_stage legacy_round legacy_round_padded legacy_uat legacy_uat_class
+
+  [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ] || return 0
+
+  legacy_stage=$(read_state_stage_value "$LEGACY_REMED_STATE_FILE")
+  case "$legacy_stage" in
+    verify|done) ;;
+    *)
+      echo "Error: needs-round requires stage verify or done, got: $legacy_stage" >&2
+      exit 1
+      ;;
+  esac
+
+  legacy_round=$(read_state_round_value "$LEGACY_REMED_STATE_FILE")
+  legacy_round_padded=$(normalize_round_padded_value "$legacy_round") || exit 1
+  legacy_uat="$PHASE_DIR/remediation/round-${legacy_round_padded}/R${legacy_round_padded}-UAT.md"
+  if [ ! -f "$legacy_uat" ]; then
+    echo "Error: needs-round current round UAT evidence is missing for round $legacy_round_padded" >&2
+    exit 1
+  fi
+
+  if type uat_file_status_class >/dev/null 2>&1; then
+    legacy_uat_class=$(uat_file_status_class "$legacy_uat")
+    if [ "$legacy_uat_class" != "issues_found" ]; then
+      echo "Error: needs-round requires a finalized 'issues_found' UAT; current UAT is '$legacy_uat_class': $legacy_uat" >&2
+      exit 1
+    fi
+  fi
+}
+
+# Auto-migrate: if old-location state file exists but new doesn't, migrate.
+# `needs-round` defers this until after read-only validation so rejected calls
+# remain side-effect-free for brownfield old-location remediation layouts.
+if [ "$CMD" != "needs-round" ]; then
+  migrate_legacy_remediation_state_if_needed
 fi
 
 # Major/critical chain order (UAT report serves as discussion — no separate discuss step)
@@ -594,6 +665,10 @@ case "$CMD" in
     # Guard: requires an existing state file — can't advance to "next round" if
     # remediation was never initialized. Without this guard, get_round() defaults
     # to "01" and start_new_round() creates round-02 from a phantom round-01.
+    if [ ! -f "$STATE_FILE" ] && [ -f "$LEGACY_REMED_STATE_FILE" ]; then
+      preflight_legacy_remediation_needs_round
+      migrate_legacy_remediation_state_if_needed
+    fi
     if [ ! -f "$STATE_FILE" ] && [ ! -f "$LEGACY_STATE_FILE" ]; then
       echo "Error: no UAT remediation state exists for $PHASE_DIR — cannot advance to next round without prior init" >&2
       exit 1
@@ -610,15 +685,7 @@ case "$CMD" in
       current_layout=$(get_layout)
       if [ "$current_layout" = "round-dir" ]; then
         current_round=$(get_round)
-        current_round_num=$(printf '%s\n' "$current_round" | sed 's/^0*//')
-        current_round_num="${current_round_num:-0}"
-        case "$current_round_num" in
-          *[!0-9]*|"")
-            echo "Error: needs-round could not resolve numeric current round: $current_round" >&2
-            exit 1
-            ;;
-        esac
-        current_round_padded=$(printf '%02d' "$current_round_num")
+        current_round_padded=$(normalize_round_padded_value "$current_round") || exit 1
         phase_num=$(extract_phase_num)
         current_round_uat="$PHASE_DIR/remediation/uat/round-${current_round_padded}/R${current_round_padded}-UAT.md"
         current_flat_uat="$PHASE_DIR/${phase_num}-UAT-round-${current_round_padded}.md"

--- a/scripts/uat-remediation-state.sh
+++ b/scripts/uat-remediation-state.sh
@@ -598,6 +598,24 @@ case "$CMD" in
       echo "Error: no UAT remediation state exists for $PHASE_DIR — cannot advance to next round without prior init" >&2
       exit 1
     fi
+    current_stage=$(get_stage)
+    case "$current_stage" in
+      verify|done) ;;
+      *)
+        echo "Error: needs-round requires stage verify or done, got: $current_stage" >&2
+        exit 1
+        ;;
+    esac
+    if type current_uat >/dev/null 2>&1 && type uat_file_status_class >/dev/null 2>&1; then
+      current_uat_file=$(current_uat "$PHASE_DIR")
+      if [ -n "$current_uat_file" ] && [ -f "$current_uat_file" ]; then
+        current_uat_class=$(uat_file_status_class "$current_uat_file")
+        if [ "$current_uat_class" != "issues_found" ]; then
+          echo "Error: needs-round requires a finalized 'issues_found' UAT; current UAT is '$current_uat_class': $current_uat_file" >&2
+          exit 1
+        fi
+      fi
+    fi
     start_new_round
     ;;
 

--- a/scripts/uat-remediation-state.sh
+++ b/scripts/uat-remediation-state.sh
@@ -606,13 +606,44 @@ case "$CMD" in
         exit 1
         ;;
     esac
-    if type current_uat >/dev/null 2>&1 && type uat_file_status_class >/dev/null 2>&1; then
-      current_uat_file=$(current_uat "$PHASE_DIR")
-      if [ -n "$current_uat_file" ] && [ -f "$current_uat_file" ]; then
+    if type uat_file_status_class >/dev/null 2>&1; then
+      current_layout=$(get_layout)
+      if [ "$current_layout" = "round-dir" ]; then
+        current_round=$(get_round)
+        current_round_num=$(printf '%s\n' "$current_round" | sed 's/^0*//')
+        current_round_num="${current_round_num:-0}"
+        case "$current_round_num" in
+          *[!0-9]*|"")
+            echo "Error: needs-round could not resolve numeric current round: $current_round" >&2
+            exit 1
+            ;;
+        esac
+        current_round_padded=$(printf '%02d' "$current_round_num")
+        phase_num=$(extract_phase_num)
+        current_round_uat="$PHASE_DIR/remediation/uat/round-${current_round_padded}/R${current_round_padded}-UAT.md"
+        current_flat_uat="$PHASE_DIR/${phase_num}-UAT-round-${current_round_padded}.md"
+        current_uat_file=""
+        if [ -f "$current_round_uat" ]; then
+          current_uat_file="$current_round_uat"
+        elif [ -n "$phase_num" ] && [ -f "$current_flat_uat" ]; then
+          current_uat_file="$current_flat_uat"
+        else
+          echo "Error: needs-round current round UAT evidence is missing for round $current_round_padded" >&2
+          exit 1
+        fi
         current_uat_class=$(uat_file_status_class "$current_uat_file")
         if [ "$current_uat_class" != "issues_found" ]; then
           echo "Error: needs-round requires a finalized 'issues_found' UAT; current UAT is '$current_uat_class': $current_uat_file" >&2
           exit 1
+        fi
+      elif type current_uat >/dev/null 2>&1; then
+        current_uat_file=$(current_uat "$PHASE_DIR")
+        if [ -n "$current_uat_file" ] && [ -f "$current_uat_file" ]; then
+          current_uat_class=$(uat_file_status_class "$current_uat_file")
+          if [ "$current_uat_class" != "issues_found" ]; then
+            echo "Error: needs-round requires a finalized 'issues_found' UAT; current UAT is '$current_uat_class': $current_uat_file" >&2
+            exit 1
+          fi
         fi
       fi
     fi

--- a/testing/verify-uat-autocontinue.sh
+++ b/testing/verify-uat-autocontinue.sh
@@ -10,6 +10,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 PASS=0
 FAIL=0
+VIBE_VERIFY_STEP4_BLOCK=$(sed -n '/4\. \*\*UAT Remediation Auto-Continuation:/,/### Mode: Add Phase/p' "$ROOT/commands/vibe.md")
 
 pass() {
   echo "PASS  $1"
@@ -49,18 +50,19 @@ else
   fail "vibe.md missing transition banner with issue count"
 fi
 
-# 5. vibe.md calls needs-round in auto-continuation path
-if grep -q 'uat-remediation-state.sh needs-round' "$ROOT/commands/vibe.md"; then
-  pass "vibe.md calls needs-round in auto-continuation path"
+# 5. vibe.md Step 4 routes auto-continuation through prepare-reverification
+if echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'prepare-reverification.sh'; then
+  pass "vibe.md Step 4 routes auto-continuation through prepare-reverification.sh"
 else
-  fail "vibe.md missing needs-round call in auto-continuation path"
+  fail "vibe.md Step 4 missing prepare-reverification.sh transition"
 fi
 
-# 6. vibe.md resolves the UAT cap via shared helper-backed decision mode
-if grep -q 'resolve-uat-remediation-round-limit.sh --next-round-decision' "$ROOT/commands/vibe.md" && grep -q 'max_uat_remediation_rounds' "$ROOT/commands/vibe.md"; then
-  pass "vibe.md resolves the UAT remediation round cap via shared decision helper"
+# 6. vibe.md Step 4 explains why prepare-reverification owns this transition
+if echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'finalizes and validates the active UAT before state mutation' \
+  && echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'direct .*needs-round.*not the transition path'; then
+  pass "vibe.md Step 4 documents prepare-reverification transition ownership"
 else
-  fail "vibe.md missing shared helper-backed max_uat_remediation_rounds handling"
+  fail "vibe.md Step 4 missing prepare-reverification transition rationale"
 fi
 
 # 7. defaults.json contains max_uat_remediation_rounds=false
@@ -94,15 +96,11 @@ else
   pass "verify.md orchestrated mode correctly defers needs-round to caller"
 fi
 
-# 11. vibe.md Step 4: cap check (current-round) appears BEFORE needs-round call
-# Structural ordering: the LLM must read the current round and check the cap
-# before calling needs-round, which mutates state.
-_cap_line=$(grep -n 'uat-remediation-state.sh current-round' "$ROOT/commands/vibe.md" | head -1 | cut -d: -f1)
-_needs_line=$(grep -n 'uat-remediation-state.sh needs-round' "$ROOT/commands/vibe.md" | head -1 | cut -d: -f1)
-if [ -n "$_cap_line" ] && [ -n "$_needs_line" ] && [ "$_cap_line" -lt "$_needs_line" ]; then
-  pass "vibe.md: cap check (current-round) appears before needs-round call"
+# 11. vibe.md Step 4 does not directly call needs-round; prepare-reverification owns mutation
+if echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'uat-remediation-state.sh needs-round'; then
+  fail "vibe.md Step 4 must not directly call uat-remediation-state.sh needs-round"
 else
-  fail "vibe.md: cap check must appear BEFORE needs-round call in Step 4 (cap@${_cap_line:-?} vs needs@${_needs_line:-?})"
+  pass "vibe.md Step 4 avoids direct needs-round mutation"
 fi
 
 # 12. vibe.md documents the real prepare-reverification archived/skipped contract
@@ -122,15 +120,15 @@ else
   fail "verify.md missing skipped=ready_for_verify or flat-layout archived basename handling"
 fi
 
-# 14. vibe.md and verify.md fail-close on empty cap-check helper output
-# Both command files must instruct the LLM to STOP (no state mutation) when
-# _cap_reached or _cap_decision is empty — matching the fail-close hardening
-# in phase-detect.sh and prepare-reverification.sh.
-if grep -q '_cap_reached.*empty\|_cap_decision.*empty' "$ROOT/commands/vibe.md" \
-  && grep -q 'no state mutation on error' "$ROOT/commands/vibe.md"; then
-  pass "vibe.md fail-closes on empty/malformed cap-check helper output"
+# 14. vibe.md and verify.md fail-close on malformed transition helper output
+# vibe.md Step 4 must stop when prepare-reverification fails or emits malformed output;
+# verify.md standalone mode still stops on malformed cap-helper output.
+if echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'prepare-reverification.*exits nonzero' \
+  && echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'malformed' \
+  && echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'STOP'; then
+  pass "vibe.md Step 4 fail-closes on nonzero/malformed prepare output"
 else
-  fail "vibe.md missing fail-close guard for empty cap-check helper output"
+  fail "vibe.md Step 4 missing fail-close guard for nonzero/malformed prepare output"
 fi
 if grep -q '_cap_reached.*empty\|_cap_decision.*empty' "$ROOT/commands/verify.md" \
   && grep -q 'no state mutation on error' "$ROOT/commands/verify.md"; then

--- a/testing/verify-uat-autocontinue.sh
+++ b/testing/verify-uat-autocontinue.sh
@@ -72,11 +72,14 @@ else
   fail "defaults.json missing max_uat_remediation_rounds=false"
 fi
 
-# 8. vibe.md and verify.md both handle cap_reached explicitly
-if grep -q 'skipped=cap_reached' "$ROOT/commands/vibe.md" && grep -q 'skipped=cap_reached' "$ROOT/commands/verify.md"; then
-  pass "vibe.md and verify.md both handle cap_reached"
+# 8. vibe.md Verify Step 4 and verify.md both handle cap_reached explicitly
+if echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q '_skipped=cap_reached' \
+  && echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'Reached maximum UAT remediation rounds' \
+  && echo "$VIBE_VERIFY_STEP4_BLOCK" | grep -q 'Do NOT re-enter remediation' \
+  && grep -q 'skipped=cap_reached' "$ROOT/commands/verify.md"; then
+  pass "vibe.md Step 4 and verify.md both handle cap_reached"
 else
-  fail "vibe.md or verify.md missing cap_reached handling"
+  fail "vibe.md Step 4 or verify.md missing cap_reached handling"
 fi
 
 # 9. verify.md standalone mode uses the shared helper before needs-round

--- a/tests/prepare-reverification.bats
+++ b/tests/prepare-reverification.bats
@@ -442,6 +442,49 @@ EOF
   [[ "$output" == *"archived=in-round-dir"* ]]
 }
 
+@test "round-dir layout: finalized active UAT injects missing count fields before advancing" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-05"
+  printf 'stage=verify\nround=05\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md" <<'EOF'
+---
+phase: "03"
+round: "05"
+status: in_progress
+---
+# UAT — Remediation Round 05
+
+## Tests
+
+### D01: Review accepted deviation
+
+- **Result:** pass
+
+### PR05-T01: Verify remediation behavior
+
+- **Result:** PARTIAL — still blocked
+- **Issue:** Reverification still finds the bug
+  - Description: Reverification still finds the bug
+  - Severity: major
+EOF
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/prepare-reverification.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q '^status: issues_found$' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+  grep -q '^passed: 1$' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+  grep -q '^skipped: 0$' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+  grep -q '^issues: 1$' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+  grep -q '^total_tests: 2$' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+  grep -q '^completed: 20' "$PHASE_DIR/remediation/uat/round-05/R05-UAT.md"
+
+  grep -q '^stage=research$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=06$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ -d "$PHASE_DIR/remediation/uat/round-06" ]
+  [[ "$output" == *"archived=in-round-dir"* ]]
+  [[ "$output" == *"round=06"* ]]
+}
+
 @test "round-dir layout: refuses active current-round UAT with incomplete Result before mutation" {
   mkdir -p "$PHASE_DIR/remediation/uat/round-12"
   printf 'stage=verify\nround=12\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"

--- a/tests/prepare-reverification.bats
+++ b/tests/prepare-reverification.bats
@@ -396,3 +396,85 @@ EOF
   grep -q "^round=01$" "$nested_phase/remediation/uat/.uat-remediation-stage"
   [ ! -d "$nested_phase/remediation/uat/round-02" ]
 }
+
+@test "round-dir layout: finalizes active current-round UAT before advancing generically" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-03"
+  printf 'stage=verify\nround=03\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md" <<'EOF'
+---
+phase: "03"
+status: in_progress
+completed:
+total_tests: 2
+passed: 0
+skipped: 0
+issues: 0
+---
+# UAT — Remediation Round 03
+
+## Tests
+
+### D01: Review accepted deviation
+
+- **Result:** pass
+
+### PR03-T01: Verify remediation behavior
+
+- **Result:** issue
+- **Issue:** Reverification still finds the bug
+  - Description: Reverification still finds the bug
+  - Severity: major
+EOF
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/prepare-reverification.sh" "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q '^status: issues_found$' "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md"
+  grep -q '^passed: 1$' "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md"
+  grep -q '^issues: 1$' "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md"
+  grep -q '^total_tests: 2$' "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md"
+  grep -q '^completed: 20' "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md"
+
+  grep -q '^stage=research$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=04$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ -d "$PHASE_DIR/remediation/uat/round-04" ]
+  [[ "$output" == *"archived=in-round-dir"* ]]
+}
+
+@test "round-dir layout: refuses active current-round UAT with incomplete Result before mutation" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-12"
+  printf 'stage=verify\nround=12\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-12/R12-UAT.md" <<'EOF'
+---
+phase: "03"
+status: in_progress
+completed:
+total_tests: 2
+passed: 0
+skipped: 0
+issues: 0
+---
+# UAT — Remediation Round 12
+
+## Tests
+
+### D01: Review accepted deviation
+
+- **Result:** pass
+
+### PR12-T01: Verify remediation behavior
+
+- **Result:**
+EOF
+
+  cd "$TEST_TEMP_DIR"
+  run bash "$SCRIPTS_DIR/prepare-reverification.sh" "$PHASE_DIR"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not finalized as 'issues_found'"* ]]
+  grep -q '^status: in_progress$' "$PHASE_DIR/remediation/uat/round-12/R12-UAT.md"
+  grep -q '^stage=verify$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=12$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ ! -d "$PHASE_DIR/remediation/uat/round-13" ]
+}

--- a/tests/uat-format-finalize.bats
+++ b/tests/uat-format-finalize.bats
@@ -433,6 +433,25 @@ EOF
   [[ "$output" == *"Error"* ]]
 }
 
+@test "finalize-uat-status: missing frontmatter fails closed without rewriting body" {
+  local uat="$TEST_TEMP_DIR/01-UAT.md"
+  create_uat_file "$uat" <<'EOF'
+# UAT without frontmatter
+
+## Tests
+
+### P01-T1: Test one
+
+- **Result:** pass
+EOF
+  cp "$uat" "$uat.before"
+
+  run bash "$SCRIPTS_DIR/finalize-uat-status.sh" "$uat"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing YAML frontmatter block"* ]]
+  cmp -s "$uat.before" "$uat"
+}
+
 # --- finalize-uat-status.sh robustness: edge-case Result values ---
 
 @test "finalize-uat-status: Result with leading whitespace → pass" {

--- a/tests/uat-format-finalize.bats
+++ b/tests/uat-format-finalize.bats
@@ -646,6 +646,51 @@ EOF
   grep -q "^completed: $today" "$uat"
 }
 
+@test "finalize-uat-status: injects missing canonical count fields" {
+  local uat="$TEST_TEMP_DIR/R05-UAT.md"
+  create_uat_file "$uat" <<'EOF'
+---
+phase: 03
+round: 05
+status: in_progress
+---
+
+## Tests
+
+### D01: Review accepted deviation
+
+- **Result:** pass
+
+### PR05-T01: Verify recurring remediation behavior
+
+- **Result:** issue
+- **Issue:** Re-verification still finds the problem
+  - Description: Re-verification still finds the problem
+  - Severity: major
+
+### PR05-T02: Optional follow-up
+
+- **Result:** skip
+EOF
+
+  run bash "$SCRIPTS_DIR/finalize-uat-status.sh" "$uat"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=issues_found"* ]]
+  [[ "$output" == *"passed=1"* ]]
+  [[ "$output" == *"skipped=1"* ]]
+  [[ "$output" == *"issues=1"* ]]
+  [[ "$output" == *"total=3"* ]]
+
+  local today
+  today=$(date +%Y-%m-%d)
+  grep -q '^status: issues_found$' "$uat"
+  grep -q "^completed: $today$" "$uat"
+  grep -q '^passed: 1$' "$uat"
+  grep -q '^skipped: 1$' "$uat"
+  grep -q '^issues: 1$' "$uat"
+  grep -q '^total_tests: 3$' "$uat"
+}
+
 # --- extract-uat-issues.sh lenient parsing tests ---
 
 create_uat_phase() {

--- a/tests/uat-remediation-state.bats
+++ b/tests/uat-remediation-state.bats
@@ -861,6 +861,12 @@ EOF
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
+  cat > "$PHASE_DIR/remediation/uat/round-01/R01-UAT.md" <<'EOF'
+---
+status: issues_found
+---
+# UAT
+EOF
 
   run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
   [ "$status" -eq 0 ]
@@ -938,12 +944,56 @@ EOF
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
   bash "$SCRIPTS_DIR/uat-remediation-state.sh" advance "$PHASE_DIR" >/dev/null
+  cat > "$PHASE_DIR/remediation/uat/round-01/R01-UAT.md" <<'EOF'
+---
+status: issues_found
+---
+# UAT
+EOF
 
   run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
   [ "$status" -eq 0 ]
   [ "$(echo "$output" | head -1)" = "research" ]
   echo "$output" | grep -q "^round=02$"
   [ -d "$PHASE_DIR/remediation/uat/round-02" ]
+}
+
+@test "needs-round refuses previous-round fallback when current round UAT is missing" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-01" "$PHASE_DIR/remediation/uat/round-02"
+  printf 'stage=done\nround=02\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-01/R01-UAT.md" <<'EOF'
+---
+status: issues_found
+---
+# Previous round UAT
+EOF
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"current round UAT evidence is missing"* ]]
+  grep -q '^stage=done$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=02$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ ! -d "$PHASE_DIR/remediation/uat/round-03" ]
+}
+
+@test "needs-round accepts exact current flat archive during migration bridge" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-02"
+  printf 'stage=done\nround=02\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/01-UAT-round-02.md" <<'EOF'
+---
+status: issues_found
+---
+# Flat archive for current round
+EOF
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | head -1)" = "research" ]
+  grep -q '^stage=research$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=03$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ -d "$PHASE_DIR/remediation/uat/round-03" ]
 }
 
 @test "needs-round refuses when current round UAT is active" {

--- a/tests/uat-remediation-state.bats
+++ b/tests/uat-remediation-state.bats
@@ -945,3 +945,39 @@ EOF
   echo "$output" | grep -q "^round=02$"
   [ -d "$PHASE_DIR/remediation/uat/round-02" ]
 }
+
+@test "needs-round refuses when current round UAT is active" {
+  mkdir -p "$PHASE_DIR/remediation/uat/round-03"
+  printf 'stage=verify\nround=03\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md" <<'EOF'
+---
+status: in_progress
+---
+# UAT
+EOF
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"requires a finalized 'issues_found' UAT"* ]]
+  grep -q '^stage=verify$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=03$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  [ ! -d "$PHASE_DIR/remediation/uat/round-04" ]
+}
+
+@test "needs-round refuses lifecycle stages before verify or done" {
+  local stage
+  for stage in research plan execute fix; do
+    rm -rf "$PHASE_DIR/remediation"
+    mkdir -p "$PHASE_DIR/remediation/uat/round-01"
+    printf 'stage=%s\nround=01\nlayout=round-dir\n' "$stage" > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+
+    run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"needs-round requires stage verify or done, got: $stage"* ]]
+    grep -q "^stage=$stage$" "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+    grep -q '^round=01$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+    [ ! -d "$PHASE_DIR/remediation/uat/round-02" ]
+  done
+}

--- a/tests/uat-remediation-state.bats
+++ b/tests/uat-remediation-state.bats
@@ -996,6 +996,76 @@ EOF
   [ -d "$PHASE_DIR/remediation/uat/round-03" ]
 }
 
+@test "needs-round refuses old remediation state before migration when stage is not terminal" {
+  mkdir -p "$PHASE_DIR/remediation/round-01"
+  printf 'stage=research\nround=01\n' > "$PHASE_DIR/remediation/.uat-remediation-stage"
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"needs-round requires stage verify or done, got: research"* ]]
+  [ -f "$PHASE_DIR/remediation/.uat-remediation-stage" ]
+  [ -d "$PHASE_DIR/remediation/round-01" ]
+  [ ! -d "$PHASE_DIR/remediation/uat" ]
+  [ ! -d "$PHASE_DIR/remediation/round-02" ]
+}
+
+@test "needs-round refuses old remediation state before migration when current UAT is active" {
+  mkdir -p "$PHASE_DIR/remediation/round-01"
+  printf 'stage=done\nround=01\n' > "$PHASE_DIR/remediation/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/round-01/R01-UAT.md" <<'EOF'
+---
+status: in_progress
+---
+# Active old-location UAT
+EOF
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"requires a finalized 'issues_found' UAT"* ]]
+  [ -f "$PHASE_DIR/remediation/.uat-remediation-stage" ]
+  [ -f "$PHASE_DIR/remediation/round-01/R01-UAT.md" ]
+  [ ! -d "$PHASE_DIR/remediation/uat" ]
+}
+
+@test "needs-round refuses old remediation state before migration when current UAT evidence is missing" {
+  mkdir -p "$PHASE_DIR/remediation/round-01"
+  printf 'stage=done\nround=01\n' > "$PHASE_DIR/remediation/.uat-remediation-stage"
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"current round UAT evidence is missing"* ]]
+  [ -f "$PHASE_DIR/remediation/.uat-remediation-stage" ]
+  [ -d "$PHASE_DIR/remediation/round-01" ]
+  [ ! -d "$PHASE_DIR/remediation/uat" ]
+  [ ! -d "$PHASE_DIR/remediation/round-02" ]
+}
+
+@test "needs-round migrates old remediation state after finalized current UAT preflight" {
+  mkdir -p "$PHASE_DIR/remediation/round-01"
+  printf 'stage=done\nround=01\n' > "$PHASE_DIR/remediation/.uat-remediation-stage"
+  cat > "$PHASE_DIR/remediation/round-01/R01-UAT.md" <<'EOF'
+---
+status: issues_found
+---
+# Finalized old-location UAT
+EOF
+
+  run bash "$SCRIPTS_DIR/uat-remediation-state.sh" needs-round "$PHASE_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | head -1)" = "research" ]
+  [ ! -f "$PHASE_DIR/remediation/.uat-remediation-stage" ]
+  [ ! -d "$PHASE_DIR/remediation/round-01" ]
+  [ -f "$PHASE_DIR/remediation/uat/round-01/R01-UAT.md" ]
+  [ -d "$PHASE_DIR/remediation/uat/round-02" ]
+  grep -q '^stage=research$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^round=02$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+  grep -q '^layout=round-dir$' "$PHASE_DIR/remediation/uat/.uat-remediation-stage"
+}
+
 @test "needs-round refuses when current round UAT is active" {
   mkdir -p "$PHASE_DIR/remediation/uat/round-03"
   printf 'stage=verify\nround=03\nlayout=round-dir\n' > "$PHASE_DIR/remediation/uat/.uat-remediation-stage"


### PR DESCRIPTION
## Linked Issue

Fixes #619

## What

This PR fixes UAT remediation re-verification drift by making `scripts/prepare-reverification.sh` own the transition from a completed remediation round to the next round, including finalizing the active `R{RR}-UAT.md` before any next-round state mutation. It also hardens lower-level `needs-round` mutation guards, updates `/vbw:vibe` Verify-mode auto-continuation to route through the transition owner, and includes a maintainer-requested fix to `.github/agents/fix-issue.agent.md` so main-sync checkpoints skip redundant local test runs when `origin/main` has not advanced.

## Why

The root cause was an ownership split: `/vbw:vibe` could advance remediation state directly through `scripts/uat-remediation-state.sh needs-round`, bypassing the deterministic finalization and validation responsibility in `scripts/prepare-reverification.sh`. That allowed `.uat-remediation-stage` to move to the next round while the current round UAT still had `status: in_progress`, leaving state reconciliation correctly stuck. The durable fix is to make `prepare-reverification.sh` the transition boundary and make `needs-round` fail closed when called from the wrong lifecycle state or against an unfinalized current UAT.

## How

- `scripts/prepare-reverification.sh`: finalizes active current round-dir UAT artifacts before advancing, preserves cap-reached/fail-closed behavior, and avoids mutating state when Result values are incomplete or malformed.
- `scripts/uat-remediation-state.sh`: adds read-only current-round/current-UAT guards so direct `needs-round` calls cannot skip finalization or run outside `verify`/`done` lifecycle stages.
- `scripts/finalize-uat-status.sh`: updates UAT frontmatter counts/status robustly for pass/skip/issue/fail/partial results and supports injected missing count fields.
- `commands/vibe.md`: routes Verify-mode UAT remediation auto-continuation through `prepare-reverification.sh` instead of calling `needs-round` directly.
- `testing/verify-uat-autocontinue.sh`: scopes the contract check to the Verify Step 4 transition block and verifies fail-closed/cap handling for the prepared transition path.
- `tests/prepare-reverification.bats`, `tests/uat-remediation-state.bats`, `tests/uat-format-finalize.bats`: add behavior coverage for current-round finalization, fail-closed malformed Result handling, direct mutation guards, and finalization semantics.
- `.github/agents/fix-issue.agent.md`: avoids redundant `testing/run-all.sh` runs at no-op main-sync checkpoints where no code changed.

## Acceptance criteria verification

1. `prepare-reverification.sh` finalizes active current round-dir UAT before mutation: covered by `tests/prepare-reverification.bats` current-round finalization scenarios.
2. Successful prepare writes `issues_found`, updated counts/completed date, advances to next round, and creates the next round dir: covered by `tests/prepare-reverification.bats` and `tests/uat-format-finalize.bats`.
3. Empty/malformed checkpoint Result exits nonzero with no mutation: covered by `tests/prepare-reverification.bats` and `tests/uat-format-finalize.bats` malformed Result cases.
4. `needs-round` rejects stages outside `verify`/`done`: covered by `tests/uat-remediation-state.bats` lifecycle guard cases.
5. `needs-round` rejects current UAT status classes other than `issues_found`: covered by `tests/uat-remediation-state.bats` active current UAT guard cases.
6. `/vbw:vibe` Verify Step 4 routes through `prepare-reverification.sh`: covered by `testing/verify-uat-autocontinue.sh`.
7. Cap-reached, malformed/nonzero prepare output, and transition banners are preserved: covered by `testing/verify-uat-autocontinue.sh`.
8. Contract tests assert the Step 4 transition ownership and fail-closed behavior: covered by `testing/verify-uat-autocontinue.sh`.
9. BATS fixtures use generic `R{RR}-UAT.md` coverage, including non-06 rounds: covered by `tests/prepare-reverification.bats`.
10. Local full-suite validation passed from the feature worktree during the fix cycle: `bash testing/run-all.sh` passed with 1/1 lint, 51/51 contract checks, and 3569 BATS passing.

## Testing

- `bash testing/verify-uat-autocontinue.sh`
- `bats tests/prepare-reverification.bats tests/uat-remediation-state.bats tests/uat-format-finalize.bats`
- `bash testing/run-all.sh` — passed during the fix cycle with 1/1 lint, 51/51 contract checks, 3569 BATS passing

Maintainer requested no additional local test reruns after the final `.github/agents/fix-issue.agent.md` no-op sync instruction commit.

## QA summary

- Primary QA: 4 rounds completed.
  - Round 1 fixed medium contract issues around finalization count fields and direct `needs-round` bypasses.
  - Round 2 fixed medium contract issue around legacy old-location stage migration before rejection.
  - Round 3 fixed low contract-test scoping issue in `testing/verify-uat-autocontinue.sh`.
  - Round 4 was clean; empty QA evidence commit added.
- Cross-model QA: skipped because this is a GPT-class session; no different higher-value model-family reviewer was available under the workflow gate.
- Copilot PR review: pending after PR is opened/marked ready.

## Scope notes

This PR intentionally does not change `/vbw:list-todos`, release/version metadata, or external consumer/debug target state. The `.github/agents/fix-issue.agent.md` change is a maintainer-requested workflow correction added to this PR so future fix-workflow runs do not re-run local tests after no-op main-sync checkpoints.
