### PR TITLE
fix(state): parse ROADMAP checklist items with markdown emphasis (#651)

### DIFF
--- a/scripts/phase-state-utils.sh
+++ b/scripts/phase-state-utils.sh
@@ -64,7 +64,7 @@ normalize_roadmap_phase_num() {
 
 roadmap_checklist_phase_num_from_line() {
   local line="$1" raw_num
-  if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+  if [[ "$line" =~ ^-\ \[.\]\ [*_]*\[?[*_]*Phase\ ([0-9][0-9]*): ]]; then
     raw_num="${BASH_REMATCH[1]}"
     normalize_roadmap_phase_num "$raw_num"
     return 0

--- a/scripts/state-updater.sh
+++ b/scripts/state-updater.sh
@@ -77,7 +77,7 @@ fi
 if ! type roadmap_checklist_phase_num_from_line >/dev/null 2>&1; then
   roadmap_checklist_phase_num_from_line() {
     local line="$1" raw_num
-    if [[ "$line" =~ ^-\ \[.\]\ \[?Phase\ ([0-9][0-9]*): ]]; then
+    if [[ "$line" =~ ^-\ \[.\]\ [*_]*\[?[*_]*Phase\ ([0-9][0-9]*): ]]; then
       raw_num="${BASH_REMATCH[1]}"
       normalize_roadmap_phase_num "$raw_num"
       return 0

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -912,8 +912,11 @@ run_check_state_vs_roadmap() {
       roadmap_checklist_count=$((roadmap_checklist_count + 1))
     fi
   done < "$ROADMAP_FILE"
-  # Accept ### or ## section headings (bootstrap may use ## instead of ###)
-  roadmap_section_count=$(grep -cE '^#{2,3} (\[)?Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
+  # Accept ### or ## section headings (bootstrap may use ## instead of ###).
+  # Tolerate the same markdown emphasis as the checklist parser above (e.g.
+  # "## **Phase N:**") so an author who emphasizes BOTH checklist items and
+  # headings does not produce a checklist-count vs section-count mismatch (#651).
+  roadmap_section_count=$(grep -cE '^#{2,3} [*_]*(\[)?[*_]*Phase [0-9]+:' "$ROADMAP_FILE" 2>/dev/null || true)
 
   local details="" failed=false
 

--- a/scripts/verify-state-consistency.sh
+++ b/scripts/verify-state-consistency.sh
@@ -904,7 +904,8 @@ run_check_state_vs_roadmap() {
   fi
 
   local roadmap_checklist_count roadmap_section_count
-  # Accept both plain "- [ ] Phase N:" and bootstrap link "- [ ] [Phase N:"
+  # Accept plain "- [ ] Phase N:", bootstrap link "- [ ] [Phase N:", and
+  # markdown-emphasis "- [ ] **Phase N:**" (bold/italic markers around the optional link bracket)
   roadmap_checklist_count=0
   while IFS= read -r line || [ -n "$line" ]; do
     if roadmap_checklist_phase_num_from_line "$line" >/dev/null 2>&1; then

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2537,6 +2537,77 @@ EOF
 }
 
 # ============================================================
+# Markdown-emphasis ROADMAP checklist (#651)
+# ROADMAP checklists are frequently authored or edited with emphasis, e.g.
+# "- [ ] **Phase N: Name**". (The in-repo bootstrap-roadmap.sh emits the link
+# form "- [ ] [Phase N: Name](#anchor)"; emphasized checklists come from LLM-
+# or hand-authored ROADMAPs.) The verifier must parse the emphasized form too,
+# not count 0 entries and hard-block archive.
+# ============================================================
+
+@test "roadmap_vs_summaries parses markdown-bold ROADMAP correctly (#651)" {
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] **Phase 1: Setup**
+- [ ] **Phase 2: Backend API**
+- [ ] **Phase 3: Frontend**
+
+## Phase 1: Setup
+## Phase 2: Backend API
+## Phase 3: Frontend
+EOF
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c2_pass
+  c2_pass=$(echo "$output" | jq -r '.checks.roadmap_vs_summaries.pass')
+  [ "$c2_pass" = "true" ]
+}
+
+@test "state_vs_roadmap phase count matches with markdown-bold ROADMAP (#651)" {
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] **Phase 1: Setup**
+- [ ] **Phase 2: Backend API**
+- [ ] **Phase 3: Frontend**
+
+## Phase 1: Setup
+## Phase 2: Backend API
+## Phase 3: Frontend
+EOF
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode advisory
+  [ "$status" -eq 0 ]
+
+  local c4_pass
+  c4_pass=$(echo "$output" | jq -r '.checks.state_vs_roadmap.pass')
+  [ "$c4_pass" = "true" ]
+}
+
+@test "roadmap_checklist_phase_num_from_line parses plain, link, and emphasis forms (#651)" {
+  # Unit guard for the parser the verifier depends on. Bootstrap emits the bold
+  # form; legacy plain and link forms must keep working; non-phase lines must not match.
+  source "$SCRIPTS_DIR/phase-state-utils.sh"
+  [ "$(roadmap_checklist_phase_num_from_line '- [ ] Phase 1: plain')" = "1" ]
+  [ "$(roadmap_checklist_phase_num_from_line '- [x] [Phase 2: link](#x)')" = "2" ]
+  [ "$(roadmap_checklist_phase_num_from_line '- [ ] **Phase 3: bold**')" = "3" ]
+  [ "$(roadmap_checklist_phase_num_from_line '- [ ] *Phase 4: italic*')" = "4" ]
+  [ "$(roadmap_checklist_phase_num_from_line '- [ ] **[Phase 5: bold link](#y)**')" = "5" ]
+  [ "$(roadmap_checklist_phase_num_from_line '- [ ] [**Phase 6: link bold**](#z)')" = "6" ]
+  run roadmap_checklist_phase_num_from_line '- [ ] not a phase line'
+  [ "$status" -ne 0 ]
+}
+
+# ============================================================
 # UAT-awareness tests
 # ============================================================
 

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2632,6 +2632,32 @@ EOF
   [ "$verdict" = "pass" ]
 }
 
+@test "state_vs_roadmap reconciles when BOTH checklist and ## headings are emphasized (#651)" {
+  # Asymmetry regression: if an author bolds both the checklist items and the
+  # ## Phase headings, the checklist count and section count must still agree
+  # (both parse emphasis), so state_vs_roadmap does not falsely fail.
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] **Phase 1: Setup**
+- [ ] **Phase 2: Backend API**
+- [ ] **Phase 3: Frontend**
+
+## **Phase 1: Setup**
+## **Phase 2: Backend API**
+## **Phase 3: Frontend**
+EOF
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  [ "$status" -eq 0 ]
+  local c4_pass
+  c4_pass=$(echo "$output" | jq -r '.checks.state_vs_roadmap.pass')
+  [ "$c4_pass" = "true" ]
+}
+
 # ============================================================
 # UAT-awareness tests
 # ============================================================

--- a/tests/verify-state-consistency.bats
+++ b/tests/verify-state-consistency.bats
@@ -2607,6 +2607,31 @@ EOF
   [ "$status" -ne 0 ]
 }
 
+@test "archive mode exits 0 on a markdown-bold ROADMAP (#651 blocking path)" {
+  # #651's user-visible breakage is `--mode archive` hard-blocking (exit 2) on
+  # a bold ROADMAP. Assert the archive gate now passes for the emphasized form.
+  cd "$TEST_TEMP_DIR"
+  scaffold_consistent_workspace
+
+  cat > "$TEST_TEMP_DIR/.vbw-planning/ROADMAP.md" <<'EOF'
+# Roadmap
+
+- [x] **Phase 1: Setup**
+- [ ] **Phase 2: Backend API**
+- [ ] **Phase 3: Frontend**
+
+## Phase 1: Setup
+## Phase 2: Backend API
+## Phase 3: Frontend
+EOF
+
+  run bash "$SCRIPTS_DIR/verify-state-consistency.sh" "$TEST_TEMP_DIR/.vbw-planning" --mode archive
+  [ "$status" -eq 0 ]
+  local verdict
+  verdict=$(echo "$output" | jq -r '.verdict')
+  [ "$verdict" = "pass" ]
+}
+
 # ============================================================
 # UAT-awareness tests
 # ============================================================


### PR DESCRIPTION
## What

Make VBW's state-consistency verifier parse ROADMAP checklist items and `## Phase N:` section headings that use markdown **bold**/_italic_ emphasis (e.g. `- [ ] **Phase 1: Setup**`), in addition to the existing plain and bootstrap-link forms.

Closes #651.

## Why

ROADMAP checklists are frequently authored or hand-edited with emphasis (the in-repo `bootstrap-roadmap.sh` emits the link form, but LLM- and hand-authored ROADMAPs commonly use bold). `roadmap_checklist_phase_num_from_line()` only matched `- [ ] Phase N:` and `- [ ] [Phase N:`, so on any emphasized ROADMAP the verifier counted **0** checklist entries, failing `roadmap_vs_summaries` and `state_vs_roadmap` and **hard-blocking `verify-state-consistency.sh --mode archive`** (exit 2) — a persistent, unfixable "state drift" with no workaround.

## How

- **Checklist parser** (`scripts/phase-state-utils.sh` + the guarded duplicate in `scripts/state-updater.sh`): widened the regex `\[?Phase` → `[*_]*\[?[*_]*Phase`, tolerating emphasis markers around the optional link bracket. Plain and link forms still parse; non-phase lines still don't match.
- **Section-heading counter** (`scripts/verify-state-consistency.sh`): widened symmetrically (`^#{2,3} [*_]*(\[)?[*_]*Phase [0-9]+:`) so a ROADMAP that emphasizes *both* checklist items and `## Phase N:` headings doesn't fail on a checklist-vs-section count mismatch (found in QA round 2).
- **Tests** (`tests/verify-state-consistency.bats`): 5 new tests — bold `roadmap_vs_summaries` + `state_vs_roadmap`, a `--mode archive` bold test (the exact #651 blocking path), a parser unit test across plain/link/bold/italic/bold-link + a negative, and a both-emphasized reconciliation test. All confirmed to fail against the pre-fix regex.

Single centralized parser: every ROADMAP-checklist consumer routes through `roadmap_checklist_phase_num_from_line`, so this is a complete fix, not a point patch.

## Testing

- [x] `bash testing/run-all.sh` green: **3596 BATS / 0 failed, 51/51 contract, lint 1/1**
- [x] `shellcheck -S warning` clean on all changed scripts; `bash -n` clean
- [x] New tests verified as genuine regression guards (fail pre-fix, pass post-fix)
- [x] Back-compat: plain and bootstrap-link forms still parse; non-phase lines still rejected
- [x] 3 QA review rounds (reports posted as comments)
