### PR TITLE
fix(debug): require UAT AskUserQuestion boundary

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -601,6 +601,8 @@ If `AUTO_UAT` is `"true"`: skip the prompt and proceed directly.
 
 2. Present checkpoints one at a time using CHECKPOINT + AskUserQuestion:
 
+    **Checkpoint presentation boundary (NON-NEGOTIABLE):** The debug UAT checkpoint loop is conversational and blocking. Each cycle presents exactly one checkpoint, and the CHECKPOINT display plus the `AskUserQuestion` tool_use MUST be emitted in the same assistant response. Treat the checkpoint display and tool call as one atomic presentation step: never split them across turns. A text-only checkpoint is invalid because it gives the user no structured response path and can let the turn end prematurely. Do NOT end the turn after displaying checkpoint text; the only valid pause is waiting for the blocking `AskUserQuestion` response. Do not process an answer, advance to later checkpoints, persist UAT state, or finalize the session until that tool response is available.
+
    Per @${CLAUDE_PLUGIN_ROOT}/references/vbw-brand-essentials.md:
     ```text
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -758,7 +758,7 @@ fi
 if [ -n "$DEBUG_INLINE_UAT_BLOCK" ]; then
   pass "debug.md inline UAT block extracted for scoped contract checks"
 else
-  fail "debug.md inline UAT block extracted for scoped contract checks"
+  fail "debug.md inline UAT block missing; scoped contract checks cannot run"
 fi
 
 if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'CHECKPOINT display plus the `AskUserQuestion` tool_use MUST be emitted in the same assistant response'; then

--- a/testing/verify-debug-session-contract.sh
+++ b/testing/verify-debug-session-contract.sh
@@ -225,6 +225,7 @@ DEBUG_PATH_A_BLOCK="$(sed -n '/^[[:space:]]*\*\*Path A:/,/^[[:space:]]*\*\*Path 
 DEBUG_PATH_B_BLOCK="$(sed -n '/^[[:space:]]*\*\*Path B:/,/^5\./p' "$DEBUG_CMD" 2>/dev/null || true)"
 DEBUG_ACCEPTED_EXCEPTION_BLOCK="$(sed -n '/^[[:space:]]*<accepted_exception_debug_semantics>[[:space:]]*$/,/^[[:space:]]*<\/accepted_exception_debug_semantics>[[:space:]]*$/p' "$DEBUG_CMD" 2>/dev/null || true)"
 DEBUG_STEP5_BLOCK="$(sed -n '/^5\. \*\*Persist to debug session/,/^If `INVESTIGATION_OUTCOME=fixed_now`/p' "$DEBUG_CMD" 2>/dev/null || true)"
+DEBUG_INLINE_UAT_BLOCK="$(sed -n '/^[[:space:]]*<debug_inline_uat>[[:space:]]*$/,/^[[:space:]]*<\/debug_inline_uat>[[:space:]]*$/p' "$DEBUG_CMD" 2>/dev/null || true)"
 
 if grep -q "debug_session_routing" "$DEBUG_CMD" 2>/dev/null; then
   pass "debug.md has debug_session_routing section"
@@ -754,6 +755,44 @@ else
   fail "debug.md missing inline UAT section (debug_inline_uat)"
 fi
 
+if [ -n "$DEBUG_INLINE_UAT_BLOCK" ]; then
+  pass "debug.md inline UAT block extracted for scoped contract checks"
+else
+  fail "debug.md inline UAT block extracted for scoped contract checks"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'CHECKPOINT display plus the `AskUserQuestion` tool_use MUST be emitted in the same assistant response'; then
+  pass "debug.md inline UAT requires checkpoint display and AskUserQuestion in the same assistant response"
+else
+  fail "debug.md inline UAT missing same-response checkpoint + AskUserQuestion contract"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'one atomic presentation step' \
+  && contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'never split them across turns'; then
+  pass "debug.md inline UAT treats checkpoint display and tool call as atomic and unsplittable"
+else
+  fail "debug.md inline UAT missing atomic unsplittable presentation contract"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'A text-only checkpoint is invalid'; then
+  pass "debug.md inline UAT invalidates text-only checkpoints"
+else
+  fail "debug.md inline UAT missing text-only checkpoint invalidation"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'Do NOT end the turn after displaying checkpoint text' \
+  && contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'only valid pause is waiting for the blocking `AskUserQuestion` response'; then
+  pass "debug.md inline UAT forbids ending the turn after checkpoint text"
+else
+  fail "debug.md inline UAT missing no-end-turn/blocking-tool boundary"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'Do not process an answer, advance to later checkpoints, persist UAT state, or finalize the session until that tool response is available'; then
+  pass "debug.md inline UAT blocks answer processing and persistence until tool response"
+else
+  fail "debug.md inline UAT missing blocking response-before-advance contract"
+fi
+
 if contains_literal "$(awk '
   BEGIN { delim=0 }
   /^---$/ {
@@ -772,6 +811,12 @@ if grep -Fq 'question: "Scenario: {scenario description}\n\nExpected: {expected 
   pass "debug.md inline UAT modal question includes Scenario and Expected"
 else
   fail "debug.md inline UAT modal question missing Scenario and Expected"
+fi
+
+if contains_literal "$DEBUG_INLINE_UAT_BLOCK" 'question: "Scenario: {scenario description}\n\nExpected: {expected result}\n\nDoes the behavior match this checkpoint?"'; then
+  pass "debug.md inline UAT scoped block keeps Scenario and Expected in modal question"
+else
+  fail "debug.md inline UAT scoped block missing Scenario and Expected modal question"
 fi
 
 if grep -Fq 'question: "Expected: {expected result}"' "$ROOT/commands/debug.md" 2>/dev/null; then


### PR DESCRIPTION
Fixes #629

## What
Strengthens the `/vbw:debug` inline UAT checkpoint prompt contract and adds scoped contract coverage for that boundary.

- `commands/debug.md`: debug inline UAT Step 2 now says checkpoint text and the `AskUserQuestion` tool_use are one atomic, same-response presentation step; text-only checkpoints are invalid; the model must not end the turn after checkpoint text; and UAT processing cannot advance until the blocking tool response is available.
- `testing/verify-debug-session-contract.sh`: extracts the `<debug_inline_uat>` block specifically and verifies the new same-response, atomic, no-end-turn, text-only-invalid, blocking-response, and self-contained modal invariants.

## Why
The observed failure was not missing tool availability: the same `/vbw:debug` run successfully used `AskUserQuestion` for the QA → UAT gate, then later printed a debug UAT checkpoint and ended the turn without the tool call. The root cause is a prompt-contract gap in the debug inline UAT loop, not the Claude Code platform or normal `/vbw:verify` flow. The durable fix is to make the tool-call boundary explicit where the failing behavior occurs and pin it with a scoped contract test so similar wording elsewhere cannot mask a regression.

## How
- `commands/debug.md`: adds a compact `Checkpoint presentation boundary` paragraph inside `<debug_inline_uat>` Step 2, immediately before the checkpoint display and modal instructions.
- `testing/verify-debug-session-contract.sh`: adds `DEBUG_INLINE_UAT_BLOCK` extraction and literal assertions against that extracted block, keeping the contract tied to the affected debug inline UAT section.
- `testing/verify-debug-session-contract.sh`: Copilot round 1 follow-up corrected the missing-block failure message so failed contract output names the missing invariant instead of repeating the success text.

## Acceptance criteria verification
1. Same assistant response: satisfied by `commands/debug.md` Step 2 wording requiring the CHECKPOINT display plus `AskUserQuestion` tool_use in the same assistant response; checked by `testing/verify-debug-session-contract.sh`.
2. Atomic presentation: satisfied by Step 2 wording that the display and tool call are one atomic presentation step and must never be split across turns; checked by the scoped contract assertions.
3. No end-turn after checkpoint text: satisfied by Step 2 wording forbidding ending the turn after checkpoint text and allowing only the blocking `AskUserQuestion` wait; checked by the scoped contract assertions.
4. Text-only checkpoint invalid: satisfied by Step 2 wording explicitly marking text-only checkpoints invalid; checked by the scoped contract assertions.
5. Blocking response before processing/persistence/finalization: satisfied by Step 2 wording forbidding answer processing, later checkpoints, UAT persistence, or finalization until the tool response is available; checked by the scoped contract assertions.
6. Self-contained modal: unchanged and verified — the modal question still includes `Scenario:` and `Expected:`; checked both globally and inside `<debug_inline_uat>`.
7. Scoped test extraction: satisfied by `DEBUG_INLINE_UAT_BLOCK` extraction from `<debug_inline_uat>` through `</debug_inline_uat>` and assertions against that variable.
8. Targeted checks pass: `verify-debug-session-contract.sh`, `verify-askuserquestion-contract.sh`, and `verify-commands-contract.sh` all passed locally.
9. Full suite passes: `bash testing/run-all.sh` passed locally.

## Testing
- [x] `bash testing/verify-debug-session-contract.sh`
- [x] `bash testing/verify-askuserquestion-contract.sh`
- [x] `bash testing/verify-commands-contract.sh`
- [x] `bash testing/run-all.sh`
- [x] GitHub Actions: all 18 checks passed on `7062af33`

Local full-suite result:
- Lint checks: 1/1 passed
- Contract checks: 51/51 passed
- BATS: 3589 passed, 0 failed

GitHub Actions result:
- `CI_GREEN — all 18 checks passed`

## QA summary
- Primary QA: 1 round, clean PASS, 0 findings. Evidence commit: `cf0a19aa`.
- Cross-model QA: skipped because this is a GitHub Copilot/GPT-class session; no eligible different-model reviewer is available under the workflow gate.
- Copilot PR review round 1: 1 low finding, fixed in `7062af33`.
  - Finding: missing-block failure message in `testing/verify-debug-session-contract.sh` repeated the success message.
  - Resolution: changed the failure message to `debug.md inline UAT block missing; scoped contract checks cannot run`.
- Copilot PR review round 2: clean `COMMENTED` review with no new comments; zero unresolved Copilot threads remain.

## Commits
- `1601b421` — `fix(debug): require UAT AskUserQuestion boundary`
- `cf0a19aa` — `fix(debug): address QA round 1`
- `7062af33` — `fix(debug): address Copilot review round 1`
