### PR TITLE
fix(statusline): add CLAUDE_CODE_CONTEXT_WINDOW_FLOOR for under-reported context windows

### DIFF
--- a/config/model-context-windows.json
+++ b/config/model-context-windows.json
@@ -1,9 +1,0 @@
-{
-  "_comment": "Known context window sizes by model ID. Used to correct under-reported or missing context_window_size values from Claude Code hook events. Update when new large-context models are released.",
-  "windows": {
-    "claude-opus-4-7": 1000000,
-    "claude-sonnet-4-6": 1000000,
-    "claude-haiku-4-5": 1000000,
-    "claude-haiku-4-5-20251001": 1000000
-  }
-}

--- a/config/model-context-windows.json
+++ b/config/model-context-windows.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Known context window sizes by model ID. Used to correct under-reported or missing context_window_size values from Claude Code hook events. Update when new large-context models are released.",
+  "windows": {
+    "claude-opus-4-7": 1000000,
+    "claude-sonnet-4-6": 1000000,
+    "claude-haiku-4-5": 1000000,
+    "claude-haiku-4-5-20251001": 1000000
+  }
+}

--- a/config/token-budgets.json
+++ b/config/token-budgets.json
@@ -1,5 +1,5 @@
 {
-  "_comment_context_windows": "All Claude 4.x models have ~200K token context windows (~800K chars at 4:1 ratio)",
+  "_comment_context_windows": "Claude 4.x context windows vary by model: Sonnet 4.6, Opus 4.7, and Haiku 4.5 have 1M token windows; older Claude 4 models had ~200K. Budgets are sized as a conservative percentage of 200K to stay safe across all models.",
   "_comment_scaling_rationale": "Budgets are set at 1-4% of model context windows to leave headroom for instructions, codebase context, and prior conversation. Character budgets used instead of tokens for cross-model consistency and simpler enforcement.",
   "_comment_percentage_breakdown": {
     "scout": "1% of 800K = 8K chars (Sonnet/Haiku - research queries)",

--- a/scripts/vbw-statusline.sh
+++ b/scripts/vbw-statusline.sh
@@ -395,6 +395,7 @@ for _floor_sdir in "${CLAUDE_CONFIG_DIR:-}" "$HOME/.config/claude-code" "$HOME/.
   [ -n "$_S_FLOOR" ] && break
 done
 _AC_FLOOR="${CLAUDE_CODE_CONTEXT_WINDOW_FLOOR:-${_S_FLOOR:-}}"
+unset _floor_sdir _S_FLOOR
 
 # Match Claude Code's truthiness check: "1", "true", "yes", "on" all disable
 # Uses case-insensitive patterns for bash 3.2 compatibility (macOS default)
@@ -406,16 +407,19 @@ esac
 # Strip leading zeros to prevent bash octal interpretation (e.g., "08000" → "8000")
 _ac_dec() { local v="${1#"${1%%[!0]*}"}"; echo "${v:-0}"; }
 
-if [ "$_AC_SKIP" = "false" ] && [ "${CTX_SIZE:-0}" -gt 0 ] 2>/dev/null; then
-  # Apply context window floor before cap: raises CTX_SIZE when Claude Code
-  # under-reports context_window_size (set CLAUDE_CODE_CONTEXT_WINDOW_FLOOR to
-  # your actual window, e.g. 1000000 for Sonnet 4.6 + extra usage on Max plan).
-  if [ -n "$_AC_FLOOR" ]; then
-    _FL="$(_ac_dec "${_AC_FLOOR%%.*}")"
-    if [ "${_FL:-0}" -gt "${CTX_SIZE:-0}" ] 2>/dev/null; then
-      CTX_SIZE="$_FL"
-    fi
+# Apply context window floor unconditionally (display correction, independent of
+# whether autocompact normalization is active). Raises CTX_SIZE when Claude Code
+# under-reports context_window_size for the user's subscription window.
+# Set CLAUDE_CODE_CONTEXT_WINDOW_FLOOR to your actual window (e.g. 1000000 for
+# Sonnet 4.6 + extra usage on a Max plan).
+if [ -n "$_AC_FLOOR" ] && [ "${CTX_SIZE:-0}" -gt 0 ] 2>/dev/null; then
+  _FL="$(_ac_dec "${_AC_FLOOR%%.*}")"
+  if [ "${_FL:-0}" -gt "${CTX_SIZE:-0}" ] 2>/dev/null; then
+    CTX_SIZE="$_FL"
   fi
+fi
+
+if [ "$_AC_SKIP" = "false" ] && [ "${CTX_SIZE:-0}" -gt 0 ] 2>/dev/null; then
   # Apply AUTO_COMPACT_WINDOW cap (if set, use the smaller of window and cap)
   _AC_CTX="$CTX_SIZE"
   if [ -n "$_AC_WINDOW_CAP" ]; then

--- a/scripts/vbw-statusline.sh
+++ b/scripts/vbw-statusline.sh
@@ -326,6 +326,7 @@ MODEL=${MODEL:-Claude}; VER=${VER:-?}
 # make users think they have more headroom than they do. Normalize so 100% = trigger.
 #
 # Algorithm (reverse-engineered from cli.js v2.1.76):
+#   context_window   = max(reported, CONTEXT_WINDOW_FLOOR)  [if floor set]
 #   effective_window = context_window - min(max_output_tokens, 20000)
 #   default_trigger  = effective_window - 13000
 #   override_trigger = floor(effective_window * pct / 100)   [if override set]
@@ -346,6 +347,10 @@ MODEL=${MODEL:-Claude}; VER=${VER:-?}
 #     Older models (3.5 Sonnet=8K, Claude 3=4K) use smaller deductions internally,
 #     making our buffer estimate ~12K too large (pessimistic/safe direction).
 #     Users on older models can set CLAUDE_CODE_MAX_OUTPUT_TOKENS for accuracy.
+#   - FLOOR and CAP interact: floor raises the raw window; cap then clamps the
+#     trigger-math reference. Setting FLOOR > CAP produces no benefit — the cap
+#     still governs the trigger and the floor has no effect on the displayed window.
+#     Avoid combining them. If both are set and FLOOR > CAP, use only FLOOR.
 
 _AC_DISABLED=""
 _AC_OVERRIDE=""

--- a/scripts/vbw-statusline.sh
+++ b/scripts/vbw-statusline.sh
@@ -321,20 +321,6 @@ CACHE_W=${CACHE_W:-0}; CACHE_R=${CACHE_R:-0}; COST=${COST:-0}
 DUR_MS=${DUR_MS:-0}; API_MS=${API_MS:-0}; ADDED=${ADDED:-0}; REMOVED=${REMOVED:-0}
 MODEL=${MODEL:-Claude}; VER=${VER:-?}
 
-# Correct under-reported context_window_size for large-context models.
-# Claude Code may report 200K (or omit the field) for models with 1M context windows,
-# causing the trigger threshold to be computed against 200K instead of 1M.
-# Use a lookup table to ensure CTX_SIZE reflects the actual model window before
-# the compaction trigger is calculated.
-_MODEL_ID=$(printf '%s' "$input" | jq -r '.model.id // ""' 2>/dev/null || echo "")
-_WIN_CFG="$_SL_SCRIPT_DIR/../config/model-context-windows.json"
-if [ -n "$_MODEL_ID" ] && [ -f "$_WIN_CFG" ]; then
-  _KNOWN_WIN=$(jq -r --arg m "$_MODEL_ID" '.windows[$m] // 0' "$_WIN_CFG" 2>/dev/null || echo "0")
-  if [ "${_KNOWN_WIN:-0}" -gt "${CTX_SIZE:-0}" ] 2>/dev/null; then
-    CTX_SIZE="$_KNOWN_WIN"
-  fi
-fi
-
 # --- Autocompact buffer normalization (#237) ---
 # Claude Code reserves context for autocompact that's never usable. Raw percentages
 # make users think they have more headroom than they do. Normalize so 100% = trigger.
@@ -351,8 +337,9 @@ fi
 #            1M + override=95 → buffer=69K (6.9%)
 #
 # Also respects:
-#   CLAUDE_CODE_AUTO_COMPACT_WINDOW — caps context window for compact math
-#   CLAUDE_CODE_MAX_OUTPUT_TOKENS   — min(value, 20000) for output deduction
+#   CLAUDE_CODE_CONTEXT_WINDOW_FLOOR — raises CTX_SIZE when CC under-reports (e.g. 1000000)
+#   CLAUDE_CODE_AUTO_COMPACT_WINDOW  — caps context window for compact math
+#   CLAUDE_CODE_MAX_OUTPUT_TOKENS    — min(value, 20000) for output deduction
 # Notes:
 #   - Override decimals (e.g., 95.5) handled via fixed-point x10 math.
 #   - Output token deduction defaults to 20K (correct for Claude 4 family).
@@ -364,6 +351,7 @@ _AC_DISABLED=""
 _AC_OVERRIDE=""
 _AC_WINDOW_CAP=""
 _AC_MAX_OUTPUT=""
+_AC_FLOOR=""
 
 # Resolve env vars: real env > settings.json env block (single jq call for all 4)
 # Note: first settings.json with any env value wins — values are NOT merged across files.
@@ -389,6 +377,20 @@ _AC_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-$_S_OVERRIDE}"
 _AC_WINDOW_CAP="${CLAUDE_CODE_AUTO_COMPACT_WINDOW:-$_S_WINDOW}"
 _AC_MAX_OUTPUT="${CLAUDE_CODE_MAX_OUTPUT_TOKENS:-$_S_OUTPUT}"
 
+# CLAUDE_CODE_CONTEXT_WINDOW_FLOOR: read separately to avoid changing the 4-field
+# join sentinel ("|||") and IFS read above. Raises CTX_SIZE when Claude Code
+# under-reports context_window_size for a user's actual subscription window.
+# Example: Sonnet 4.6 on Max with extra usage enabled has 1M, but CC may report 200K.
+# Set to your actual window: e.g. 1000000 or 500000.
+_S_FLOOR=""
+for _floor_sdir in "${CLAUDE_CONFIG_DIR:-}" "$HOME/.config/claude-code" "$HOME/.claude"; do
+  [ -z "$_floor_sdir" ] && continue
+  [ -f "$_floor_sdir/settings.json" ] || continue
+  _S_FLOOR=$(jq -r '.env.CLAUDE_CODE_CONTEXT_WINDOW_FLOOR // ""' "$_floor_sdir/settings.json" 2>/dev/null)
+  [ -n "$_S_FLOOR" ] && break
+done
+_AC_FLOOR="${CLAUDE_CODE_CONTEXT_WINDOW_FLOOR:-${_S_FLOOR:-}}"
+
 # Match Claude Code's truthiness check: "1", "true", "yes", "on" all disable
 # Uses case-insensitive patterns for bash 3.2 compatibility (macOS default)
 _AC_SKIP=false
@@ -400,6 +402,15 @@ esac
 _ac_dec() { local v="${1#"${1%%[!0]*}"}"; echo "${v:-0}"; }
 
 if [ "$_AC_SKIP" = "false" ] && [ "${CTX_SIZE:-0}" -gt 0 ] 2>/dev/null; then
+  # Apply context window floor before cap: raises CTX_SIZE when Claude Code
+  # under-reports context_window_size (set CLAUDE_CODE_CONTEXT_WINDOW_FLOOR to
+  # your actual window, e.g. 1000000 for Sonnet 4.6 + extra usage on Max plan).
+  if [ -n "$_AC_FLOOR" ]; then
+    _FL="$(_ac_dec "${_AC_FLOOR%%.*}")"
+    if [ "${_FL:-0}" -gt "${CTX_SIZE:-0}" ] 2>/dev/null; then
+      CTX_SIZE="$_FL"
+    fi
+  fi
   # Apply AUTO_COMPACT_WINDOW cap (if set, use the smaller of window and cap)
   _AC_CTX="$CTX_SIZE"
   if [ -n "$_AC_WINDOW_CAP" ]; then

--- a/scripts/vbw-statusline.sh
+++ b/scripts/vbw-statusline.sh
@@ -321,6 +321,20 @@ CACHE_W=${CACHE_W:-0}; CACHE_R=${CACHE_R:-0}; COST=${COST:-0}
 DUR_MS=${DUR_MS:-0}; API_MS=${API_MS:-0}; ADDED=${ADDED:-0}; REMOVED=${REMOVED:-0}
 MODEL=${MODEL:-Claude}; VER=${VER:-?}
 
+# Correct under-reported context_window_size for large-context models.
+# Claude Code may report 200K (or omit the field) for models with 1M context windows,
+# causing the trigger threshold to be computed against 200K instead of 1M.
+# Use a lookup table to ensure CTX_SIZE reflects the actual model window before
+# the compaction trigger is calculated.
+_MODEL_ID=$(printf '%s' "$input" | jq -r '.model.id // ""' 2>/dev/null || echo "")
+_WIN_CFG="$_SL_SCRIPT_DIR/../config/model-context-windows.json"
+if [ -n "$_MODEL_ID" ] && [ -f "$_WIN_CFG" ]; then
+  _KNOWN_WIN=$(jq -r --arg m "$_MODEL_ID" '.windows[$m] // 0' "$_WIN_CFG" 2>/dev/null || echo "0")
+  if [ "${_KNOWN_WIN:-0}" -gt "${CTX_SIZE:-0}" ] 2>/dev/null; then
+    CTX_SIZE="$_KNOWN_WIN"
+  fi
+fi
+
 # --- Autocompact buffer normalization (#237) ---
 # Claude Code reserves context for autocompact that's never usable. Raw percentages
 # make users think they have more headroom than they do. Normalize so 100% = trigger.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_CONTEXT_WINDOW_FLOOR` env var (real env or `settings.json .env` block)
- When set, raises `CTX_SIZE` to the floor value before the compaction trigger is calculated
- Reverts the prior incorrect `config/model-context-windows.json` approach
- Updates stale `token-budgets.json` comment about Claude 4.x context windows

Fixes #638

## Why the model-lookup approach was wrong

Context window size for Sonnet 4.6 depends on subscription tier + extra usage:
- All paid plans (chat): 500K
- Claude Code, paid plan, extra usage enabled: 1M
- Claude Code, no extra usage: unknown (likely 200K or 500K)

Hardcoding 1M for all Sonnet 4.6 users would break the status line for users who
genuinely have a smaller window. Claude Code already knows the correct value for
the user's subscription — if it reports 200K while the user has 1M, that is a
Claude Code under-reporting issue.

## The correct fix

A user-configurable floor that the affected user can set explicitly:

```json
// settings.json
{ "env": { "CLAUDE_CODE_CONTEXT_WINDOW_FLOOR": "1000000" } }
```

Same pattern as the existing `CLAUDE_CODE_AUTO_COMPACT_WINDOW` cap, but working
upward instead of downward.

## Test plan

- [ ] Shell syntax: `bash -n scripts/vbw-statusline.sh`
- [ ] ShellCheck: `shellcheck -S warning scripts/vbw-statusline.sh`
- [ ] Contract tests: `bash testing/verify-bash-scripts-contract.sh`
- [ ] Smoke: set `CLAUDE_CODE_CONTEXT_WINDOW_FLOOR=1000000` in settings.json, status line shows ~967K window

🤖 Generated with [Claude Code](https://claude.com/claude-code)