### PR TITLE
fix(qa): optimize known-issue gate comparisons

### DIFF
--- a/scripts/qa-result-gate.sh
+++ b/scripts/qa-result-gate.sh
@@ -1092,45 +1092,16 @@ extract_frontmatter_json_object_array() {
   local file_path="${1:-}"
   local key_name="${2:-}"
   local kind="${3:-issue}"
-  local item=""
   local tmp_file=""
   [ -f "$file_path" ] || { echo '[]'; return 0; }
   [ -n "$key_name" ] || { echo '[]'; return 0; }
 
-  tmp_file=$(mktemp)
-  while IFS= read -r item; do
-    item=$(printf '%s' "$item" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    [ -n "$item" ] || continue
-    case "$kind" in
-      issue)
-        printf '%s' "$item" | jq -ce '
-          select(
-            type == "object"
-            and (.test | type == "string")
-            and (.file | type == "string")
-            and (.error | type == "string")
-          )
-        ' >> "$tmp_file" 2>/dev/null || true
-        ;;
-      resolution|outcome)
-        printf '%s' "$item" | jq -ce '
-          select(
-            type == "object"
-            and (.test | type == "string")
-            and (.file | type == "string")
-            and (.error | type == "string")
-            and (.disposition | type == "string")
-            and (.rationale | type == "string")
-            and (
-              .disposition == "resolved"
-              or .disposition == "accepted-process-exception"
-              or .disposition == "unresolved"
-            )
-          )
-        ' >> "$tmp_file" 2>/dev/null || true
-        ;;
-    esac
-  done < <(extract_frontmatter_array_items "$file_path" "$key_name")
+  tmp_file=$(mktemp) || { echo '[]'; return 0; }
+  if ! extract_frontmatter_array_items "$file_path" "$key_name" > "$tmp_file" 2>/dev/null; then
+    rm -f "$tmp_file"
+    echo '[]'
+    return 0
+  fi
 
   if [ ! -s "$tmp_file" ]; then
     rm -f "$tmp_file"
@@ -1138,7 +1109,34 @@ extract_frontmatter_json_object_array() {
     return 0
   fi
 
-  jq -sc 'unique_by(.test, .file, .error) | sort_by(.test, .file, .error)' "$tmp_file"
+  jq -Rsc --arg kind "$kind" '
+    def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
+    def valid_issue:
+      type == "object"
+      and (.test | type == "string")
+      and (.file | type == "string")
+      and (.error | type == "string");
+    def valid_resolution:
+      valid_issue
+      and (.disposition | type == "string")
+      and (.rationale | type == "string")
+      and (
+        .disposition == "resolved"
+        or .disposition == "accepted-process-exception"
+        or .disposition == "unresolved"
+      );
+    split("\n")
+    | map(trim | select(length > 0) | (try fromjson catch empty))
+    | if $kind == "issue" then
+        map(select(valid_issue))
+      elif $kind == "resolution" or $kind == "outcome" then
+        map(select(valid_resolution))
+      else
+        []
+      end
+    | unique_by(.test, .file, .error)
+    | sort_by(.test, .file, .error)
+  ' "$tmp_file"
   rm -f "$tmp_file"
 }
 
@@ -1207,12 +1205,18 @@ json_object_array_covers_full_issue_objects() {
   if jq -e -n \
     --slurpfile required "$required_file" \
     --slurpfile candidate "$candidate_file" '
+      def issue_key: [.test, .file, .error] | @json;
       ($required[0] // empty) as $required_array |
       ($candidate[0] // empty) as $candidate_array |
       if (($required_array | type) != "array") or (($candidate_array | type) != "array") then
         false
       else
-        [$candidate_array[] | select(type == "object") | {test: .test, file: .file, error: .error}] as $candidate_identities |
+        (reduce ($candidate_array[] | select(
+          type == "object"
+          and (.test | type == "string")
+          and (.file | type == "string")
+          and (.error | type == "string")
+        )) as $candidate ({}; .[$candidate | issue_key] = true)) as $candidate_index |
         all($required_array[];
           if type != "object" then
             false
@@ -1221,9 +1225,7 @@ json_object_array_covers_full_issue_objects() {
           elif ((.test | type) != "string") or ((.file | type) != "string") or ((.error | type) != "string") then
             false
           else
-            {test: .test, file: .file, error: .error} as $required_identity
-            | $candidate_identities
-            | any(. == $required_identity)
+            ($candidate_index[issue_key] // false) == true
           end
         )
       end
@@ -1267,18 +1269,29 @@ json_object_array_dispositions_match() {
   if jq -e -n \
     --slurpfile expected "$expected_file" \
     --slurpfile actual "$actual_file" '
+      def disposition_key: [.test, .file, .error, .disposition] | @json;
       ($expected[0] // empty) as $expected_array |
       ($actual[0] // empty) as $actual_array |
       if (($expected_array | type) != "array") or (($actual_array | type) != "array") then
         false
       else
-        [$actual_array[] | select(type == "object") | {test: .test, file: .file, error: .error, disposition: .disposition}] as $actual_dispositions |
+        (reduce ($actual_array[] | select(
+          type == "object"
+          and (.test | type == "string")
+          and (.file | type == "string")
+          and (.error | type == "string")
+          and (.disposition | type == "string")
+        )) as $actual_disposition ({}; .[$actual_disposition | disposition_key] = true)) as $actual_disposition_index |
         all($expected_array[];
-          (type != "object")
-          or ((.test // "") == "")
-          or ({test: .test, file: .file, error: .error, disposition: .disposition} as $expected_disposition
-            | $actual_dispositions
-            | any(. == $expected_disposition))
+          if type != "object" then
+            true
+          elif ((.test // "") == "") then
+            true
+          elif ((.test | type) != "string") or ((.file | type) != "string") or ((.error | type) != "string") or ((.disposition | type) != "string") then
+            false
+          else
+            ($actual_disposition_index[disposition_key] // false) == true
+          end
         )
       end
     ' >/dev/null 2>&1; then

--- a/tests/qa-result-gate.bats
+++ b/tests/qa-result-gate.bats
@@ -4593,13 +4593,15 @@ VERIF
 }
 
 @test "known-issue structural helpers avoid delimiter and large-array argv regressions" {
+  gate_extract_body=$(extract_function_span "$REPO_ROOT/scripts/qa-result-gate.sh" "extract_frontmatter_json_object_array" "collect_frontmatter_json_object_array_in_dir") || false
   gate_cover_body=$(extract_function_span "$REPO_ROOT/scripts/qa-result-gate.sh" "json_object_array_covers_full_issue_objects" "load_known_issue_registry_json") || false
   gate_disposition_body=$(extract_function_span "$REPO_ROOT/scripts/qa-result-gate.sh" "json_object_array_dispositions_match" "json_object_array_has_disposition") || false
   snapshot_body=$(extract_function_span "$REPO_ROOT/scripts/qa-remediation-state.sh" "write_known_issue_snapshot" "materialize_round_known_issues_snapshot") || false
+  [ -n "$gate_extract_body" ]
   [ -n "$gate_cover_body" ]
   [ -n "$gate_disposition_body" ]
   [ -n "$snapshot_body" ]
-  combined_body=$(printf '%s\n%s\n%s\n' "$gate_cover_body" "$gate_disposition_body" "$snapshot_body")
+  combined_body=$(printf '%s\n%s\n%s\n%s\n' "$gate_extract_body" "$gate_cover_body" "$gate_disposition_body" "$snapshot_body")
 
   [[ "$combined_body" != *"--argjson issues"* ]]
   [[ "$combined_body" != *"--argjson required"* ]]
@@ -4612,6 +4614,11 @@ VERIF
   [[ "$combined_body" != *"--arg file"* ]]
   [[ "$combined_body" != *"--arg error"* ]]
   [[ "$combined_body" != *"--arg disposition"* ]]
+  [[ "$gate_extract_body" != *"while IFS= read -r item"* ]]
+  [[ "$gate_extract_body" != *"printf '%s' \"\$item\" | jq"* ]]
+  [[ "$gate_extract_body" == *"jq -Rsc"* ]]
+  [[ "$gate_cover_body" == *"@json"* ]]
+  [[ "$gate_disposition_body" == *"@json"* ]]
 }
 
 @test "large Pest namespace known-issue registry avoids argv limits and proceeds" {


### PR DESCRIPTION
## Linked Issue

Fixes #617

## What

Optimizes the known-issue handling path in `scripts/qa-result-gate.sh` so the 3,500-entry Pest known-issue regression no longer creates a process/CPU explosion under `testing/run-all.sh`. The BATS coverage in `tests/qa-result-gate.bats` now also guards the batching/indexing invariants that keep this path fast and argv-safe.

## Why

The root cause was deterministic shell/JQ data processing, not a missing timeout: the gate parsed frontmatter JSON by invoking `jq` per item and then performed repeated array scans for coverage/disposition checks. With thousands of known issues, that became expensive enough to look like a hang while `run-all.sh` captured worker output. The fix keeps validation in the deterministic shell layer and changes the algorithmic shape from per-item process spawning plus repeated scans to batched parsing and indexed lookups.

## How

- `scripts/qa-result-gate.sh`: replaces per-item JSON validation in `extract_frontmatter_json_object_array` with a single `jq -Rsc` batch parse over frontmatter items; replaces O(n²) coverage and disposition scans with delimiter-safe identity indexes keyed by `@json` tuples.
- `tests/qa-result-gate.bats`: extends the structural regression test to require batched parsing and `@json` identity keys while preserving the 3,500-entry Pest fixture and mktemp failure-path coverage.

## Acceptance criteria verification

1. `bash testing/run-all.sh` produces regular completion output and exits without needing manual termination when this shard includes the large Pest known-issue test.
   - Satisfied by the optimized helpers in `scripts/qa-result-gate.sh` lines 1091-1141 and 1184-1298.
   - Verified locally with `bash testing/run-all.sh`: `Lint checks: 1/1 passed`, `Contract checks: 51/51 passed`, `BATS: 3570 passed, 0 failed`, `All checks completed`.

2. The large-registry coverage remains meaningful for avoiding argv-limit regressions.
   - Satisfied by the existing 3,500-entry Pest fixture retained in `tests/qa-result-gate.bats` lines 4624-4703.
   - The structural guard at `tests/qa-result-gate.bats` lines 4595-4621 now rejects argv-heavy/per-item patterns and requires `jq -Rsc` plus delimiter-safe `@json` keys.

3. If the test is intentionally long, the suite emits enough progress or shard-level diagnostics to distinguish expected work from a hang.
   - The test is no longer intentionally long after the root-cause optimization. Focused and full-suite runs completed without manual termination, so no extra run-all log noise was added.
   - Full-suite output included the launch line, per-contract/lint `PASS:` lines, serial BATS marker, final BATS summary, and `All checks completed`.

## Testing

- [x] `bash -n scripts/qa-result-gate.sh`
- [x] `bats tests/qa-result-gate.bats --filter 'known-issue structural helpers|large Pest namespace known-issue registry|known-issue coverage comparison write failure|known-issue disposition comparison write failure'`
- [x] `bats tests/qa-result-gate.bats` — 183 tests, 0 failures
- [x] `bash testing/run-lint.sh`
- [x] `bash testing/run-all.sh` — lint 1/1, contracts 51/51, BATS 3570/0
- [x] `git diff --check`
- [x] GitHub Actions — `CI_GREEN`, all 18 checks passed

## QA summary

- Primary QA: 1 round (`qa-investigator`), clean. Evidence commit: `f3c161b3` (`fix(qa): address QA round 1`).
- Cross-model QA: skipped because this is a GPT-class session; no different eligible model family is available under the workflow gate.
- Copilot PR review: 1 round, clean. Fresh review state `COMMENTED`, commit `f3c161b3814fb2ae56f1315d959c192a5070f2f3`, generated no inline comments and left zero unresolved Copilot-authored threads.

## GitNexus / impact notes

- GitNexus MCP failed to start in this session.
- `npx gitnexus analyze` indexed the worktree, but CLI impact did not resolve bash helper symbols and `detect-changes --scope all` did not map bash/test hunks.
- Fallback scope check: `git diff --stat` reports only `scripts/qa-result-gate.sh` and `tests/qa-result-gate.bats`; `git diff --check` is clean.
