### PR TITLE
fix(todos): compact machine-managed STATE todos

### DIFF
--- a/scripts/track-known-issues.sh
+++ b/scripts/track-known-issues.sh
@@ -1223,14 +1223,16 @@ promote_todos() {
       printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" AWK_STOP="$awk_stop_pattern" awk '
         $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
         in_todos && $0 ~ ENVIRON["AWK_STOP"] { in_todos=0; print; next }
-        in_todos && /^[[:space:]]*None\.?[[:space:]]*$/ { print ENVIRON["ENTRIES"]; in_todos=0; next }
+        in_todos && /^[[:space:]]*None\.?[[:space:]]*$/ { if (!inserted) { print ENVIRON["ENTRIES"]; inserted=1 } next }
+        in_todos && /^[[:space:]]*$/ { next }
         { print }
       ' > "$tmp_file"
     else
       # Append new entries before the next section heading after the anchor
       printf '%s\n' "$state_content" | ENTRIES="${new_entries%$'\n'}" AWK_ANCHOR="$awk_anchor" AWK_STOP="$awk_stop_pattern" awk '
         $0 ~ ENVIRON["AWK_ANCHOR"] { in_todos=1; print; next }
-        in_todos && $0 ~ ENVIRON["AWK_STOP"] { print ENVIRON["ENTRIES"]; print ""; in_todos=0; print; next }
+        in_todos && $0 ~ ENVIRON["AWK_STOP"] { print ENVIRON["ENTRIES"]; in_todos=0; print; next }
+        in_todos && /^[[:space:]]*$/ { next }
         { print }
         END { if (in_todos) { print ENVIRON["ENTRIES"] } }
       ' > "$tmp_file"

--- a/scripts/track-uat-deviations.sh
+++ b/scripts/track-uat-deviations.sh
@@ -422,7 +422,6 @@ insert_todo_line() {
     in_todos && $0 ~ stop_re {
       if (!inserted) {
         print todo_line
-        print ""
         inserted = 1
       }
       in_todos = 0
@@ -436,6 +435,7 @@ insert_todo_line() {
       }
       next
     }
+    in_todos && /^[[:space:]]*$/ { next }
     { print }
     END {
       if (in_todos && !inserted) {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -70,6 +70,21 @@ setup_temp_dir() {
   mkdir -p "$TEST_TEMP_DIR/.vbw-planning"
 }
 
+assert_no_blank_lines_in_state_section() {
+  local start_re="$1"
+  local stop_re="$2"
+  local state_path="$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+
+  awk -v start_re="$start_re" -v stop_re="$stop_re" '
+    $0 ~ start_re { seen_start=1; in_section=1; next }
+    in_section && $0 ~ stop_re { seen_stop=1; in_section=0; exit }
+    in_section && /^[[:space:]]*$/ { failed=1; exit }
+    END {
+      if (failed || !seen_start || !seen_stop) exit 1
+    }
+  ' "$state_path"
+}
+
 # Clean up temp directory
 teardown_temp_dir() {
   [ -n "${TEST_TEMP_DIR:-}" ] && rm -rf "$TEST_TEMP_DIR"

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -347,16 +347,6 @@ write_legacy_state_md_with_todos() {
   } > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
-assert_no_blank_lines_in_state_section() {
-  local start_re="$1"
-  local stop_re="$2"
-  awk -v start_re="$start_re" -v stop_re="$stop_re" '
-    $0 ~ start_re { in_section=1; next }
-    in_section && $0 ~ stop_re { exit 0 }
-    in_section && /^[[:space:]]*$/ { exit 1 }
-  ' "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
-}
-
 write_known_issues_registry() {
   local phase_num="$1"
   shift

--- a/tests/track-known-issues.bats
+++ b/tests/track-known-issues.bats
@@ -347,6 +347,16 @@ write_legacy_state_md_with_todos() {
   } > "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
 }
 
+assert_no_blank_lines_in_state_section() {
+  local start_re="$1"
+  local stop_re="$2"
+  awk -v start_re="$start_re" -v stop_re="$stop_re" '
+    $0 ~ start_re { in_section=1; next }
+    in_section && $0 ~ stop_re { exit 0 }
+    in_section && /^[[:space:]]*$/ { exit 1 }
+  ' "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
 write_known_issues_registry() {
   local phase_num="$1"
   shift
@@ -389,6 +399,7 @@ write_known_issues_registry() {
   grep -q "CrashTests.swift" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   # Source traceability from last_seen_in field
   grep -q "(see 03-02)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  assert_no_blank_lines_in_state_section '^## Todos$' '^## '
 }
 
 @test "track-known-issues: promote-todos deduplicates existing entries" {
@@ -421,6 +432,7 @@ write_known_issues_registry() {
   run bash -c 'awk "/^## Todos?$/{f=1;next} f&&/^##/{exit} f" "$1" | grep -q "^None\\.$"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   [ "$status" -ne 0 ]
   grep -q "\[KNOWN-ISSUE\] TestA (A.swift)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  assert_no_blank_lines_in_state_section '^## Todos$' '^## '
 }
 
 @test "track-known-issues: promote-todos handles multiple issues" {
@@ -438,6 +450,7 @@ write_known_issues_registry() {
   # Both new entries present
   grep -q "TestA" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "TestB" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  assert_no_blank_lines_in_state_section '^## Todos$' '^## '
 }
 
 @test "track-known-issues: promote-todos works with legacy Pending Todos layout" {
@@ -456,6 +469,7 @@ write_known_issues_registry() {
   # Legacy section structure preserved
   grep -q "### Pending Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -q "### Completed Todos" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  assert_no_blank_lines_in_state_section '^### Pending Todos$' '(^### Completed Todos$)|(^## )'
 }
 
 @test "track-known-issues: promote-todos appends to non-empty legacy Pending Todos" {
@@ -476,6 +490,7 @@ write_known_issues_registry() {
   # Known issue appears before Completed Todos, not after
   run bash -c 'awk "/^### Completed Todos/{exit} /KNOWN-ISSUE/{found=1} END{exit !found}" "$1"' -- "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   [ "$status" -eq 0 ]
+  assert_no_blank_lines_in_state_section '^### Pending Todos$' '(^### Completed Todos$)|(^## )'
 }
 
 @test "track-known-issues: promote-todos dedup uses exact key not substring" {

--- a/tests/track-uat-deviations.bats
+++ b/tests/track-uat-deviations.bats
@@ -65,6 +65,32 @@ Phase 03
 EOF
 }
 
+write_state_with_existing_flat_todos() {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# Test Project
+
+## Current
+
+Phase 03
+
+## Todos
+
+- Existing manual todo (added 2026-04-01) (ref:11111111)
+
+## Done
+EOF
+}
+
+assert_no_blank_lines_in_state_section() {
+  local start_re="$1"
+  local stop_re="$2"
+  awk -v start_re="$start_re" -v stop_re="$stop_re" '
+    $0 ~ start_re { in_section=1; next }
+    in_section && $0 ~ stop_re { exit 0 }
+    in_section && /^[[:space:]]*$/ { exit 1 }
+  ' "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+}
+
 write_accepted_uat() {
   local sig="$1"
   local result="${2:-pass}"
@@ -267,6 +293,7 @@ EOF
   grep -Fq -- "- [UAT-DEVIATION] R03: Full-project SwiftLint unavailable" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   grep -Fq -- "(added $today) (ref:$ref)" "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
   ! grep -Fxq 'None.' "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
+  assert_no_blank_lines_in_state_section '^## Todos$' '^## '
 
   details="$TEST_TEMP_DIR/.vbw-planning/todo-details.json"
   [ -f "$details" ]
@@ -293,6 +320,25 @@ EOF
   [ "$(jq -r --arg ref "$ref" '.items[$ref].files | index("remediation/uat/round-03/R03-SUMMARY.md") != null' "$details")" = "true" ]
   [ "$(jq -r --arg ref "$ref" '.items[$ref].files | index("remediation/uat/round-03/R03-UAT.md") != null' "$details")" = "true" ]
   [ "$(jq -r --arg ref "$ref" '.items[$ref].files | index("R03-UAT.md") == null' "$details")" = "true" ]
+}
+
+@test "track-uat-deviations: todo-from-uat appends flat todo without blank separators" {
+  local sig ref today todos_block expected_block
+  write_state_with_existing_flat_todos
+  sig=$(bash "$SCRIPT" signature "R03" "remediation/uat/round-03/R03-SUMMARY.md" "Full-project SwiftLint unavailable")
+  write_accepted_uat "$sig"
+  today=$(date +%Y-%m-%d)
+
+  run bash "$SCRIPT" todo-from-uat "$PHASE_DIR" "$PHASE_DIR/remediation/uat/round-03/R03-UAT.md" D01
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"todo_status=added"* ]]
+  ref=$(extract_output_value todo_ref)
+
+  todos_block=$(awk '/^## Todos$/ { found=1; next } found && /^## / { exit } found { print }' "$TEST_TEMP_DIR/.vbw-planning/STATE.md")
+  expected_block=$'- Existing manual todo (added 2026-04-01) (ref:11111111)\n'
+  expected_block+="- [UAT-DEVIATION] R03: Full-project SwiftLint unavailable (phase 03, see remediation/uat/round-03/R03-SUMMARY.md) (added ${today}) (ref:${ref})"
+  [ "$todos_block" = "$expected_block" ]
+  assert_no_blank_lines_in_state_section '^## Todos$' '^## '
 }
 
 @test "track-uat-deviations: todo-from-uat dedupes repeated accepted deviation by ref" {
@@ -327,6 +373,7 @@ EOF
   [[ "$pending_block" == *"[UAT-DEVIATION]"* ]]
   [[ "$pending_block" == *"(ref:$ref)"* ]]
   [[ "$completed_block" != *"[UAT-DEVIATION]"* ]]
+  assert_no_blank_lines_in_state_section '^### Pending Todos$' '(^### Completed Todos$)|(^## )'
 
   list_output=$(cd "$TEST_TEMP_DIR" && bash "$SCRIPTS_DIR/list-todos.sh")
   [ "$(printf '%s' "$list_output" | jq -r '.section')" = "### Pending Todos" ]

--- a/tests/track-uat-deviations.bats
+++ b/tests/track-uat-deviations.bats
@@ -81,16 +81,6 @@ Phase 03
 EOF
 }
 
-assert_no_blank_lines_in_state_section() {
-  local start_re="$1"
-  local stop_re="$2"
-  awk -v start_re="$start_re" -v stop_re="$stop_re" '
-    $0 ~ start_re { in_section=1; next }
-    in_section && $0 ~ stop_re { exit 0 }
-    in_section && /^[[:space:]]*$/ { exit 1 }
-  ' "$TEST_TEMP_DIR/.vbw-planning/STATE.md"
-}
-
 write_accepted_uat() {
   local sig="$1"
   local result="${2:-pass}"
@@ -119,6 +109,40 @@ write_accepted_uat() {
 extract_output_value() {
   local key="$1"
   printf '%s\n' "$output" | awk -F= -v k="$key" '$1 == k {print substr($0, length(k) + 2); exit}'
+}
+
+@test "shared todo section assertion fails closed for malformed STATE fixtures" {
+  cat > "$TEST_TEMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# Test Project
+
+## Current
+Phase 03
+
+## Done
+EOF
+  run assert_no_blank_lines_in_state_section '^## Todos$' '^## '
+  [ "$status" -ne 0 ]
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# Test Project
+
+## Todos
+- Existing todo
+EOF
+  run assert_no_blank_lines_in_state_section '^## Todos$' '^## '
+  [ "$status" -ne 0 ]
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/STATE.md" <<'EOF'
+# Test Project
+
+## Todos
+- Existing todo
+
+- Another todo
+## Done
+EOF
+  run assert_no_blank_lines_in_state_section '^## Todos$' '^## '
+  [ "$status" -ne 0 ]
 }
 
 @test "track-uat-deviations: signature is stable for source identity and text" {


### PR DESCRIPTION
Fixes #630

## What

This PR compacts deterministic machine-managed `STATE.md` todo insertion for accepted UAT deviations and known-issue promotion. `scripts/track-uat-deviations.sh` now suppresses blank-only lines while rewriting the active todo section, and `scripts/track-known-issues.sh` applies the same invariant for both `None.` replacement and append-before-heading promotion. Focused BATS coverage now asserts the compact no-blank-lines invariant for flat and legacy todo layouts.

## Why

The root cause was script-side awk mutation logic that preserved existing blank separators inside the active todo section and, for append paths, emitted an additional blank line before the next section heading. Fixing the deterministic writers is the durable architectural fix because it restores the `STATE.md` formatting invariant at the mutation boundary rather than spending prompt tokens asking agents to avoid a formatting symptom.

## How

- `scripts/track-uat-deviations.sh`: removes the explicit blank emitted after new `[UAT-DEVIATION]` insertion and skips blank-only lines while `insert_todo_line` is inside the active todo section.
- `scripts/track-known-issues.sh`: keeps the `None.` replacement branch active until the stop heading so trailing blanks are suppressed, avoids duplicate replacement with an `inserted` guard, skips blank-only lines while active, and removes the explicit blank emitted before the stop heading in append mode.
- `tests/test_helper.bash`: adds a shared `assert_no_blank_lines_in_state_section` helper that fails closed when the start heading is missing, the stop heading is missing, or a blank-only line appears inside the active section.
- `tests/track-uat-deviations.bats`: adds flat non-empty append coverage, no-blank-lines assertions for flat `None.`, flat append, and legacy Pending Todos insertion, plus negative coverage for malformed STATE fixtures.
- `tests/track-known-issues.bats`: adds no-blank-lines assertions for flat `None.`, flat append, multi-entry append, legacy `None.`, and legacy append promotion.

## Acceptance criteria verification

1. `scripts/track-uat-deviations.sh` writes a `[UAT-DEVIATION]` todo into flat `## Todos` replacing `None.` without blank-only lines inside the active todo section. Satisfied by the updated `insert_todo_line` blank suppression and `tests/track-uat-deviations.bats` assertion in `todo-from-uat adds UAT deviation todo and detail from phase root`.
2. `scripts/track-uat-deviations.sh` appends a `[UAT-DEVIATION]` todo to a non-empty flat `## Todos` section as a contiguous bullet before the next `##` heading, with no blank-only line between bullets or before the stop heading. Satisfied by `todo-from-uat appends flat todo without blank separators`.
3. `scripts/track-uat-deviations.sh` appends a `[UAT-DEVIATION]` todo to legacy `### Pending Todos` before `### Completed Todos` as a contiguous bullet, preserving completed-section isolation. Satisfied by `todo-from-uat inserts legacy todos before completed section`.
4. `scripts/track-known-issues.sh` promotes known issues into flat `## Todos` replacing `None.` without blank-only lines inside the active todo section. Satisfied by `promote-todos adds new issues to STATE.md` and `promote-todos replaces None placeholder`.
5. `scripts/track-known-issues.sh` appends one or more `[KNOWN-ISSUE]` todos to a non-empty flat `## Todos` section as contiguous bullets before the next `##` heading. Satisfied by `promote-todos handles multiple issues`.
6. `scripts/track-known-issues.sh` promotes known issues into legacy `### Pending Todos` for both `None.` replacement and append-to-existing cases without blank-only lines inside the active pending section. Satisfied by `promote-todos works with legacy Pending Todos layout` and `promote-todos appends to non-empty legacy Pending Todos`.
7. Existing duplicate detection, known-issue suppression, accepted-process-exception annotation updates, detail sidecar writes, legacy ref healing, and `list-todos.sh` parsing behavior remain unchanged. Satisfied by unchanged existing logic plus the passing focused and full test suite, including `tests/todo-lifecycle.bats` and `testing/verify-todo-pickup-contract.sh`.
8. Focused tests cover the compact no-blank-lines invariant for UAT deviation insertion and known-issue promotion, and `bash testing/run-all.sh` passes. Satisfied by the new assertions, fail-closed shared helper coverage, local validation, and green CI listed below.

## Testing

- [x] `bats tests/track-uat-deviations.bats tests/track-known-issues.bats tests/todo-lifecycle.bats` — 75 tests, 0 failures
- [x] `bash testing/verify-todo-pickup-contract.sh` — 87 passed, 0 failed
- [x] `bash testing/run-all.sh` after initial implementation — lint 1/1, contracts 51/51, BATS 3590 passed, 0 failed
- [x] `bats tests/track-uat-deviations.bats && bats tests/track-known-issues.bats` after Copilot remediation — 19 + 29 tests, 0 failures
- [x] `bash testing/run-all.sh` after Copilot remediation — lint 1/1, contracts 51/51, BATS 3591 passed, 0 failed
- [x] `bash testing/run-all.sh` after merging latest `origin/main` — lint 1/1, contracts 51/51, BATS 3591 passed, 0 failed
- [x] GitHub Actions on `b2a5dc930a1537814ed97c90e551ffbfc83f7d14` — CI_GREEN, all 18 checks passed
- [x] GitNexus file-level impact analysis for `track-uat-deviations.sh`, `track-known-issues.sh`, and `tests/test_helper.bash` — LOW risk, 0 direct callers/processes/modules reported. Function-level shell symbols were not indexed by GitNexus.
- [x] GitNexus `detect-changes --scope all` — exited successfully; no graph-mapped symbol changes detected.

## QA summary

- Primary QA: 1 round completed with `qa-investigator`; 0 legitimate findings. Evidence commit: `6530d069`.
- Cross-model QA: skipped by workflow gate because this GitHub Copilot session is not Opus-class.
- Copilot PR review round 1: 2 low-severity test-helper findings fixed in `90b9c560`; both threads replied to and resolved.
- Copilot PR review round 2: clean fresh review on `b2a5dc93`; generated no new comments and unresolved Copilot thread count is 0.
- Main sync: latest `origin/main` merged cleanly; post-review sync found 0 new commits on main and PR merge state is CLEAN.
