### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #662)

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -3,7 +3,7 @@ name: vbw:config
 category: supporting
 disable-model-invocation: true
 description: View and modify VBW configuration including effort profile, verification tier, and skill-hook wiring.
-argument-hint: [setting value]
+argument-hint: "[setting value]"
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion
 ---
 

--- a/commands/help.md
+++ b/commands/help.md
@@ -3,7 +3,7 @@ name: vbw:help
 category: supporting
 disable-model-invocation: true
 description: Display all available VBW commands with descriptions and usage examples.
-argument-hint: [command-name]
+argument-hint: "[command-name]"
 allowed-tools: Read, Glob, Bash
 ---
 

--- a/commands/list-todos.md
+++ b/commands/list-todos.md
@@ -3,7 +3,7 @@ name: vbw:list-todos
 category: supporting
 disable-model-invocation: true
 description: List pending todos from STATE.md with action hints.
-argument-hint: [priority filter]
+argument-hint: "[priority filter]"
 allowed-tools: Read, Edit, Bash
 ---
 

--- a/commands/map.md
+++ b/commands/map.md
@@ -3,7 +3,7 @@ name: vbw:map
 category: advanced
 disable-model-invocation: true
 description: Analyze existing codebase with adaptive Scout teammates to produce structured mapping documents.
-argument-hint: [--incremental] [--package=name] [--tier=solo|duo|quad]
+argument-hint: "[--incremental] [--package=name] [--tier=solo|duo|quad]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, Agent, TeamCreate, TaskCreate, SendMessage, TeamDelete, Skill, LSP
 ---
 

--- a/commands/pause.md
+++ b/commands/pause.md
@@ -3,7 +3,7 @@ name: vbw:pause
 category: supporting
 disable-model-invocation: true
 description: Save session notes for next time (state auto-persists).
-argument-hint: [notes]
+argument-hint: "[notes]"
 allowed-tools: Read, Write
 ---
 

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -4,7 +4,7 @@ category: monitoring
 hidden: true
 disable-model-invocation: true
 description: Run deep verification on completed phase work using the QA agent.
-argument-hint: [phase-number] [--tier=quick|standard|deep] [--effort=thorough|balanced|fast|turbo]
+argument-hint: "[phase-number] [--tier=quick|standard|deep] [--effort=thorough|balanced|fast|turbo]"
 allowed-tools: Read, Write, Bash, Glob, Grep, Agent, Skill, LSP
 ---
 

--- a/commands/rtk.md
+++ b/commands/rtk.md
@@ -3,7 +3,7 @@ name: vbw:rtk
 category: supporting
 disable-model-invocation: true
 description: Install, update, verify, and manage optional RTK tool-output compression.
-argument-hint: [status|install|init|verify|update|uninstall]
+argument-hint: "[status|install|init|verify|update|uninstall]"
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 

--- a/commands/skills.md
+++ b/commands/skills.md
@@ -3,7 +3,7 @@ name: vbw:skills
 category: supporting
 disable-model-invocation: true
 description: Browse and install community skills from skills.sh based on your project's tech stack.
-argument-hint: [--search <query>] [--list] [--refresh]
+argument-hint: "[--search <query>] [--list] [--refresh]"
 allowed-tools: Read, Bash, Glob, Grep, WebFetch, AskUserQuestion, LSP
 ---
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -3,7 +3,7 @@ name: vbw:status
 category: monitoring
 disable-model-invocation: true
 description: Display project progress dashboard with phase status, velocity metrics, and next action.
-argument-hint: [--verbose] [--metrics]
+argument-hint: "[--verbose] [--metrics]"
 allowed-tools: Read, Glob, Grep, Bash, LSP
 ---
 


### PR DESCRIPTION
Closes #662.

## Summary

Purely mechanical single-character transform to 9 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (9)

- `commands/skills.md`
- `commands/status.md`
- `commands/map.md`
- `commands/pause.md`
- `commands/help.md`
- `commands/list-todos.md`
- `commands/rtk.md`
- `commands/qa.md`
- `commands/config.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
