### PR TITLE
fix(pre-push-hook): guard --verify call with plugin-name check (closes #635)

### DIFF
--- a/scripts/pre-push-hook.sh
+++ b/scripts/pre-push-hook.sh
@@ -21,6 +21,22 @@ if [ ! -f "$ROOT/scripts/bump-version.sh" ]; then
   exit 0
 fi
 
+# Plugin-name guard (issue #635): mirror validate-commit.sh's check so we never
+# invoke `--verify` against a non-VBW bump-version.sh. Many repos have their own
+# `scripts/bump-version.sh` that interprets `$1` as the new semver string —
+# calling such a script with `--verify` corrupts every package.json `version`
+# field. Only proceed when this is a VBW-managed repo (the same condition
+# validate-commit.sh already enforces). Non-VBW repos can either name their
+# plugin `vbw` in `.claude-plugin/plugin.json`, or `git push --no-verify` to
+# bypass.
+if [ ! -f "$ROOT/.claude-plugin/plugin.json" ]; then
+  exit 0
+fi
+PLUGIN_NAME=$(jq -r '.name // ""' "$ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "")
+if [ "$PLUGIN_NAME" != "vbw" ]; then
+  exit 0
+fi
+
 VERIFY_OUTPUT=$(bash "$ROOT/scripts/bump-version.sh" --verify 2>&1) || {
   echo ""
   echo "ERROR: Push blocked -- version files are out of sync."


### PR DESCRIPTION
## Summary

Fixes #635 — `scripts/pre-push-hook.sh` invokes `bash scripts/bump-version.sh --verify` against any repo that has a `scripts/bump-version.sh` file, with no check that the script implements VBW's `--verify` convention. In repos whose `bump-version.sh` predates VBW (or follows different conventions), `--verify` gets interpreted as the new semver string and is persisted as the literal `"--verify"` into every `package.json` `version` field — silent data corruption on every push.

The sibling PostToolUse hook `scripts/validate-commit.sh` already has the correct guard at lines 51-53. This PR mirrors it in `pre-push-hook.sh`.

## Patch

4 new lines, immediately before the existing `--verify` call:

```bash
if [ ! -f "$ROOT/.claude-plugin/plugin.json" ]; then
  exit 0
fi
PLUGIN_NAME=$(jq -r '.name // ""' "$ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "")
if [ "$PLUGIN_NAME" != "vbw" ]; then
  exit 0
fi
```

## Test plan

Manual smoke tests against three scenarios:

| Scenario | Plugin guard | Behaviour |
|---|---|---|
| VBW's own repo (`name=vbw`) | PROCEEDS | calls `--verify` as before (no regression) |
| Non-VBW repo with `scripts/bump-version.sh` but no `.claude-plugin/plugin.json` | SKIPS | exit 0 silently — no corruption |
| Non-VBW plugin (`name=other`) | SKIPS | exit 0 silently — no corruption |

All three matched expected behaviour.

Suggested additional coverage before merge (not in this PR — happy to follow up if you want):
- A real test in `tests/` that exercises `pre-push-hook.sh` against a fixture repo with a non-VBW `bump-version.sh`. Today's coverage is manual + the smoke verification documented in #635.

## Compatibility

- **VBW's own development workflow:** unchanged (the version-consistency check still fires on every push from this repo, because `.claude-plugin/plugin.json` here has `name=vbw`).
- **Third-party repos using VBW:** the hook becomes inert unless they intentionally name their plugin `vbw`. This is a soft block — they can still use `git push --no-verify` to bypass, or rename their plugin if they want the check.
- **Repos that DO ship a VBW-shaped `bump-version.sh --verify` mode but a different plugin name:** the guard would skip them too. If that's a meaningful population, a follow-up could relax the check to "if `bump-version.sh --verify` exists as a documented mode" — but the simplest correctness-preserving fix today is to mirror `validate-commit.sh` exactly.

## Discovery context

Hit this while running VBW against `swt-labs/stop-wasting-tokens` during M1 of a v3 redesign. Every push silently rewrote ~10 `package.json` `version` fields. Caught it by inspecting `git status` after pushes — full trail in #635, including a workaround commit (a `--verify` mode added to the local `bump-version.sh`) at `swt-labs/stop-wasting-tokens@2dd44ee`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)